### PR TITLE
[auto] Translate JAVA API Reference to Korean

### DIFF
--- a/korean/java/_index.md
+++ b/korean/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram for Java
+type: docs
+weight: 11
+url: /ko/java/
+description: Aspose.Diagram for Java API 참조에는 예제, 코드 스니펫 및 API 문서가 포함되어 있습니다. 패키지, 클래스, 인터페이스 및 기타 API 세부 정보를 제공합니다.
+is_root: true
+---
+
+## Packages
+| 패키지 | 설명 |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | com.aspose.diagram 패키지는 Microsoft Visio를 사용하지 않고 Microsoft Visio 문서를 생성, 변환, 수정, 렌더링 및 인쇄하기 위한 클래스를 제공합니다. |

--- a/korean/java/com.aspose.diagram/_index.md
+++ b/korean/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Aspose.Diagram for Java API 참조
+description: com.aspose.diagram 패키지는 Microsoft Visio를 사용하지 않고 Microsoft Visio 문서를 생성, 변환, 수정, 렌더링 및 인쇄하기 위한 클래스를 제공합니다.
+type: docs
+weight: 10
+url: /ko/java/com.aspose.diagram/
+---
+
+
+com.aspose.diagram 패키지는 Microsoft Visio를 사용하지 않고 Microsoft Visio 문서를 생성, 변환, 수정, 렌더링 및 인쇄하기 위한 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | 시간이 많이 소요되는 모든 작업에서 중단 요청을 모니터링합니다. |
+| [Act](../com.aspose.diagram/act) | 객체의 바로 가기 메뉴에 표시되는 사용자 지정 명령 이름을 정의하고 해당 명령이 수행하는 동작을 지정합니다. |
+| [ActCollection](../com.aspose.diagram/actcollection) | Act 컬렉션. |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | ActiveX 컨트롤을 나타냅니다. |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | ActiveX 컨트롤을 나타냅니다. |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | ActiveX 컨트롤을 지속시키는 지속성 방법을 나타냅니다. |
+| [Align](../com.aspose.diagram/align) | 도형이 고정된 가이드 또는 가이드 포인트에 대한 도형의 정렬을 나타냅니다. |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | 선택적 int. |
+| [Alignment](../com.aspose.diagram/alignment) | 탭 정렬을 지정합니다. |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | 탭 정렬을 지정합니다. |
+| [Annotation](../com.aspose.diagram/annotation) | 문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다. |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Annotation 컬렉션. |
+| [ArcTo](../com.aspose.diagram/arcto) | X, Y 및 A 요소에 각각 의해 표현되는 원호의 x 및 y 좌표와 활을 포함합니다. |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | ArcTo 컬렉션. |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | 선의 화살촉 크기를 지정합니다. |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | 선의 화살촉 크기를 지정합니다. |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | .NET PrintDocument 클래스를 기반으로 하는 자체 버전으로, 다이어그램을 인쇄하고 미리 보기 위해 PrintPreviewDialog 폼에 전달할 수 있습니다. |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | 사용자 인터페이스에서 수행된 마지막 성공적인 자동 연결 작업의 도형 데이터 항목과 상위 DataRecordset 요소의 열을 비교하는 규칙을 정의합니다. |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | 자동 간격 옵션을 나타냅니다. |
+| [BOOL](../com.aspose.diagram/bool) | 불리언. |
+| [Bevel](../com.aspose.diagram/bevel) | 도형의 베벨을 나타냅니다. |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | 도형의 그림자 유형을 지정합니다. |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | 도형에 적용할 수 있는 사전 설정 오른쪽 조명을 나타냅니다. |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | 도형의 그림자 유형을 지정합니다. |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | 도형의 표면 외관을 설명합니다. |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | 3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다. |
+| [BevelType](../com.aspose.diagram/beveltype) | 도형의 그림자 유형을 지정합니다. |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | 3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다. |
+| [BoolValue](../com.aspose.diagram/boolvalue) | 불리언 값. |
+| [Bullet](../com.aspose.diagram/bullet) | 글머리표 스타일을 결정합니다. |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | 글머리표 스타일을 결정합니다. |
+| [Calendar](../com.aspose.diagram/calendar) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [Case](../com.aspose.diagram/case) | 도형 텍스트의 대소문자를 결정합니다. |
+| [CaseValue](../com.aspose.diagram/casevalue) | 도형 텍스트의 대소문자를 결정합니다. |
+| [Char](../com.aspose.diagram/char) | 도형 텍스트의 서식 속성을 포함합니다(예: 글꼴, 색상, 텍스트 스타일, 대소문자, 기준선에 대한 위치 및 포인트 크기). |
+| [CharCollection](../com.aspose.diagram/charcollection) | 문자 컬렉션. |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | CheckBox ActiveX 컨트롤을 나타냅니다. |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | 체크 박스의 체크 값 유형을 나타냅니다. |
+| [Collection](../com.aspose.diagram/collection) | 컬렉션의 기본 클래스입니다. |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | 강력히 형식화된 컬렉션을 위한 추상 기본 클래스를 제공합니다. |
+| [Color](../com.aspose.diagram/color) | ARGB(알파, 빨강, 초록, 파랑) 색상을 나타냅니다. |
+| [ColorEntry](../com.aspose.diagram/colorentry) | 색상표 항목을 포함합니다. |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | 문서의 색상표를 포함합니다. |
+| [ColorValue](../com.aspose.diagram/colorvalue) | 색상 값을 나타냅니다 |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | ComboBox ActiveX 컨트롤을 나타냅니다. |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | 명령 버튼을 나타냅니다. |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | 합성 중에 사용할 품질 수준을 지정합니다. |
+| [CompoundType](../com.aspose.diagram/compoundtype) | 선의 화살촉 크기를 지정합니다. |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | 선 그리기 스타일을 나타냅니다. |
+| [CompressionType](../com.aspose.diagram/compressiontype) | 이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | 커넥터가 재경로 지정되는 시점을 결정합니다. |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | 커넥터가 재경로 지정되는 시점을 결정합니다. |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | 두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다. |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | 두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다. |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | 동적 커넥터의 라인 점프 스타일을 결정합니다. |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | 동적 커넥터의 라인 점프 스타일을 결정합니다. |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | 커넥터의 외관을 결정합니다. |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | 커넥터의 외관을 결정합니다. |
+| [ConType](../com.aspose.diagram/contype) | 핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다. |
+| [ConValue](../com.aspose.diagram/convalue) | 핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다. |
+| [Connect](../com.aspose.diagram/connect) | 그림에서 두 도형 사이의 연결을 나타내며, 예를 들어 조직도에서 선과 상자를 연결합니다. |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Connect 컬렉션. |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | 커넥터의 방향성을 기준으로 반환된 도형 ID 배열을 필터링합니다. |
+| [Connection](../com.aspose.diagram/connection) | 도형에 정의된 하나의 연결 지점에 대한 요소를 포함합니다. |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | ConnectionABCD 요소는 Connection 요소의 구식 버전이며 이전 호환성을 위해서만 존재합니다. |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | ConnectionABCD 컬렉션. |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Connection 컬렉션. |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | 커넥터가 연결될 도형상의 위치를 지정합니다. |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | 커넥터를 사용하여 두 도형 사이의 연결 규칙을 나타내며, 시작 도형의 어느 연결 지점에서 시작하는지와 종료 도형 및 그 연결 지점을 포함합니다. |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | 다음 값 중 하나일 수 있습니다: RightAngle, StraightLines, 또는 CurvedLines. |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | 다음 값 중 하나일 수 있습니다: Document, Page, 또는 Master. |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | 비교에 사용할 그룹 또는 도형의 속성을 지정합니다. |
+| [Control](../com.aspose.diagram/control) | 도형에 정의된 각 컨트롤 핸들의 x 및 y 좌표에 대한 요소와 컨트롤 핸들의 동작 방식을 지정하는 요소를 포함합니다. |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | ActiveX 컨트롤의 테두리 유형을 나타냅니다. |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | Caption이 컨트롤에 대해 상대적으로 위치하는 방식을 나타냅니다. |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Control 컬렉션. |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | ListBox 또는 ComboBox에 있는 목록의 시각적 외관을 나타냅니다. |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | 사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다. |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형을 나타냅니다. |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Form 또는 Image 내부의 그림 정렬을 나타냅니다. |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | 컨트롤 캡션에 대한 그림 위치를 나타냅니다. |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | 그림을 표시하는 방법을 나타냅니다. |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | 스크롤 바 유형을 나타냅니다. |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | 스크롤 방향 유형을 나타냅니다. |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | 특수 효과 유형을 나타냅니다. |
+| [ControlType](../com.aspose.diagram/controltype) | 모든 유형의 ActiveX 컨트롤을 나타냅니다. |
+| [Coordinate](../com.aspose.diagram/coordinate) | x 및 y 좌표에 대한 추상 클래스입니다. |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | 좌표 컬렉션입니다. |
+| [CountryCode](../com.aspose.diagram/countrycode) | 다이어그램 국가 식별자를 나타냅니다. |
+| [Cp](../com.aspose.diagram/cp) | 해당 Char 요소에 따라 서식이 지정된 문자 속성 실행의 시작을 표시합니다. |
+| [CustomProp](../com.aspose.diagram/customprop) | CustomProp 구조체입니다. |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | CustomProps 컬렉션입니다. |
+| [CustomValue](../com.aspose.diagram/customvalue) | 속성 값입니다. |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Visio 사용자 인터페이스의 외부 데이터 창에 데이터 열이 표시되는 방식을 정의하고, 데이터 유형 및 서식을 정의하여 열의 데이터를 지정합니다. |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | DataColumn 컬렉션입니다. |
+| [DataConnection](../com.aspose.diagram/dataconnection) | 하나 이상의 DataRecordset 요소와 비 XML 데이터 소스 간의 통신을 추상화합니다. |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | DataConnection 컬렉션입니다. |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | 데이터베이스 연결 옵션을 구성할 수 있게 합니다. |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Microsoft Visio에서 데이터베이스에 질의한 데이터를 저장, 서식 지정, 새로 고침 및 노출합니다. |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | DataRecordSet 컬렉션입니다. |
+| [DateTime](../com.aspose.diagram/datetime) | 일반적으로 날짜와 시간으로 표현되는 특정 시점을 나타냅니다. |
+| [DateValue](../com.aspose.diagram/datevalue) | 날짜 및 시간 값입니다. |
+| [Diagram](../com.aspose.diagram/diagram) | Visio 개체 계층 구조의 루트 요소. |
+| [DiagramException](../com.aspose.diagram/diagramexception) | 모든 Aspose.Diagram 예외의 기본 클래스 |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Visio (VDX\VSX) 형식으로 다이어그램을 저장할 때 추가 옵션을 지정하는 데 사용할 수 있습니다. |
+| [DisplayMode](../com.aspose.diagram/displaymode) | Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원이 어떻게 표시되는지를 지정합니다. |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다. |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다. |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원이 어떻게 표시되는지를 지정합니다. |
+| [DocProps](../com.aspose.diagram/docprops) | 문서의 미리보기 품질, 범위 및 출력 형식을 제어하는 요소를 포함합니다. |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | 문서의 제목, 작성자 등과 같은 문서 속성 요소를 포함합니다. |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | 문서 설정을 지정하는 요소를 포함합니다. |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | 문서의 ShapeSheet 구조를 지정합니다. |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Double 값 |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다. |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다. |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | 페이지에 사용할 그리기 축척 유형을 지정합니다. |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | 페이지에 사용할 그리기 축척 유형을 지정합니다. |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | 페이지의 그리기 크기를 지정합니다. |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | 페이지의 그리기 크기를 지정합니다. |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | 드롭 버튼에 표시되는 기호를 나타냅니다. |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. |
+| [Ellipse](../com.aspose.diagram/ellipse) | 타원의 중심점 및 타원 위의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | Ellipse 컬렉션. |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | 타원 호에 대한 정보를 지정하는 요소를 포함합니다. |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | EllipticalArcTo 컬렉션. |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Emf 메타파일 렌더링 설정. |
+| [Encoding](../com.aspose.diagram/encoding) | 문자 인코딩을 나타냅니다. |
+| [Event](../com.aspose.diagram/event) | 도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다. |
+| [EventItem](../com.aspose.diagram/eventitem) | 이벤트 코드를 캡슐화합니다. |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | EventItem 컬렉션. |
+| [Field](../com.aspose.diagram/field) | 도형 텍스트에 삽입된 함수와 수식을 지정하는 요소를 포함합니다. |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | 필드 컬렉션. |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | 파일 시스템에 저장된 단일 TrueType 글꼴 파일을 나타냅니다. |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | 파일 형식 감지 메서드에 의해 반환된 데이터를 [FileFormatUtil](../com.aspose.diagram/fileformatutil) 로부터 포함합니다. |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | 스프레드시트 파일 형식 유형을 열거합니다 |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | 파일 형식 열거형을 문자열이나 파일 확장자로 변환하고 다시 변환하는 유틸리티 메서드를 제공합니다. |
+| [Fill](../com.aspose.diagram/fill) | 패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다. |
+| [FillType](../com.aspose.diagram/filltype) | 채우기 형식 유형. |
+| [Fld](../com.aspose.diagram/fld) | 해당 Field 요소에 대한 텍스트 필드 삽입 지점을 나타냅니다. |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | 두 배 포인트 숫자 컬렉션을 포함합니다 |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | TrueType 글꼴 파일을 포함하는 폴더를 나타냅니다. |
+| [Font](../com.aspose.diagram/font) | 글꼴에 대한 정보를 포함합니다. |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Font 요소의 컬렉션을 포함합니다. |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | 글꼴 설정을 지정합니다 |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | 다양한 글꼴 소스를 지정할 수 있게 하는 클래스들을 위한 추상 기본 클래스입니다. |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | 글꼴 소스 유형을 지정합니다. |
+| [Foreign](../com.aspose.diagram/foreign) | Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다. |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [ForeignType](../com.aspose.diagram/foreigntype) | 데이터 유형. |
+| [FormatTxt](../com.aspose.diagram/formattxt) | 텍스트 서식을 위한 추상 클래스 |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | 도형의 텍스트를 포함하는 FormatTxt 컬렉션. |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | 연결이 시작되는 도형의 부분. |
+| [Geom](../com.aspose.diagram/geom) | 도형을 구성하는 선과 호의 정점 좌표를 지정하는 요소를 포함합니다. |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Geom 컬렉션. |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | 이 클래스는 객체 가장자리 외부에 색상 흐림 윤곽선을 추가하는 글로우 효과를 지정합니다. |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | 비트 값은 특정 접착 설정이 켜져 있는지 꺼져 있는지를 나타냅니다. |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | 문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다. |
+| [GlueType](../com.aspose.diagram/gluetype) | 도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다. |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | 도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다. |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | 특정 도형에 접착된 연결 지점의 차원 및 방향성을 기반으로 반환할 도형을 식별하는 상수를 지정합니다; Shape.GluedShapes 메서드에 전달됩니다. |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | 그라디언트의 모든 방향 유형을 나타냅니다. |
+| [GradientFill](../com.aspose.diagram/gradientfill) | 그라디언트 채우기를 나타냅니다. |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | 도형의 채우기 색상 그라디언트 유형을 지정합니다. |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | 모든 그라디언트 채우기 유형을 나타냅니다. |
+| [GradientStop](../com.aspose.diagram/gradientstop) | 그라디언트 스톱을 나타냅니다. |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | 그라디언트 스톱 컬렉션을 나타냅니다. |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | 그라디언트 셰이딩 스타일을 나타냅니다. |
+| [GridDensity](../com.aspose.diagram/griddensity) | 페이지에 사용할 가로/세로 그리드 유형을 지정합니다. |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | 페이지에 사용할 가로/세로 그리드 유형을 지정합니다. |
+| [Group](../com.aspose.diagram/group) | 그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다. |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | 다이어그램 페이지를 HTML로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다. |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | 문서의 머리글 및 바닥글 요소를 포함합니다. |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | 머리글 및 바닥글 텍스트에 사용되는 글꼴을 지정합니다. |
+| [Help](../com.aspose.diagram/help) | Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다. |
+| [HorzAlign](../com.aspose.diagram/horzalign) | 도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다. |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | 도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다. |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | 도형 또는 그리기 페이지와 다른 그리기 페이지, 다른 파일, 또는 웹 사이트 간에 여러 번 점프를 생성하는 요소를 포함합니다. |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | 하이퍼링크 컬렉션. |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | 선택적 int. |
+| [Image](../com.aspose.diagram/image) | 비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다. |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | 이미지 컨트롤을 나타냅니다. |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | 문서 페이지의 생성된 이미지에 대한 색상 모드를 지정합니다. |
+| [ImageFormat](../com.aspose.diagram/imageformat) | 이미지의 파일 형식을 지정합니다. |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | 다이어그램 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다. |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | 각 [Diagram](../com.aspose.diagram/diagram) 객체에 대한 글꼴 구성. |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | 무한선상의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | InfiniteLine 컬렉션. |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | 입력기(Input Method Editor)의 기본 실행 시간 모드를 나타냅니다. |
+| [IntValue](../com.aspose.diagram/intvalue) | 정수 값 |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | InterpolationMode 열거형은 이미지가 확대되거나 회전될 때 사용되는 알고리즘을 지정합니다. |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | 인터럽트와 관련된 모든 연산자를 나타냅니다. |
+| [Issue](../com.aspose.diagram/issue) | 문서의 단일 검증 문제를 나타냅니다. |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Issue 컬렉션. |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | 상위 검증 문제의 대상에 따라, 상위 검증 문제가 연결된 페이지 또는 페이지와 도형을 모두 지정합니다. |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | 레이블 ActiveX 컨트롤을 나타냅니다. |
+| [Layer](../com.aspose.diagram/layer) | 페이지에 대한 단일 레이어와 그 속성을 정의하는 요소를 포함합니다. |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Layer 컬렉션. |
+| [LayerMem](../com.aspose.diagram/layermem) | 도형이 할당된 각 레이어를 지정하는 LayerMember 요소를 포함합니다. |
+| [Layout](../com.aspose.diagram/layout) | 도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다. |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | 레이아웃 방향을 설정하는 데 사용됩니다. |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | 페이지(들)의 레이아웃을 재배치하기 위해 도형 레이아웃의 스타일 및 추가 옵션을 지정하는 데 사용됩니다. |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | 레이아웃 스타일을 지정하는 데 사용됩니다. |
+| [License](../com.aspose.diagram/license) | 구성 요소를 라이선스하는 메서드를 제공합니다. |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | 라이트 릭 방향 유형을 나타냅니다. |
+| [Line](../com.aspose.diagram/line) | 도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다. |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다. |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다. |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다. |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다. |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | 점프를 추가하려는 동적 커넥터를 결정합니다. |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | 점프를 추가하려는 동적 커넥터를 결정합니다. |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | 로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다. |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | 로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다. |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다. |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다. |
+| [LineTo](../com.aspose.diagram/lineto) | 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다. |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | LineTo 컬렉션. |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | ListBox ActiveX 컨트롤을 나타냅니다. |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | 다이어그램 형식 선택 로드를 위한 열거형. |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | 다이어그램을 Diagram 객체에 로드할 때 추가 옵션을 지정할 수 있습니다. |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | 도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다. |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | 도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다. |
+| [Margin](../com.aspose.diagram/margin) | 여백을 지정합니다. |
+| [Master](../com.aspose.diagram/master) | 문서의 마스터를 정의하는 요소를 포함합니다. |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | Master 컬렉션. |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | 문서에 정의된 마스터 바로가기를 지정합니다. |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | MasterShortcut 컬렉션. |
+| [MeasureConst](../com.aspose.diagram/measureconst) | 단위\ 측정. |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | 메모리에 저장된 단일 TrueType 폰트 파일을 나타냅니다. |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | MilestoneHelper를 사용하여 마일스톤 도형의 속성을 설정합니다. |
+| [Misc](../com.aspose.diagram/misc) | 선택 강조 및 가시성을 제어하는 요소와 같이 도형 및 그룹의 다양한 요소를 포함합니다. |
+| [MoveTo](../com.aspose.diagram/moveto) | 도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로 중단 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | MoveTo 컬렉션. |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | x 및 y 좌표, 두 번째에서 마지막 매듭의 위치, 마지막 가중치의 위치, 첫 번째 매듭의 위치, 첫 번째 가중치의 위치 및 비균일 유리 B-스플라인(NURBS)의 수식을 포함합니다. |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | NURBSTo 컬렉션. |
+| [ObjType](../com.aspose.diagram/objtype) | Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다. |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다. |
+| [ObjectKind](../com.aspose.diagram/objectkind) | 텍스트 필드 유형을 나타냅니다. |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | 텍스트 필드 유형을 나타냅니다. |
+| [ObjectType](../com.aspose.diagram/objecttype) | ForeignType 속성이 "Object"인 경우, ForeignData 요소에도 ObjectType 속성이 있어야 합니다. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | 옵션인 부호 없는 정수. |
+| [OutputFormat](../com.aspose.diagram/outputformat) | 도면의 출력 형식을 지정합니다. |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | 도면의 출력 형식을 지정합니다. |
+| [Page](../com.aspose.diagram/page) | 문서에서 페이지를 정의하는 요소를 포함합니다. |
+| [PageCollection](../com.aspose.diagram/pagecollection) | 페이지 컬렉션. |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | 페이지 저장 프로세스 종료에 대한 정보. |
+| [PageLayout](../com.aspose.diagram/pagelayout) | 페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 셀을 포함합니다. 예를 들어 페이지 내 모든 도형 간 간격, 모든 커넥터 간 간격, 그리고 모든 커넥터의 라우팅 스타일 등이 있습니다. |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다. |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다. |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다. |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다. |
+| [PageProps](../com.aspose.diagram/pageprops) | 페이지 너비, 높이 및 축척과 같은 페이지 속성을 제어하는 셀을 포함합니다. |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | 페이지 저장 프로세스에 대한 정보. |
+| [PageSheet](../com.aspose.diagram/pagesheet) | 페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다. |
+| [PageSize](../com.aspose.diagram/pagesize) | 생성된 이미지의 페이지 크기에 대한 정보를 포함합니다. |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | 페이지 저장 프로세스 시작에 대한 정보. |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | 용지 크기 형식 선택을 저장하기 위한 열거형. |
+| [Para](../com.aspose.diagram/para) | 도형 텍스트에 대한 단락 서식 요소를 포함합니다. 예: 들여쓰기, 행 간격, 글머리표, 단락의 가로 정렬 등. |
+| [ParaCollection](../com.aspose.diagram/paracollection) | 단락 컬렉션. |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | 출력 파일의 PDF 준수 수준을 지정합니다. |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | 디지털 서명에 사용되는 디지털 해시 알고리즘을 지정합니다. |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | PDF 문서를 암호화하는 데 사용할 암호화 알고리즘을 지정합니다. |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | PDF 암호화에 대한 세부 정보를 포함합니다. |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | PDF 문서에 대한 사용자 권한을 지정합니다. |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | 다이어그램 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | 이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다. |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | 도형의 핀 위치를 지정합니다. |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | 렌더링 중 픽셀 오프셋 방식을 지정합니다. |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | 자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다. |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | 자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다. |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | 사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다. |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | 사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다. |
+| [PolylineTo](../com.aspose.diagram/polylineto) | 폴리라인의 마지막 점과 폴리라인 수식의 x 및 y 좌표를 포함합니다. |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | PolylineTo 컬렉션. |
+| [Pos](../com.aspose.diagram/pos) | 도형 텍스트의 기준선에 대한 위치를 지정합니다. |
+| [PosValue](../com.aspose.diagram/posvalue) | 도형 텍스트의 기준선에 대한 위치를 지정합니다. |
+| [Pp](../com.aspose.diagram/pp) | 단락 속성 실행의 시작을 지정합니다. |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | 위치를 포함한 모든 카메라 속성을 설정하기 위한 다양한 알고리즘 방법을 나타냅니다. |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Shape 테마 스타일의 색상 속성을 설정하는 데 사용됩니다. |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | 테마 빠른 스타일 값을 지정합니다. |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | 미리 설정된 그림자 유형을 나타냅니다. |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Shape 테마 스타일 속성을 설정하는 데 사용됩니다. |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | 테마 값을 지정합니다. |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | 테마 변형 값을 지정합니다. |
+| [PreviewScope](../com.aspose.diagram/previewscope) | 문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다. |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | 문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다. |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다. |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다. |
+| [PrintProps](../com.aspose.diagram/printprops) | 그리기 페이지가 프린터 페이지에 어떻게 형식이 지정되는지(표시되는지) 제어하는 요소를 포함합니다. |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | 다이어그램을 인쇄할 때 추가 옵션을 지정할 수 있습니다. |
+| [Prop](../com.aspose.diagram/prop) | 사용자 지정 속성을 정의하는 요소와 도형에 데이터를 연결하는 요소를 포함합니다. |
+| [PropCollection](../com.aspose.diagram/propcollection) | Prop 컬렉션. |
+| [PropType](../com.aspose.diagram/proptype) | 속성 유형. |
+| [Protection](../com.aspose.diagram/protection) | 잠금은 도형에 대한 실수로 인한 변경을 방지하는 데 도움이 되지만 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | RadioButton ActiveX 컨트롤을 나타냅니다. |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | 두 사각형을 서로 상대적으로 배치하는 방법을 나타냅니다. |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | RelCubBezTo 점들의 x 및 y 좌표를 포함합니다. |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | RelCubBezTo 컬렉션. |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | 타원 호에 대한 정보를 지정하는 요소를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | RelEllipticalArcTo 컬렉션. |
+| [RelLineTo](../com.aspose.diagram/rellineto) | 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다. |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | RelLineTo 컬렉션. |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | 도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로에서 끊김 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | RelMoveTo 컬렉션. |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | RelQuadBezTo의 점에 대한 x 및 y 좌표를 포함합니다. |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | RelQuadBezTo 컬렉션. |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | 다이어그램에 대한 숨김 정보 제거를 지정합니다. |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | 이것은 사용자가 다이어그램을 특정 형식으로 저장할 때 추가 옵션을 지정할 수 있도록 하는 클래스들을 위한 추상 기본 클래스입니다. |
+| [ResizeMode](../com.aspose.diagram/resizemode) | 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다. |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다. |
+| [Reviewer](../com.aspose.diagram/reviewer) | 문서 검토자에 대한 식별 정보를 포함하는 요소를 포함합니다. |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | 검토자 컬렉션. |
+| [RotationType](../com.aspose.diagram/rotationtype) | 도형의 그림자 유형을 지정합니다. |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | 도형의 효과 속성에 대한 투영 유형을 지정합니다. |
+| [RouteStyle](../com.aspose.diagram/routestyle) | 로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다. |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | 로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다. |
+| [Row](../com.aspose.diagram/row) | 데이터 레코드셋의 행을 나타냅니다. |
+| [RowCollection](../com.aspose.diagram/rowcollection) | 행 컬렉션. |
+| [Rule](../com.aspose.diagram/rule) | 다이어그램 검증 규칙 집합에서 단일 검증 규칙을 나타냅니다. |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | 규칙 컬렉션. |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | 상위 검증 이슈와 관련된 검증 규칙에 대한 정보를 지정합니다. |
+| [RuleSet](../com.aspose.diagram/ruleset) | 다이어그램 검증 규칙의 한 세트를 나타냅니다. |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | RuleSet 컬렉션. |
+| [RuleValue](../com.aspose.diagram/rulevalue) | 규칙 값. |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | 페이지 눈금자에 대한 수평 구분을 지정합니다. |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | 페이지 눈금자에 대한 수평 구분을 지정합니다. |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | 페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다. |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | 다이어그램 페이지를 SVG로 렌더링할 때 추가 옵션을 지정할 수 있도록 합니다. |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | 다이어그램 형식 선택 저장을 위한 열거형입니다. |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | 이것은 사용자가 다이어그램을 특정 형식으로 저장할 때 추가 옵션을 지정할 수 있도록 하는 클래스들을 위한 추상 기본 클래스입니다. |
+| [Scratch](../com.aspose.diagram/scratch) | 다른 요소가 참조하는 수식을 입력하고 테스트할 수 있는 작업 영역을 포함합니다. |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | 스크래치 컬렉션. |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | ScrollBar 컨트롤을 나타냅니다. |
+| [SelectMode](../com.aspose.diagram/selectmode) | 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다. |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다. |
+| [Shape](../com.aspose.diagram/shape) | 마스터, 페이지 또는 그룹 도형 요소에서 도형을 정의하는 요소를 포함합니다. |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | 도형 컬렉션. |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | 배치 가능한 도형에 대한 배치 동작을 지정합니다. |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | 배치 가능한 도형에 대한 배치 동작을 지정합니다. |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | 사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | 사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | 자식 요소에 대한 배치 스타일을 결정합니다. |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | 자식 요소에 대한 배치 스타일을 결정합니다. |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다. |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다. |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다. |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다. |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | 도형의 그림자 유형을 지정합니다. |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | 도형의 그림자 유형을 지정합니다. |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | 도형의 그림자 유형을 지정합니다. |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | 도형의 그림자 유형을 지정합니다. |
+| [ShdwType](../com.aspose.diagram/shdwtype) | 페이지에 대한 기본 그림자 유형을 나타냅니다. |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | 페이지에 대한 기본 그림자 유형을 나타냅니다. |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | 드롭 버튼을 표시할 시점을 지정합니다. |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | 도형 또는 페이지에 정의된 각 스마트 태그에 대한 정보를 포함하는 요소를 포함합니다. |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | SmartTagDef 컬렉션. |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | 선과 곡선 및 채워진 영역의 가장자리에 스무딩(안티앨리어싱)이 적용되는지 여부를 지정합니다. |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다. |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다. |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다. |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다. |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | 명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다. |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | SolutionXML 컬렉션. |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | SpinButton 컨트롤을 나타냅니다. |
+| [SplineKnot](../com.aspose.diagram/splineknot) | 스플라인의 제어점 및 스플라인의 매듭에 대한 x 및 y 좌표를 포함하며, 각각 X, Y 및 A 요소로 표시됩니다. |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | SplineKnot 컬렉션. |
+| [SplineStart](../com.aspose.diagram/splinestart) | 스플라인의 두 번째 제어점, 두 번째 매듭, 첫 번째 매듭, 마지막 매듭 및 스플라인 차수에 대한 x 및 y 좌표를 포함합니다. |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | SplineStart 컬렉션. |
+| [Str2Value](../com.aspose.diagram/str2value) | 문자열 값. |
+| [StrValue](../com.aspose.diagram/strvalue) | 문자열 값 |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | 스트림 옵션을 나타냅니다. |
+| [Style](../com.aspose.diagram/style) | 도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다. |
+| [StyleProp](../com.aspose.diagram/styleprop) | 스타일에 텍스트, 선, 채우기 속성이 포함되는지와 같은 스타일 동작을 제어하는 요소를 포함합니다. |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | 문서에 정의된 스타일을 나타냅니다. |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | StyleSheets 컬렉션. |
+| [StyleValue](../com.aspose.diagram/stylevalue) | 도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다. |
+| [Tab](../com.aspose.diagram/tab) | Tab 요소의 컬렉션을 포함합니다. |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Tab 요소의 컬렉션을 포함합니다 |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | TabCollection 요소의 컬렉션을 포함합니다 |
+| [Text](../com.aspose.diagram/text) | 도형의 텍스트를 포함합니다. |
+| [TextBlock](../com.aspose.diagram/textblock) | 도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다. |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | 텍스트 박스 ActiveX 컨트롤을 나타냅니다. |
+| [TextCollection](../com.aspose.diagram/textcollection) | 도형의 텍스트를 포함합니다. |
+| [TextDirection](../com.aspose.diagram/textdirection) | 텍스트 블록 내 문자 방향을 지정합니다. |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | 텍스트 블록 내 문자 방향을 지정합니다. |
+| [TextXForm](../com.aspose.diagram/textxform) | 도형 텍스트 블록에 대한 위치 정보를 지정하는 요소를 포함합니다. |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | 도형의 3차원 서식을 나타냅니다. |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | 페이지를 TIFF 형식으로 저장할 때 적용할 압축 유형을 지정합니다. |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | 타임라인 도형의 속성을 설정하기 위한 TimeLineHelper. |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | 연결이 이루어지는 도형의 부분. |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | ToggleButton ActiveX 컨트롤을 나타냅니다. |
+| [Tp](../com.aspose.diagram/tp) | 탭 속성 실행의 시작을 지정합니다. |
+| [Txt](../com.aspose.diagram/txt) | 도형의 텍스트 |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | 포함된 요소에 따라 다양한 유형을 지정합니다. |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | 포함된 요소에 따라 다양한 유형을 지정합니다. |
+| [TypeField](../com.aspose.diagram/typefield) | Type은 텍스트 필드 값의 데이터 유형을 지정합니다. |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Type은 텍스트 필드 값의 데이터 유형을 지정합니다. |
+| [TypeProp](../com.aspose.diagram/typeprop) | Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다. |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다. |
+| [TypeValue](../com.aspose.diagram/typevalue) | 선택적 열거형. |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | 탭 정렬을 지정합니다. |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | 탭 정렬을 지정합니다. |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | 요소의 속성을 지정합니다. |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | 요소의 지정된 속성. |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | 알 수 없는 컨트롤. |
+| [User](../com.aspose.diagram/user) | 다른 요소와 추가 도구에서 참조하는 사용자 지정 요소에 수식을 입력하기 위한 작업 영역을 포함합니다. |
+| [UserCollection](../com.aspose.diagram/usercollection) | 사용자 컬렉션. |
+| [Validation](../com.aspose.diagram/validation) | 문서에 대한 다이어그램 검증 정보를 저장합니다. |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | 문서 검증과 관련된 속성을 캡슐화합니다. |
+| [Value](../com.aspose.diagram/value) | 값. |
+| [VbaModule](../com.aspose.diagram/vbamodule) | VBA 프로젝트에 포함된 모듈을 나타냅니다. |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | [VbaModule](../com.aspose.diagram/vbamodule) 목록을 나타냅니다. |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | VBA 모듈 유형을 나타냅니다. |
+| [VbaProject](../com.aspose.diagram/vbaproject) | VBA 프로젝트를 나타냅니다. |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | VBA 프로젝트의 참조를 나타냅니다. |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | VBA 프로젝트의 모든 참조를 나타냅니다. |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | VBA 프로젝트 참조 유형을 나타냅니다. |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다. |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다. |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | 검증 규칙의 대상을 정의하는 내용을 지정합니다; ValidationRule.TargetType 속성에 전달되고 반환됩니다. |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | 동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다. |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | 동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다. |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | 경고 정보 |
+| [WarningType](../com.aspose.diagram/warningtype) | WarningType |
+| [Window](../com.aspose.diagram/window) | Microsoft Visio 인스턴스에서 열린 창을 나타냅니다. |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | 창 컬렉션. |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | 비트 플래그를 지정하는 정수. |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | 다음 중 하나일 수 있는 열거값: Drawing, Sheet, Stencil, 또는 Icon. |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | 다이어그램 페이지를 XAML로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [XForm](../com.aspose.diagram/xform) | 패턴, 두께 및 색상과 같은 도형의 선 속성을 제어하는 요소를 포함합니다. |
+| [XForm1D](../com.aspose.diagram/xform1d) | 1차원 도형의 시작점과 끝점의 x 및 y 좌표를 포함합니다. |
+| [XJustify](../com.aspose.diagram/xjustify) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다. |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다. |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | 다이어그램 페이지를 XPS로 렌더링할 때 추가 옵션을 지정할 수 있습니다. |
+| [YJustify](../com.aspose.diagram/yjustify) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다. |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | 페이지 저장 프로세스의 진행 상황을 제어/표시합니다. |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | 내보낸 스트림 제공자를 나타냅니다. |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | 경고에 대한 콜백 인터페이스입니다. |

--- a/korean/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/korean/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Aspose.Diagram for Java API 참조
+description: 시간이 많이 소요되는 모든 작업에서 중단 요청을 모니터링합니다.
+type: docs
+weight: 10
+url: /ko/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+시간이 많이 소요되는 모든 작업에서 중단 요청을 모니터링합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | 현재 작업에 대한 중단 요청 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+현재 작업에 대한 중단 요청 여부를 나타냅니다. true인 경우 현재 작업이 중단됩니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/act/_index.md
+++ b/korean/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Aspose.Diagram for Java API 참조
+description: 객체의 바로 가기 메뉴에 표시되는 사용자 지정 명령 이름을 정의하고 해당 명령이 수행하는 동작을 지정합니다.
+type: docs
+weight: 11
+url: /ko/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+객체의 바로 가기 메뉴에 표시되는 사용자 지정 명령 이름을 정의하고 해당 명령이 수행하는 동작을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Act()](#Act--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | 사용자가 해당 Menu 요소에 정의된 명령 이름을 클릭할 때 실행되는 수식을 포함합니다. |
+| [getBeginGroup()](#getBeginGroup--) | 이 동작 위의 메뉴에 구분자가 삽입되는지 여부를 나타냅니다. |
+| [getButtonFace()](#getButtonFace--) | 바로 가기 메뉴 항목 옆에 표시되는 아이콘을 식별합니다. |
+| [getChecked()](#getChecked--) | 도형의 바로 가기 메뉴에서 명령 이름 옆에 체크 표시가 표시되는지 여부를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDisabled()](#getDisabled--) | 비활성화된 요소는 명령 이름이 바로 가기 메뉴에 표시되는지 여부를 결정합니다. |
+| [getFlyoutChild()](#getFlyoutChild--) | 동작 행이 위에 있는 마지막 행 중 플라이아웃 자식이 아닌 행의 하위 플라이아웃 메뉴인지 여부를 결정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getInvisible()](#getInvisible--) | 보이지 않는 요소는 스마트 태그 또는 바로 가기 메뉴에서 동작이 표시되는지 여부를 나타냅니다. |
+| [getMenu()](#getMenu--) | 도형 또는 페이지의 바로 가기 메뉴에 표시되는 명령 이름을 지정합니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getReadOnly()](#getReadOnly--) | 스마트 태그 또는 바로 가기 메뉴에서 동작이 읽기 전용인지 여부를 결정합니다. |
+| [getSortKey()](#getSortKey--) | 바로 가기 또는 스마트 태그 메뉴에 표시되는 동작 순서를 결정하는 번호를 지정합니다. |
+| [getTagName()](#getTagName--) | 동작과 연결된 스마트 태그의 이름을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/act\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/act\#getID--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/act\#getIX--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/act\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/act\#getNameU--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+사용자가 해당 Menu 요소에 정의된 명령 이름을 클릭할 때 실행되는 수식을 포함합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+이 동작 위의 메뉴에 구분자가 삽입되는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+바로 가기 메뉴 항목 옆에 표시되는 아이콘을 식별합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+도형의 바로 가기 메뉴에서 명령 이름 옆에 체크 표시가 표시되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+비활성화된 요소는 명령 이름이 바로 가기 메뉴에 표시되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+동작 행이 위에 있는 마지막 행 중 플라이아웃 자식이 아닌 행의 하위 플라이아웃 메뉴인지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+보이지 않는 요소는 스마트 태그 또는 바로 가기 메뉴에서 동작이 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+도형 또는 페이지의 바로 가기 메뉴에 표시되는 명령 이름을 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+스마트 태그 또는 바로 가기 메뉴에서 동작이 읽기 전용인지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+바로 가기 또는 스마트 태그 메뉴에 표시되는 동작 순서를 결정하는 번호를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+동작과 연결된 스마트 태그의 이름을 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/act\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/act\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/act\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/act\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/act\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/actcollection/_index.md
+++ b/korean/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Act 컬렉션.
+type: docs
+weight: 12
+url: /ko/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Act 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | 컬렉션에 Act 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getAct(int ID)](#getAct-int-) | Gets the element at the specified ID. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | 컬렉션에서 Act 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+컬렉션에 Act 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+컬렉션에서 Act 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 13
+url: /ko/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/korean/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Aspose.Diagram for Java API 참조
+description: ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 14
+url: /ko/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/korean/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Aspose.Diagram for Java API 참조
+description: ActiveX 컨트롤을 지속시키는 지속성 방법을 나타냅니다.
+type: docs
+weight: 15
+url: /ko/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+ActiveX 컨트롤을 지속시키는 지속성 방법을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | 데이터가 XML 데이터로 저장됩니다. |
+| [STORAGE](#STORAGE) | 데이터가 스토리지 바이너리 데이터로 저장됩니다. |
+| [STREAM](#STREAM) | 데이터가 스트림 바이너리 데이터로 저장됩니다. |
+| [STREAM_INIT](#STREAM-INIT) | 데이터가 streaminit 바이너리 데이터로 저장됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+데이터가 XML 데이터로 저장됩니다.
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+데이터가 스토리지 바이너리 데이터로 저장됩니다.
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+데이터가 스트림 바이너리 데이터로 저장됩니다.
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+데이터가 streaminit 바이너리 데이터로 저장됩니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/align/_index.md
+++ b/korean/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Aspose.Diagram for Java API 참조
+description: 도형이 고정된 가이드 또는 가이드 포인트에 대한 도형의 정렬을 나타냅니다.
+type: docs
+weight: 16
+url: /ko/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+도형이 붙어 있는 가이드 또는 가이드 포인트에 대한 도형의 정렬을 나타냅니다. Align 요소는 가이드 또는 가이드 포인트에 붙어 있는 도형에만 표시됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | 도형의 하단 경계가 정렬되는 수평 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수직 위치를 결정합니다. |
+| [getAlignCenter()](#getAlignCenter--) | 도형의 수평 중심이 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다. |
+| [getAlignLeft()](#getAlignLeft--) | 도형의 왼쪽 경계가 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다. |
+| [getAlignMiddle()](#getAlignMiddle--) | 수평 가이드 또는 가이드 포인트에 대해 도형의 수직 중심이 정렬되는, 부모의 원점에 대한 수직 위치를 결정합니다. |
+| [getAlignRight()](#getAlignRight--) | 도형의 오른쪽 경계가 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다. |
+| [getAlignTop()](#getAlignTop--) | 도형의 상단 경계가 정렬되는 수평 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수직 위치를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/align\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+도형의 하단 경계가 정렬되는 수평 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수직 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+도형의 수평 중심이 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+도형의 왼쪽 경계가 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+수평 가이드 또는 가이드 포인트에 대해 도형의 수직 중심이 정렬되는, 부모의 원점에 대한 수직 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+도형의 오른쪽 경계가 정렬되는 수직 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수평 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+도형의 상단 경계가 정렬되는 수평 가이드 또는 가이드 포인트에 대해, 부모의 원점에 대한 수직 위치를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/align\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/alignment/_index.md
+++ b/korean/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Alignment
+second_title: Aspose.Diagram for Java API 참조
+description: 탭 정렬을 지정합니다.
+type: docs
+weight: 18
+url: /ko/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+탭 정렬을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 탭 정렬을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/alignment\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+탭 정렬을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/alignment\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/korean/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Aspose.Diagram for Java API 참조
+description: 탭 정렬을 지정합니다.
+type: docs
+weight: 19
+url: /ko/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+탭 정렬을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CENTER](#CENTER) | Center. |
+| [DECIMAL](#DECIMAL) | Decimal. |
+| [LEFT](#LEFT) | Left. |
+| [RIGHT](#RIGHT) | Right. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center.
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+Decimal.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/korean/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Aspose.Diagram for Java API 참조
+description: 선택적 int.
+type: docs
+weight: 17
+url: /ko/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+선택적 int. 스텐실 창에서 마스터 텍스트가 왼쪽, 오른쪽 또는 가운데 정렬되는지 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | 텍스트를 가운데 정렬합니다. |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | 텍스트를 왼쪽 정렬합니다. |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | 텍스트를 오른쪽 정렬합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+텍스트를 가운데 정렬합니다.
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+텍스트를 왼쪽 정렬합니다.
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+텍스트를 오른쪽 정렬합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/annotation/_index.md
+++ b/korean/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: 주석
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다.
+type: docs
+weight: 20
+url: /ko/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | 도형에 대한 주석 텍스트를 문자열 형식으로 포함합니다. |
+| [getDate()](#getDate--) | 주석이 생성된 시점을 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getEditDate()](#getEditDate--) | 주석이 마지막으로 변경된 시점을 지정합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getLangID()](#getLangID--) | 셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다. |
+| [getMarkerIndex()](#getMarkerIndex--) | 주석 마커에 할당된 인덱스 번호를 지정합니다. |
+| [getReviewerID()](#getReviewerID--) | 문서에 마크업을 추가하는 검토자의 ID 번호를 포함합니다. |
+| [getShapeID()](#getShapeID--) | 주석의 도형 ID. |
+| [getX()](#getX--) | 페이지 좌표계에서 주석 마커의 x좌표. |
+| [getY()](#getY--) | 페이지 좌표계에서 주석 마커의 y좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/annotation\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/annotation\#getIX--)을 참조하십시오. |
+| [setShapeID(int value)](#setShapeID-int-) | 이 속성에 대한 설명은 [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+도형에 대한 주석 텍스트를 문자열 형식으로 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+주석이 생성된 시점을 지정합니다.
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+주석이 마지막으로 변경된 시점을 지정합니다.
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+주석 마커에 할당된 인덱스 번호를 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+문서에 마크업을 추가하는 검토자의 ID 번호를 포함합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+주석의 도형 ID.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+페이지 좌표계에서 주석 마커의 x좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+페이지 좌표계에서 주석 마커의 y좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/annotation\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/annotation\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+이 속성에 대한 설명은 [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/korean/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Annotation 컬렉션.
+type: docs
+weight: 21
+url: /ko/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Annotation 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | 컬렉션에 Annotation 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | 컬렉션에서 Annotation 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+컬렉션에 Annotation 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+컬렉션에서 Annotation 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/arcto/_index.md
+++ b/korean/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Aspose.Diagram for Java API 참조
+description: X, Y 및 A 요소에 각각 표시되는 원호의 x 및 y 좌표와 활(볼)을 포함합니다.
+type: docs
+weight: 22
+url: /ko/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+X, Y 및 A 요소에 각각 의해 표현되는 원호의 x 및 y 좌표와 활을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | 다음 [ArcTo](../../com.aspose.diagram/arcto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 호의 중점에서 그 현의 중점까지의 거리. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 호의 끝 정점의 x 좌표. |
+| [getY()](#getY--) | 호의 끝 정점의 y 좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/arcto\#getA--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/arcto\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/arcto\#getIX--)을 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/arcto\#getX--)을 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/arcto\#getY--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+다음 [ArcTo](../../com.aspose.diagram/arcto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+호의 중점에서 그 현의 중점까지의 거리.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+호의 끝 정점의 x 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+호의 끝 정점의 y 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/arcto\#getA--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/arcto\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/arcto\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/arcto\#getX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/arcto\#getY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/arctocollection/_index.md
+++ b/korean/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: ArcTo 컬렉션.
+type: docs
+weight: 23
+url: /ko/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+ArcTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/arrowsize/_index.md
+++ b/korean/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Aspose.Diagram for Java API 참조
+description: 선의 화살촉 크기를 지정합니다.
+type: docs
+weight: 24
+url: /ko/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+선의 화살촉 크기를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 선의 화살촉 크기를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | 이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+선의 화살촉 크기를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/korean/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 선의 화살촉 크기를 지정합니다.
+type: docs
+weight: 25
+url: /ko/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+선의 화살촉 크기를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | 거대한. |
+| [EXTRA_LARGE](#EXTRA-LARGE) | 초대형. |
+| [JUMBO](#JUMBO) | 점보. |
+| [LARGE](#LARGE) | 큰. |
+| [MEDIUM](#MEDIUM) | 보통. |
+| [SMALL](#SMALL) | 작은. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VERY_SMALL](#VERY-SMALL) | 아주 작은. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+거대한.
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+초대형.
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+점보.
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+큰.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+보통.
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+작은.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+아주 작은.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/korean/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Aspose.Diagram for Java API 참조
+description: .NET PrintDocument 클래스의 자체 버전으로, PrintPreviewDialog 폼에 전달하여 다이어그램을 인쇄하고 미리 볼 수 있습니다.
+type: docs
+weight: 26
+url: /ko/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+.NET PrintDocument 클래스를 기반으로 하는 자체 버전으로, 다이어그램을 인쇄하고 미리 보기 위해 PrintPreviewDialog 폼에 전달할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | 다이어그램을 인쇄하고 미리 보기 위해 PrintPreviewDialog 폼에 전달할 수 있는 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+다이어그램을 인쇄하고 미리 보기 위해 PrintPreviewDialog 폼에 전달할 수 있는 이 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/korean/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자 인터페이스에서 수행된 마지막 성공적인 자동 연결 작업의 도형 데이터 항목과 상위 DataRecordset 요소의 열을 비교하는 규칙을 정의합니다.
+type: docs
+weight: 27
+url: /ko/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+사용자 인터페이스에서 수행된 마지막 성공적인 자동 연결 작업의 도형 데이터 항목과 상위 DataRecordset 요소의 열을 비교하는 규칙을 정의합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | ADO 레코드셋의 열 이름에 해당합니다. |
+| [getContextType()](#getContextType--) | 비교에 사용할 그룹 또는 도형의 속성을 지정합니다. |
+| [getContextTypeLabel()](#getContextTypeLabel--) | ContextType 값이 2 또는 3인 경우, 이 속성은 비교를 정의하기 위해 필요합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | 이 속성에 대한 설명은 [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)을 참조하십시오. |
+| [setContextType(int value)](#setContextType-int-) | 이 속성에 대한 설명은 [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)을 참조하십시오. |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | 이 속성에 대한 설명은 [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+ADO 레코드셋의 열 이름에 해당합니다.
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+비교에 사용할 그룹 또는 도형의 속성을 지정합니다. 가능한 값은 다음 표에 표시됩니다.
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+ContextType 값이 2 또는 3인 경우, 이 속성은 비교를 정의하기 위해 필요합니다. ContextType = 2인 경우, ContextTypeLabel은 도형 데이터 항목 레이블이어야 하며, ContextType = 3인 경우, ContextTypeLabel은 로컬 행 이름이어야 합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+이 속성에 대한 설명은 [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+이 속성에 대한 설명은 [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+이 속성에 대한 설명은 [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/korean/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 자동 간격 옵션을 나타냅니다.
+type: docs
+weight: 28
+url: /ko/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+자동 간격 옵션을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | 인치 단위로 수평 방향에서 도형 간의 거리를 정의합니다. |
+| [getDistanceInVertical()](#getDistanceInVertical--) | 인치 단위로 수직 방향에서 도형 간의 거리를 정의합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | 이 속성에 대한 설명은 [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)을(를) 참조하십시오. |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | 이 속성에 대한 설명은 [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+인치 단위로 수평 방향에서 도형 간의 거리를 정의합니다. 기본값은 0.375인치입니다.
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+인치 단위로 수직 방향에서 도형 간의 거리를 정의합니다. 기본값은 0.375인치입니다.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+이 속성에 대한 설명은 [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+이 속성에 대한 설명은 [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevel/_index.md
+++ b/korean/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 베벨을 나타냅니다.
+type: docs
+weight: 30
+url: /ko/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+도형의 베벨을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | 베벨의 높이, 즉 형태 위에 적용되는 거리입니다. |
+| [getWidth()](#getWidth--) | 베벨의 너비, 즉 형태 안쪽으로 적용되는 거리입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)을 참조하십시오. |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+베벨의 높이, 즉 형태 위에 적용되는 거리입니다. 단위는 포인트입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+베벨의 너비, 즉 형태 안쪽으로 적용되는 거리입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/korean/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 31
+url: /ko/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 베벨 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+베벨 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 적용할 수 있는 사전 설정 오른쪽 조명을 나타냅니다.
+type: docs
+weight: 32
+url: /ko/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+도형에 적용할 수 있는 사전 설정 오른쪽 조명을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BALANCED](#BALANCED) | Balanced |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Bright room |
+| [CHILLY](#CHILLY) | Chilly |
+| [CONTRASTING](#CONTRASTING) | Contrasting |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Flood |
+| [FREEZING](#FREEZING) | Freezing |
+| [GLOW](#GLOW) | Glow |
+| [HARSH](#HARSH) | Harsh |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Morning |
+| [SOFT](#SOFT) | 소프트 |
+| [SUNRISE](#SUNRISE) | 일출 |
+| [SUNSET](#SUNSET) | 일몰 |
+| [THREE_POINT](#THREE-POINT) | 삼점 |
+| [TWO_POINT](#TWO-POINT) | 이점 |
+| [UNDEFINED](#UNDEFINED) | 조명 장비 없음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Balanced
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Bright room
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Chilly
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Contrasting
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Flood
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Freezing
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Glow
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Harsh
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Morning
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+소프트
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+일출
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+일몰
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+삼점
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+이점
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+조명 장비 없음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/korean/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 33
+url: /ko/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 베벨 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+베벨 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 표면 외관을 설명합니다.
+type: docs
+weight: 34
+url: /ko/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+도형의 표면 외관을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CLEAR](#CLEAR) | 지우기 |
+| [DARK_EDGE](#DARK-EDGE) | 어두운 가장자리 |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | 레거시 매트 |
+| [LEGACY_METAL](#LEGACY-METAL) | 레거시 메탈 |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | 레거시 플라스틱 |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | 레거시 와이어프레임 |
+| [MATTE](#MATTE) | 매트 |
+| [METAL](#METAL) | 메탈 |
+| [PLASTIC](#PLASTIC) | 플라스틱 |
+| [POWDER](#POWDER) | 분말 |
+| [SOFT_EDGE](#SOFT-EDGE) | 부드러운 가장자리 |
+| [SOFT_METAL](#SOFT-METAL) | 부드러운 금속 |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | 반투명 분말 |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | 따뜻한 매트 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+지우기
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+어두운 가장자리
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+레거시 매트
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+레거시 메탈
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+레거시 플라스틱
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+레거시 와이어프레임
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+매트
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+메탈
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+플라스틱
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+분말
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+부드러운 가장자리
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+부드러운 금속
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+반투명 분말
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+따뜻한 매트
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/korean/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Aspose.Diagram for Java API 참조
+description: 3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다.
+type: docs
+weight: 35
+url: /ko/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANGLE](#ANGLE) | 각도 |
+| [ART_DECO](#ART-DECO) | 아트 데코 |
+| [CIRCLE](#CIRCLE) | 원 |
+| [CONVEX](#CONVEX) | 볼록 |
+| [COOL_SLANT](#COOL-SLANT) | 멋진 기울기 |
+| [CROSS](#CROSS) | Cross |
+| [DIVOT](#DIVOT) | Divot |
+| [HARD_EDGE](#HARD-EDGE) | Hard edge |
+| [NONE](#NONE) | No bevel |
+| [RELAXED_INSET](#RELAXED-INSET) | Relaxed inset |
+| [RIBLET](#RIBLET) | Riblet |
+| [SLOPE](#SLOPE) | Slope |
+| [SOFT_ROUND](#SOFT-ROUND) | Soft round |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+각도
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+아트 데코
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+원
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+볼록
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+멋진 기울기
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cross
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Divot
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Hard edge
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+No bevel
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Relaxed inset
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Riblet
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Slope
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Soft round
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/beveltype/_index.md
+++ b/korean/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 36
+url: /ko/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 베벨 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/beveltype\\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+베벨 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/beveltype\\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다.
+type: docs
+weight: 37
+url: /ko/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+3D에서 도형에 적용할 수 있는 베벨 유형에 대한 사전 설정을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANGLE](#ANGLE) | 각도 |
+| [ART_DECO](#ART-DECO) | 아트 데코 |
+| [CIRCLE](#CIRCLE) | 원 |
+| [CONVEX](#CONVEX) | 볼록 |
+| [COOL_SLANT](#COOL-SLANT) | 멋진 기울기 |
+| [CROSS](#CROSS) | Cross |
+| [DIVOT](#DIVOT) | Divot |
+| [HARD_EDGE](#HARD-EDGE) | Hard edge |
+| [NONE](#NONE) | No bevel |
+| [RELAXED_INSET](#RELAXED-INSET) | Relaxed inset |
+| [RIBLET](#RIBLET) | Riblet |
+| [SLOPE](#SLOPE) | Slope |
+| [SOFT_ROUND](#SOFT-ROUND) | Soft round |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+각도
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+아트 데코
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+원
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+볼록
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+멋진 기울기
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cross
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Divot
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Hard edge
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+No bevel
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Relaxed inset
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Riblet
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Slope
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Soft round
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bool/_index.md
+++ b/korean/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Aspose.Diagram for Java API 참조
+description: 불리언.
+type: docs
+weight: 29
+url: /ko/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+불리언.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FALSE](#FALSE) | False. |
+| [TRUE](#TRUE) | True. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않은 상태. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+False.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+True.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않은 상태.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/boolvalue/_index.md
+++ b/korean/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Aspose.Diagram for Java API 참조
+description: 불리언 값.
+type: docs
+weight: 38
+url: /ko/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+불리언 값.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 불리언 값 |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | 이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)을(를) 참조하십시오. |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+| 단위 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+불리언 값
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bullet/_index.md
+++ b/korean/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Aspose.Diagram for Java API 참조
+description: 글머리표 스타일을 결정합니다.
+type: docs
+weight: 39
+url: /ko/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+글머리표 스타일을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 글머리표 스타일을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bullet\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+글머리표 스타일을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/bullet\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/korean/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Aspose.Diagram for Java API 참조
+description: 글머리표 스타일을 결정합니다.
+type: docs
+weight: 40
+url: /ko/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+글머리표 스타일을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [NONE](#NONE) | 없음. |
+| [STYLE_1](#STYLE-1) | Point. |
+| [STYLE_2](#STYLE-2) | 마름모. |
+| [STYLE_3](#STYLE-3) | 정사각형. |
+| [STYLE_4](#STYLE-4) | 큰 사각형. |
+| [STYLE_5](#STYLE-5) | 마름모들. |
+| [STYLE_6](#STYLE-6) | 화살표. |
+| [STYLE_7](#STYLE-7) | 체크. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+없음.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Point.
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+마름모.
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+정사각형.
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+큰 사각형.
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+마름모들.
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+화살표.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+체크.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/calendar/_index.md
+++ b/korean/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자 정의 속성 텍스트 필드 및 요소 수식에 사용되는 캘린더를 결정합니다.
+type: docs
+weight: 41
+url: /ko/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/calendar\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/calendar\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/korean/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: CalendarValue
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자 정의 속성 텍스트 필드 및 요소 수식에 사용되는 캘린더를 결정합니다.
+type: docs
+weight: 42
+url: /ko/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Arabic hijiri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | English Transliterated. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | French Transliterated. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebrew lunar. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Japanese Emperor Reign. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Korean Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Saka Era. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Taiwan calendar. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Thai Buddhist. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [WESTERN](#WESTERN) | Western. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Arabic hijiri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+English Transliterated.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+French Transliterated.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebrew lunar.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Japanese Emperor Reign.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Korean Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Saka Era.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Taiwan calendar.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Thai Buddhist.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Western.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/case/_index.md
+++ b/korean/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 대소문자를 결정합니다.
+type: docs
+weight: 43
+url: /ko/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+도형 텍스트의 대소문자를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Case(int value)](#Case-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형 텍스트의 대소문자를 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/case\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/case\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형 텍스트의 대소문자를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/case\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/case\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/casevalue/_index.md
+++ b/korean/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 대소문자를 결정합니다.
+type: docs
+weight: 44
+url: /ko/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+도형 텍스트의 대소문자를 결정합니다. 모든 대문자 (uppercase) 문자 (1)와 첫 글자만 대문자인 경우 (2)는 전체가 대문자로 입력된 텍스트의 모양을 변경하지 않습니다. 이러한 옵션이 효과를 보려면 텍스트를 소문자로 입력해야 합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | 모두 대문자(uppercase) 문자. |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | 첫 글자만 대문자. |
+| [NORMAL_CASE](#NORMAL-CASE) | 일반 형태. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+모두 대문자(uppercase) 문자.
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+첫 글자만 대문자.
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+일반 형태.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/char/_index.md
+++ b/korean/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 서식 속성(예: 글꼴 색상, 텍스트 스타일, 대소문자, 기준선에 대한 위치 및 포인트 크기)을 포함합니다.
+type: docs
+weight: 45
+url: /ko/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+도형 텍스트의 서식 속성을 포함합니다(예: 글꼴, 색상, 텍스트 스타일, 대소문자, 기준선에 대한 위치 및 포인트 크기).
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Char()](#Char--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | 아시아 문자 텍스트를 서식 지정하는 데 사용되는 글꼴의 ID 번호를 지정합니다. |
+| [getAsianFontName()](#getAsianFontName--) | 텍스트 서식에 사용되는 아시아 글꼴 이름을 지정합니다. Visio 2013에서 사용됩니다. |
+| [getCase()](#getCase--) | 도형 텍스트의 대소문자를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Char 요소에 포함될 때, Color 요소입니다. |
+| [getColorTrans()](#getColorTrans--) | 레이어 또는 도형 텍스트 색상의 투명도 정도를 0(완전히 불투명)에서 1(완전히 투명)까지 결정합니다. |
+| [getComplexScriptFont()](#getComplexScriptFont--) | 복합 스크립트 문자로 구성된 텍스트를 서식 지정하는 데 사용되는 글꼴 번호를 포함합니다. |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | 텍스트 서식에 사용되는 ComplexScript 글꼴 이름을 지정합니다. Visio 2013에서 사용됩니다. |
+| [getComplexScriptSize()](#getComplexScriptSize--) | 복합 스크립트 문자로 구성된 텍스트를 서식 지정하는 데 사용되는 글꼴 크기. |
+| [getDblUnderline()](#getDblUnderline--) | 텍스트 범위에 이중 밑줄이 있는지 여부를 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | 텍스트가 이중 취소선으로 서식 지정되는지 여부를 결정합니다. |
+| [getFont()](#getFont--) | 텍스트 서식에 사용되는 글꼴의 ID 번호를 지정합니다. |
+| [getFontName()](#getFontName--) | 텍스트 서식에 사용되는 글꼴의 이름을 지정합니다. Visio 2013에 사용됩니다. |
+| [getFontScale()](#getFontScale--) | 글꼴 너비를 지정합니다. |
+| [getHighlight()](#getHighlight--) | 하이라이트를 지정합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getLangID()](#getLangID--) | 셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다. |
+| [getLetterspace()](#getLetterspace--) | 두 개 이상의 문자 사이의 간격을 지정합니다. |
+| [getLocale()](#getLocale--) | 맞춤법 검사 목적으로 텍스트 실행의 로케일을 지정합니다. |
+| [getLocalizeFont()](#getLocalizeFont--) | 도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다. |
+| [getOverline()](#getOverline--) | 텍스트 위에 선이 있는지 여부를 지정합니다. |
+| [getPerpendicular()](#getPerpendicular--) | 텍스트 블록에서 텍스트 필드가 다른 텍스트에 대해 수직으로 표시되는지 여부를 지정합니다. |
+| [getPos()](#getPos--) | 도형 텍스트의 기준선에 대한 위치를 지정합니다. |
+| [getRTLText()](#getRTLText--) | 현재 문자 실행의 텍스트 방향이 왼쪽에서 오른쪽인지 오른쪽에서 왼쪽인지 결정합니다. |
+| [getSize()](#getSize--) | 도형 텍스트 블록 내 텍스트 크기를 지정합니다. |
+| [getStrikethru()](#getStrikethru--) | 텍스트가 취소선으로 서식 지정되는지 여부를 지정합니다. |
+| [getStyle()](#getStyle--) | 도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다. |
+| [getUseVertical()](#getUseVertical--) | 문자 실행이 수직인지 수평인지 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | 글꼴이 굵게 표시되는지 여부를 나타냅니다. |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | 글꼴이 이중 취소선인지 여부를 나타냅니다. |
+| [isDoubleUnderline()](#isDoubleUnderline--) | 글꼴이 이중 밑줄인지 여부를 나타냅니다. |
+| [isItalic()](#isItalic--) | 글꼴이 이탤릭인지 여부를 나타냅니다. |
+| [isStrikethrough()](#isStrikethrough--) | 글꼴이 취소선인지 여부를 나타냅니다. |
+| [isSubscript()](#isSubscript--) | 글꼴이 아래 첨자인지 여부를 나타냅니다. |
+| [isSuperscript()](#isSuperscript--) | 글꼴이 위 첨자인지 여부를 나타냅니다. |
+| [isUnderline()](#isUnderline--) | 글꼴이 밑줄인지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)을 참조하십시오. |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)을 참조하십시오. |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | 이 속성에 대한 설명은 [getCase()](../../com.aspose.diagram/char\#getCase--)을 참조하십시오. |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/char\#getColor--)을 참조하십시오. |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)를 참조하십시오. |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)를 참조하십시오. |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)를 참조하십시오. |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)를 참조하십시오. |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)를 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/char\#getDel--)를 참조하십시오. |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)를 참조하십시오. |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getFont()](../../com.aspose.diagram/char\#getFont--)를 참조하십시오. |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getFontName()](../../com.aspose.diagram/char\#getFontName--)를 참조하십시오. |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)를 참조하십시오. |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)를 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/char\#getIX--)를 참조하십시오. |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getLangID()](../../com.aspose.diagram/char\#getLangID--)를 참조하십시오. |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)를 참조하십시오. |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getLocale()](../../com.aspose.diagram/char\#getLocale--)를 참조하십시오. |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | 이 속성에 대한 설명은 [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)를 참조하십시오. |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getOverline()](../../com.aspose.diagram/char\#getOverline--)를 참조하십시오. |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)를 참조하십시오. |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | 이 속성에 대한 설명은 [getPos()](../../com.aspose.diagram/char\#getPos--)를 참조하십시오. |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)를 참조하십시오. |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getSize()](../../com.aspose.diagram/char\#getSize--)를 참조하십시오. |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)를 참조하십시오. |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | 이 속성에 대한 설명은 [getStyle()](../../com.aspose.diagram/char\#getStyle--)를 참조하십시오. |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+아시아 문자 텍스트를 서식 지정하는 데 사용되는 글꼴의 ID 번호를 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+텍스트 서식에 사용되는 아시아 글꼴 이름을 지정합니다. Visio 2013에서 사용됩니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+도형 텍스트의 대소문자를 결정합니다.
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Char 요소에 포함될 때, Color 요소입니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+레이어 또는 도형 텍스트 색상의 투명도 정도를 0(완전히 불투명)에서 1(완전히 투명)까지 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+복합 스크립트 문자로 구성된 텍스트를 서식 지정하는 데 사용되는 글꼴 번호를 포함합니다. 복합 스크립트는 문자 결합이나 형태 변환이 필요한 언어로, 오른쪽에서 왼쪽으로 쓰는 언어(아라비아어, 파르시어, 히브리어 및 우르두어)와 여러 남아시아 언어가 있습니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+텍스트 서식에 사용되는 ComplexScript 글꼴 이름을 지정합니다. Visio 2013에서 사용됩니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+복잡한 스크립트 문자로 구성된 텍스트를 서식 지정하는 데 사용되는 글꼴 크기입니다. 복잡한 스크립트는 문자 결합이나 형태 변환이 필요한 언어로, 오른쪽에서 왼쪽으로 쓰는 언어(아라비아어, 파르시어, 히브리어 및 우르두어)와 여러 남아시아 언어가 포함됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+텍스트 범위에 이중 밑줄이 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+텍스트가 이중 취소선으로 서식 지정되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+텍스트 서식에 사용되는 글꼴의 ID 번호를 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+텍스트 서식에 사용되는 글꼴의 이름을 지정합니다. Visio 2013에 사용됩니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+글꼴 너비를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+하이라이트를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다. Microsoft Office 응용 프로그램에서 지원하는 언어와 해당 언어 ID 목록은 DocLangID 요소를 참조하십시오.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+두 개 이상의 문자 사이의 간격을 지정합니다. 간격은 1/20 포인트 단위로 추가하거나 감소시킬 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+맞춤법 검사 목적으로 텍스트 실행의 로케일을 지정합니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다.
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+텍스트 위에 선이 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+텍스트 블록에서 텍스트 필드가 다른 텍스트에 대해 수직으로 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+도형 텍스트의 기준선에 대한 위치를 지정합니다.
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+현재 문자 실행의 텍스트 방향이 왼쪽에서 오른쪽인지 오른쪽에서 왼쪽인지 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+도형 텍스트 블록 내 텍스트 크기를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+텍스트가 취소선으로 서식 지정되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다.
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+문자 실행이 수직인지 수평인지 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+글꼴이 굵게 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+글꼴이 이중 취소선인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+글꼴이 이중 밑줄인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+글꼴이 이탤릭인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+글꼴이 취소선인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+글꼴이 아래 첨자인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+글꼴이 위 첨자인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+글꼴이 밑줄인지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+이 속성에 대한 설명은 [getCase()](../../com.aspose.diagram/char\#getCase--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/char\#getColor--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/char\#getDel--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getFont()](../../com.aspose.diagram/char\#getFont--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getFontName()](../../com.aspose.diagram/char\#getFontName--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/char\#getIX--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getLangID()](../../com.aspose.diagram/char\#getLangID--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getLocale()](../../com.aspose.diagram/char\#getLocale--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+이 속성에 대한 설명은 [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getOverline()](../../com.aspose.diagram/char\#getOverline--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+이 속성에 대한 설명은 [getPos()](../../com.aspose.diagram/char\#getPos--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getSize()](../../com.aspose.diagram/char\#getSize--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+이 속성에 대한 설명은 [getStyle()](../../com.aspose.diagram/char\#getStyle--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/charcollection/_index.md
+++ b/korean/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 문자 컬렉션.
+type: docs
+weight: 46
+url: /ko/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+문자 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | 컬렉션에 Char 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getChar(int IX)](#getChar-int-) | 지정된 IX에 있는 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | 컬렉션에서 Char 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+컬렉션에 Char 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+지정된 IX에 있는 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int | int 요소가 부모 요소 내에서 차지하는 0 기반 인덱스입니다. |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+컬렉션에서 Char 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: CheckBox ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 47
+url: /ko/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+CheckBox ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | 컨트롤의 단축키입니다. |
+| [getAlignment()](#getAlignment--) | 컨트롤에 대한 Caption의 위치입니다. |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getCaption()](#getCaption--) | 컨트롤에 표시되는 설명 텍스트입니다. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getGroupName()](#getGroupName--) | 그룹의 이름입니다. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPicturePosition()](#getPicturePosition--) | 컨트롤 캡션에 상대적인 그림의 위치. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getValue()](#getValue--) | 컨트롤이 선택되었는지 여부를 나타냅니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isChecked()](#isChecked--) | 상자가 선택되었는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isTripleState()](#isTripleState--) | 지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다. |
+| [isWordWrapped()](#isWordWrapped--) | 컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | 이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)을(를) 참조하십시오. |
+| [setAlignment(int value)](#setAlignment-int-) | 이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)을(를) 참조하십시오. |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setCaption(String value)](#setCaption-java.lang.String-) | 이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)을(를) 참조하십시오. |
+| [setChecked(boolean value)](#setChecked-boolean-) | 이 속성에 대한 설명은 [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)을(를) 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | 이 속성에 대한 설명은 [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)을(를) 참조하십시오. |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | 이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)을(를) 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | 이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | 이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+컨트롤의 단축키입니다.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+컨트롤에 대한 Caption의 위치입니다.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+컨트롤에 표시되는 설명 텍스트입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+그룹의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+컨트롤 캡션에 상대적인 그림의 위치.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+컨트롤이 선택되었는지 여부를 나타냅니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+상자가 선택되었는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 설정 | 설명 |
+| True    | 컨트롤은 Yes, No 및 Null 값에 대한 상태를 순환합니다. Value 속성이 Null로 설정되면 컨트롤이 흐리게(회색) 표시됩니다. |
+| False   | (기본값) 컨트롤은 Yes와 No 값에 대한 상태를 순환합니다. Null 값은 No 값처럼 표시됩니다. |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+이 속성에 대한 설명은 [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/korean/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Aspose.Diagram for Java API 참조
+description: 체크 박스의 체크 값 유형을 나타냅니다.
+type: docs
+weight: 48
+url: /ko/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+체크 박스의 체크 값 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CHECKED](#CHECKED) | Checked |
+| [MIXED](#MIXED) | Mixed |
+| [UN_CHECKED](#UN-CHECKED) | UnChecked |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+Checked
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+Mixed
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+UnChecked
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/collection/_index.md
+++ b/korean/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: 컬렉션
+second_title: Aspose.Diagram for Java API 참조
+description: 컬렉션의 기본 클래스입니다.
+type: docs
+weight: 49
+url: /ko/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+컬렉션의 기본 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Collection()](#Collection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+생성자.
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/collectionbase/_index.md
+++ b/korean/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Aspose.Diagram for Java API 참조
+description: 강력히 형식화된 컬렉션을 위한 추상 기본 클래스를 제공합니다.
+type: docs
+weight: 50
+url: /ko/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+강력히 형식화된 컬렉션을 위한 추상 기본 클래스를 제공합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | CollectionBase 클래스의 새 인스턴스를 기본 초기 용량으로 초기화합니다. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | CollectionBase 클래스의 새 인스턴스를 지정된 용량으로 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | CollectionBase 인스턴스에 항목을 추가합니다. |
+| [clear()](#clear--) | CollectionBase 인스턴스에서 모든 객체를 제거합니다. |
+| [contains(Object o)](#contains-java.lang.Object-) | 인스턴스가 이 객체를 포함하는지 여부를 반환합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 위치의 항목을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+| [iterator()](#iterator--) | CollectionBase 인스턴스를 순회하는 열거자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | 지정된 인덱스에 있는 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+CollectionBase 클래스의 새 인스턴스를 기본 초기 용량으로 초기화합니다.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+CollectionBase 클래스의 새 인스턴스를 지정된 용량으로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 용량 | int | 새 목록이 처음에 저장할 수 있는 요소 수입니다. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+CollectionBase 인스턴스에 항목을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에 추가할 객체입니다. |
+
+**Returns:**
+int - 새 요소가 삽입된 위치입니다.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+CollectionBase 인스턴스에서 모든 객체를 제거합니다.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+인스턴스가 이 객체를 포함하는지 여부를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | 테스트 객체 |
+
+**Returns:**
+boolean - 인스턴스가 이 객체를 포함하는지 여부
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+지정된 위치의 항목을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 지정된 위치 인덱스. |
+
+**Returns:**
+java.lang.Object - 지정된 위치의 항목.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int - CollectionBase 인스턴스에 포함된 요소 수.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+
+**Returns:**
+int - 리스트에서 값을 찾은 경우 해당 인덱스; 찾지 못하면 -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+CollectionBase 인스턴스를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+java.util.Iterator - CollectionBase 인스턴스용 반복자.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+지정된 인덱스에 있는 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 제거할 항목의 0부터 시작하는 인덱스. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/color/_index.md
+++ b/korean/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Aspose.Diagram for Java API 참조
+description: ARGB 알파, 빨강, 초록, 파랑 색상을 나타냅니다.
+type: docs
+weight: 51
+url: /ko/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+ARGB(알파, 빨강, 초록, 파랑) 색상을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Color()](#Color--) | 구성 함수 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 Color 객체이며 이 객체와 동등한지 테스트합니다. |
+| [fromArgb(int argb)](#fromArgb-int-) | 32비트 ARGB 값으로부터 Color 객체를 생성합니다. |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | 지정된 8비트 색상 값(빨강, 초록, 파랑)으로부터 Color 객체를 생성합니다. |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | 네 가지 ARGB 구성 요소(알파, 빨강, 초록, 파랑) 값으로부터 Color 객체를 생성합니다. |
+| [getA()](#getA--) | 이 Color 객체의 알파 구성 요소 값을 가져옵니다. |
+| [getAliceBlue()](#getAliceBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getAntiqueWhite()](#getAntiqueWhite--) | 시스템 정의 색상을 가져옵니다. |
+| [getAqua()](#getAqua--) | 시스템 정의 색상을 가져옵니다. |
+| [getAquamarine()](#getAquamarine--) | 시스템 정의 색상을 가져옵니다. |
+| [getAzure()](#getAzure--) | 시스템 정의 색상을 가져옵니다. |
+| [getB()](#getB--) | 이 Color 객체의 파랑 구성 요소 값을 가져옵니다. |
+| [getBeige()](#getBeige--) | 시스템 정의 색상을 가져옵니다. |
+| [getBisque()](#getBisque--) | 시스템 정의 색상을 가져옵니다. |
+| [getBlack()](#getBlack--) | 시스템 정의 색상을 가져옵니다. |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | 시스템 정의 색상을 가져옵니다. |
+| [getBlue()](#getBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getBlueViolet()](#getBlueViolet--) | 시스템 정의 색상을 가져옵니다. |
+| [getBrown()](#getBrown--) | 시스템 정의 색상을 가져옵니다. |
+| [getBurlyWood()](#getBurlyWood--) | 시스템 정의 색상을 가져옵니다. |
+| [getCadetBlue()](#getCadetBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getChartreuse()](#getChartreuse--) | 시스템 정의 색상을 가져옵니다. |
+| [getChocolate()](#getChocolate--) | 시스템 정의 색상을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | 시스템 정의 색상을 가져옵니다. |
+| [getCornflowerBlue()](#getCornflowerBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getCornsilk()](#getCornsilk--) | 시스템 정의 색상을 가져옵니다. |
+| [getCrimson()](#getCrimson--) | 시스템 정의 색상을 가져옵니다. |
+| [getCyan()](#getCyan--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkBlue()](#getDarkBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkCyan()](#getDarkCyan--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkGray()](#getDarkGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkGreen()](#getDarkGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkKhaki()](#getDarkKhaki--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkMagenta()](#getDarkMagenta--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkOrange()](#getDarkOrange--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkOrchid()](#getDarkOrchid--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkRed()](#getDarkRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkSalmon()](#getDarkSalmon--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkSlateGray()](#getDarkSlateGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkTurquoise()](#getDarkTurquoise--) | 시스템 정의 색상을 가져옵니다. |
+| [getDarkViolet()](#getDarkViolet--) | 시스템 정의 색상을 가져옵니다. |
+| [getDeepPink()](#getDeepPink--) | 시스템 정의 색상을 가져옵니다. |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getDimGray()](#getDimGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getDodgerBlue()](#getDodgerBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getEmpty()](#getEmpty--) | 시스템 정의 빈 색상을 가져옵니다. |
+| [getFirebrick()](#getFirebrick--) | 시스템 정의 색상을 가져옵니다. |
+| [getFloralWhite()](#getFloralWhite--) | 시스템 정의 색상을 가져옵니다. |
+| [getForestGreen()](#getForestGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getFuchsia()](#getFuchsia--) | 시스템 정의 색상을 가져옵니다. |
+| [getG()](#getG--) | 이 Color 객체의 초록 구성 요소 값을 가져옵니다. |
+| [getGainsboro()](#getGainsboro--) | 시스템 정의 색상을 가져옵니다. |
+| [getGhostWhite()](#getGhostWhite--) | 시스템 정의 색상을 가져옵니다. |
+| [getGold()](#getGold--) | 시스템 정의 색상을 가져옵니다. |
+| [getGoldenrod()](#getGoldenrod--) | 시스템 정의 색상을 가져옵니다. |
+| [getGray()](#getGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getGreen()](#getGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getGreenYellow()](#getGreenYellow--) | 시스템 정의 색상을 가져옵니다. |
+| [getHoneydew()](#getHoneydew--) | 시스템 정의 색상을 가져옵니다. |
+| [getHotPink()](#getHotPink--) | 시스템 정의 색상을 가져옵니다. |
+| [getIndianRed()](#getIndianRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getIndigo()](#getIndigo--) | 시스템 정의 색상을 가져옵니다. |
+| [getIvory()](#getIvory--) | 시스템 정의 색상을 가져옵니다. |
+| [getKhaki()](#getKhaki--) | 시스템 정의 색상을 가져옵니다. |
+| [getLavender()](#getLavender--) | 시스템 정의 색상을 가져옵니다. |
+| [getLavenderBlush()](#getLavenderBlush--) | 시스템 정의 색상을 가져옵니다. |
+| [getLawnGreen()](#getLawnGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getLemonChiffon()](#getLemonChiffon--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightBlue()](#getLightBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightCoral()](#getLightCoral--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightCyan()](#getLightCyan--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightGray()](#getLightGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightGreen()](#getLightGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightPink()](#getLightPink--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightSalmon()](#getLightSalmon--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightSeaGreen()](#getLightSeaGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightSkyBlue()](#getLightSkyBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightSlateGray()](#getLightSlateGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightSteelBlue()](#getLightSteelBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getLightYellow()](#getLightYellow--) | 시스템 정의 색상을 가져옵니다. |
+| [getLime()](#getLime--) | 시스템 정의 색상을 가져옵니다. |
+| [getLimeGreen()](#getLimeGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getLinen()](#getLinen--) | 시스템 정의 색상을 가져옵니다. |
+| [getMagenta()](#getMagenta--) | 시스템 정의 색상을 가져옵니다. |
+| [getMaroon()](#getMaroon--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumAquamarine()](#getMediumAquamarine--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumBlue()](#getMediumBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumOrchid()](#getMediumOrchid--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumPurple()](#getMediumPurple--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumTurquoise()](#getMediumTurquoise--) | 시스템 정의 색상을 가져옵니다. |
+| [getMediumVioletRed()](#getMediumVioletRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getMidnightBlue()](#getMidnightBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getMintCream()](#getMintCream--) | 시스템 정의 색상을 가져옵니다. |
+| [getMistyRose()](#getMistyRose--) | 시스템 정의 색상을 가져옵니다. |
+| [getMoccasin()](#getMoccasin--) | 시스템 정의 색상을 가져옵니다. |
+| [getNavajoWhite()](#getNavajoWhite--) | 시스템 정의 색상을 가져옵니다. |
+| [getNavy()](#getNavy--) | 시스템 정의 색상을 가져옵니다. |
+| [getOldLace()](#getOldLace--) | 시스템 정의 색상을 가져옵니다. |
+| [getOlive()](#getOlive--) | 시스템 정의 색상을 가져옵니다. |
+| [getOliveDrab()](#getOliveDrab--) | 시스템 정의 색상을 가져옵니다. |
+| [getOrange()](#getOrange--) | 시스템 정의 색상을 가져옵니다. |
+| [getOrangeRed()](#getOrangeRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getOrchid()](#getOrchid--) | 시스템 정의 색상을 가져옵니다. |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | 시스템 정의 색상을 가져옵니다. |
+| [getPaleGreen()](#getPaleGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getPaleTurquoise()](#getPaleTurquoise--) | 시스템 정의 색상을 가져옵니다. |
+| [getPaleVioletRed()](#getPaleVioletRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getPapayaWhip()](#getPapayaWhip--) | 시스템 정의 색상을 가져옵니다. |
+| [getPeachPuff()](#getPeachPuff--) | 시스템 정의 색상을 가져옵니다. |
+| [getPeru()](#getPeru--) | 시스템 정의 색상을 가져옵니다. |
+| [getPink()](#getPink--) | 시스템 정의 색상을 가져옵니다. |
+| [getPlum()](#getPlum--) | 시스템 정의 색상을 가져옵니다. |
+| [getPowderBlue()](#getPowderBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getPurple()](#getPurple--) | 시스템 정의 색상을 가져옵니다. |
+| [getR()](#getR--) | 이 Color 객체의 빨강 구성 요소 값을 가져옵니다. |
+| [getRed()](#getRed--) | 시스템 정의 색상을 가져옵니다. |
+| [getRosyBrown()](#getRosyBrown--) | 시스템 정의 색상을 가져옵니다. |
+| [getRoyalBlue()](#getRoyalBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getSaddleBrown()](#getSaddleBrown--) | 시스템 정의 색상을 가져옵니다. |
+| [getSalmon()](#getSalmon--) | 시스템 정의 색상을 가져옵니다. |
+| [getSandyBrown()](#getSandyBrown--) | 시스템 정의 색상을 가져옵니다. |
+| [getSeaGreen()](#getSeaGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getSeaShell()](#getSeaShell--) | 시스템 정의 색상을 가져옵니다. |
+| [getSienna()](#getSienna--) | 시스템 정의 색상을 가져옵니다. |
+| [getSilver()](#getSilver--) | 시스템 정의 색상을 가져옵니다. |
+| [getSkyBlue()](#getSkyBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getSlateBlue()](#getSlateBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getSlateGray()](#getSlateGray--) | 시스템 정의 색상을 가져옵니다. |
+| [getSnow()](#getSnow--) | 시스템 정의 색상을 가져옵니다. |
+| [getSpringGreen()](#getSpringGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [getSteelBlue()](#getSteelBlue--) | 시스템 정의 색상을 가져옵니다. |
+| [getTan()](#getTan--) | 시스템 정의 색상을 가져옵니다. |
+| [getTeal()](#getTeal--) | 시스템 정의 색상을 가져옵니다. |
+| [getThistle()](#getThistle--) | 시스템 정의 색상을 가져옵니다. |
+| [getTomato()](#getTomato--) | 시스템 정의 색상을 가져옵니다. |
+| [getTransparent()](#getTransparent--) | 시스템 정의 색상을 가져옵니다. |
+| [getTurquoise()](#getTurquoise--) | 시스템 정의 색상을 가져옵니다. |
+| [getViolet()](#getViolet--) | 시스템 정의 색상을 가져옵니다. |
+| [getWheat()](#getWheat--) | 시스템 정의 색상을 가져옵니다. |
+| [getWhite()](#getWhite--) | 시스템 정의 색상을 가져옵니다. |
+| [getWhiteSmoke()](#getWhiteSmoke--) | 시스템 정의 색상을 가져옵니다. |
+| [getYellow()](#getYellow--) | 시스템 정의 색상을 가져옵니다. |
+| [getYellowGreen()](#getYellowGreen--) | 시스템 정의 색상을 가져옵니다. |
+| [hashCode()](#hashCode--) | 이 Color 객체에 대한 해시 코드를 반환합니다. |
+| [isEmpty()](#isEmpty--) | 이 Color 객체가 초기화되지 않았는지 지정합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | 이 Color 객체의 32비트 ARGB 값을 가져옵니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+구성 함수
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 Color 객체이며 이 객체와 동등한지 테스트합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 테스트할 객체. |
+
+**Returns:**
+boolean - obj가 Color 객체이며 이 Color 객체와 동등하면 true; 그렇지 않으면 false.
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+32비트 ARGB 값으로부터 Color 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| argb | int | 32비트 ARGB 값을 지정하는 값. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+지정된 8비트 색상 값(빨강, 초록, 파랑)으로부터 Color 객체를 생성합니다. 알파 값은 암시적으로 255(완전 불투명)입니다. 이 메서드는 각 색상 구성 요소에 대해 32비트 값을 전달할 수 있도록 허용하지만, 각 구성 요소의 값은 8비트로 제한됩니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| red | int | 새 Color 객체의 빨강 구성 요소 값입니다. 유효한 값은 0부터 255까지입니다. |
+| 녹색 | int | 새 Color 객체의 녹색 구성 요소 값입니다. 유효한 값은 0부터 255까지입니다. |
+| 파란색 | int | 새 Color 객체의 파란색 구성 요소 값입니다. 유효한 값은 0부터 255까지입니다. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+알파, 빨강, 녹색 및 파랑 네 가지 ARGB 구성 요소 값을 사용하여 Color 객체를 생성합니다. 이 메서드는 각 구성 요소에 대해 32비트 값을 전달할 수 있지만, 각 구성 요소의 값은 8비트로 제한됩니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 알파 | int | 알파 구성 요소입니다. 유효한 값은 0부터 255까지입니다. |
+| red | int | 빨간색 구성 요소입니다. 유효한 값은 0부터 255까지입니다. |
+| 녹색 | int | 녹색 구성 요소입니다. 유효한 값은 0부터 255까지입니다. |
+| 파란색 | int | 파란색 구성 요소입니다. 유효한 값은 0부터 255까지입니다. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+이 Color 객체의 알파 구성 요소 값을 가져옵니다.
+
+**Returns:**
+byte - 이 Color 객체의 알파 구성 요소 값입니다.
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+이 Color 객체의 파랑 구성 요소 값을 가져옵니다.
+
+**Returns:**
+byte - 이 Color 객체의 파란색 구성 요소 값입니다.
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+시스템 정의 빈 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+이 Color 객체의 초록 구성 요소 값을 가져옵니다.
+
+**Returns:**
+byte - 이 Color 객체의 녹색 구성 요소 값입니다.
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+이 Color 객체의 빨강 구성 요소 값을 가져옵니다.
+
+**Returns:**
+byte - 이 Color 객체의 빨간색 구성 요소 값입니다.
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+시스템 정의 색상을 가져옵니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+이 Color 객체에 대한 해시 코드를 반환합니다.
+
+**Returns:**
+int - 이 Color 객체의 해시 코드를 지정하는 정수 값입니다.
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+이 Color 객체가 초기화되지 않았는지 지정합니다.
+
+**Returns:**
+boolean - 이 색상이 초기화되지 않은 경우 true를 반환하고, 그렇지 않으면 false를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+이 Color 객체의 32비트 ARGB 값을 가져옵니다.
+
+**Returns:**
+int - 이 Color 객체의 32비트 ARGB 값입니다.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/colorentry/_index.md
+++ b/korean/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Aspose.Diagram for Java API 참조
+description: 색상표 항목을 포함합니다.
+type: docs
+weight: 52
+url: /ko/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+색상 테이블 항목을 포함합니다. 각 색상 테이블 항목은 도형, 텍스트 및 문서의 레이어와 같은 객체에 적용할 수 있는 표준 색상을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | ARGB 색상을 나타냅니다. |
+| [getIX()](#getIX--) | 필수 int. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | 이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/colorentry\#getColor--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/colorentry\#getIX--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+ARGB 색상을 나타냅니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+필수 int. 요소가 상위 요소 내에서 차지하는 0부터 시작하는 인덱스입니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/colorentry\#getColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/colorentry\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/korean/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 색상 테이블을 포함합니다.
+type: docs
+weight: 53
+url: /ko/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+문서의 색상 테이블을 포함합니다. 각 문서는 단일 색상 테이블을 가지고 있으며, 여기에는 도형, 텍스트 및 레이어와 같은 객체에 적용할 수 있는 24가지 표준 색상이 나열됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | 컬렉션에 Color 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | 컬렉션에서 Color 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+컬렉션에 Color 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+컬렉션에서 Color 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/colorvalue/_index.md
+++ b/korean/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Aspose.Diagram for Java API 참조
+description: 색상 값을 나타냅니다
+type: docs
+weight: 54
+url: /ko/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+색상 값을 나타냅니다
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 색상 값. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)을 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+| 단위 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+색상 값. 색상을 설정하려면 0부터 23까지의 숫자 또는 16진수 표기법의 RGB 값을 입력하십시오.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: ComboBox ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 55
+url: /ko/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+ComboBox ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getBorderOleColor()](#getBorderOleColor--) | the ole color of the background. |
+| [getBorderStyle()](#getBorderStyle--) | the type of border used by the control. |
+| [getBoundColumn()](#getBoundColumn--) | Represents how the Value property is determined for a ComboBox or ListBox when the MultiSelect propertys value (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Represents the number of columns to display in a ComboBox or ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | the width of the column. |
+| [getData()](#getData--) | the binary data of the control. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Specifies the symbol displayed on the drop button |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Specifies selection behavior when entering the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getHideSelection()](#getHideSelection--) | Indicates whether selected text in the control appears highlighted when the control does not have focus. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getListRows()](#getListRows--) | 목록에 표시할 최대 행 수를 나타냅니다. |
+| [getListStyle()](#getListStyle--) | 시각적 모양. |
+| [getListWidth()](#getListWidth--) | 포인트 단위의 너비. |
+| [getMatchEntry()](#getMatchEntry--) | 사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다. |
+| [getMaxLength()](#getMaxLength--) | 최대 문자 수 |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getSelectionMargin()](#getSelectionMargin--) | 사용자가 텍스트 왼쪽 영역을 클릭하여 텍스트 라인을 선택할 수 있는지 여부를 나타냅니다. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | 열 머리글이 표시되는지 여부를 나타냅니다. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Specifies the symbol displayed on the drop button |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getTextColumn()](#getTextColumn--) | 사용자에게 표시할 ComboBox 또는 ListBox의 열을 나타냅니다. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getValue()](#getValue--) | 컨트롤의 값. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | 선택을 확장하는 데 사용되는 기본 단위를 지정합니다. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | 컨트롤에 대해 끌어다 놓기가 활성화되어 있는지 여부를 나타냅니다. |
+| [isEditable()](#isEditable--) | 사용자가 컨트롤에 입력할 수 있는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | 이 속성에 대한 설명은 [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | 이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)을 참조하십시오 |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | 이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)을(를) 참조하십시오. |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | 이 속성에 대한 설명은 [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)을(를) 참조하십시오. |
+| [setColumnCount(int value)](#setColumnCount-int-) | 이 속성에 대한 설명은 [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)을(를) 참조하십시오. |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | 이 속성에 대한 설명은 [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)을(를) 참조하십시오. |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | 이 속성에 대한 설명은 [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)을(를) 참조하십시오. |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | 이 속성에 대한 설명은 [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)을(를) 참조하십시오. |
+| [setEditable(boolean value)](#setEditable-boolean-) | 이 속성에 대한 설명은 [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)을(를) 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | 이 속성에 대한 설명은 [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | 이 속성에 대한 설명은 [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setListRows(int value)](#setListRows-int-) | 이 속성에 대한 설명은 [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)을(를) 참조하십시오. |
+| [setListStyle(int value)](#setListStyle-int-) | 이 속성에 대한 설명은 [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)을(를) 참조하십시오. |
+| [setListWidth(double value)](#setListWidth-double-) | 이 속성에 대한 설명은 [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | 이 속성에 대한 설명은 [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)을(를) 참조하십시오. |
+| [setMaxLength(int value)](#setMaxLength-int-) | 이 속성에 대한 설명은 [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | 이 속성에 대한 설명은 [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)을(를) 참조하십시오. |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | 이 속성에 대한 설명은 [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)을(를) 참조하십시오. |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | 이 속성에 대한 설명은 [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)을(를) 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오. |
+| [setTextColumn(int value)](#setTextColumn-int-) | 이 속성에 대한 설명은 [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+the type of border used by the control.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Represents how the Value property is determined for a ComboBox or ListBox when the MultiSelect propertys value (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Represents the number of columns to display in a ComboBox or ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+the width of the column.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Specifies the symbol displayed on the drop button
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+컨트롤에 진입할 때 선택 동작을 지정합니다. True는 선택이 마지막으로 컨트롤이 활성화되었을 때와 동일하게 유지됨을 지정하고, False는 컨트롤에 진입할 때 컨트롤 내 모든 텍스트가 선택됨을 지정합니다.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indicates whether selected text in the control appears highlighted when the control does not have focus.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+목록에 표시할 최대 행 수를 나타냅니다.
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+시각적 모양.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+포인트 단위의 너비.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다.
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+최대 문자 수
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+사용자가 텍스트 왼쪽 영역을 클릭하여 텍스트 라인을 선택할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+열 머리글이 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Specifies the symbol displayed on the drop button
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+사용자에게 표시할 ComboBox 또는 ListBox의 열을 나타냅니다.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+컨트롤의 값.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+선택을 확장하는 데 사용되는 기본 단위를 지정합니다. True는 기본 단위가 단일 문자임을 지정하고, false는 기본 단위가 전체 단어임을 지정합니다.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+컨트롤에 대해 끌어다 놓기가 활성화되어 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+사용자가 컨트롤에 입력할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+이 속성에 대한 설명은 [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+이 속성에 대한 설명은 [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+이 속성에 대한 설명은 [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+이 속성에 대한 설명은 [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+이 속성에 대한 설명은 [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+이 속성에 대한 설명은 [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: 명령 버튼을 나타냅니다.
+type: docs
+weight: 56
+url: /ko/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+명령 버튼을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | 컨트롤의 단축키입니다. |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getCaption()](#getCaption--) | 컨트롤에 표시되는 설명 텍스트입니다. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPicturePosition()](#getPicturePosition--) | 컨트롤 캡션에 상대적인 그림의 위치. |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | 클릭 시 컨트롤이 포커스를 가져가는지 여부를 나타냅니다. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isWordWrapped()](#isWordWrapped--) | 컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | 이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)을 참조하십시오. |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setCaption(String value)](#setCaption-java.lang.String-) | 이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)을 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)을 참조하십시오. |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | 이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)을 참조하십시오. |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | 이 속성에 대한 설명은 [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)을 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | 이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+컨트롤의 단축키입니다.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+컨트롤에 표시되는 설명 텍스트입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+컨트롤 캡션에 상대적인 그림의 위치.
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+클릭 시 컨트롤이 포커스를 가져가는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/compositingquality/_index.md
+++ b/korean/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Aspose.Diagram for Java API 참조
+description: 합성 중에 사용할 품질 수준을 지정합니다.
+type: docs
+weight: 57
+url: /ko/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+합성 중에 사용할 품질 수준을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | 선형 값을 가정합니다. |
+| [DEFAULT](#DEFAULT) | 기본 품질. |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | 감마 보정이 사용됩니다. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 고품질, 저속 합성. |
+| [HIGH_SPEED](#HIGH-SPEED) | 고속, 저품질. |
+| [INVALID](#INVALID) | 잘못된 품질. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+선형 값을 가정합니다.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+기본 품질.
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+감마 보정이 사용됩니다.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+고품질, 저속 합성.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+고속, 저품질.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+잘못된 품질.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/compoundtype/_index.md
+++ b/korean/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Aspose.Diagram for Java API 참조
+description: 선의 화살촉 크기를 지정합니다.
+type: docs
+weight: 58
+url: /ko/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+선의 화살촉 크기를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 선의 화살촉 크기를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) 를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+선의 화살촉 크기를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 선 그리기 스타일을 나타냅니다.
+type: docs
+weight: 59
+url: /ko/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+선 그리기 스타일을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [SINGLE](#SINGLE) | 단일 선(너비 lineWidth) |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | 세 개의 선, 얇게, 두껍게, 얇게 |
+| [THICK_THIN](#THICK-THIN) | 이중 선, 하나는 두껍고 하나는 얇게 |
+| [THIN_THICK](#THIN-THICK) | 이중 선, 하나는 얇고 하나는 두껍게 |
+| [THIN_THIN](#THIN-THIN) | 동일한 너비의 이중 선 |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+단일 선(너비 lineWidth)
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+세 개의 선, 얇게, 두껍게, 얇게
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+이중 선, 하나는 두껍고 하나는 얇게
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+이중 선, 하나는 얇고 하나는 두껍게
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+동일한 너비의 이중 선
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/compressiontype/_index.md
+++ b/korean/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Aspose.Diagram for Java API 참조
+description: 이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다.
+type: docs
+weight: 60
+url: /ko/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. 값은 파일에 적용된 압축 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [GIF](#GIF) | GIF 압축. |
+| [JPEG](#JPEG) | JPEG 압축. |
+| [NO](#NO) | 압축 없음(기본값). |
+| [PNG](#PNG) | PNG 압축. |
+| [TIFF](#TIFF) | TIFF 압축. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+GIF 압축.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+JPEG 압축.
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+압축 없음(기본값).
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+PNG 압축.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF 압축.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/confixedcode/_index.md
+++ b/korean/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터가 재경로 지정되는 시점을 결정합니다.
+type: docs
+weight: 61
+url: /ko/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+커넥터가 재경로 지정되는 시점을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 커넥터가 재경로 지정되는 시점을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+커넥터가 재경로 지정되는 시점을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터가 재경로 지정되는 시점을 결정합니다.
+type: docs
+weight: 62
+url: /ko/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+커넥터가 재경로 지정되는 시점을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | 절대 재경로 지정 안 함. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | 자유롭게 재경로 지정. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | 필요에 따라 재경로 지정. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | 교차 시 재경로 지정. |
+| [RESERVED_1](#RESERVED-1) | 내부 사용 전용으로 예약됨. |
+| [RESERVED_2](#RESERVED-2) | 내부 사용 전용으로 예약됨. |
+| [RESERVED_3](#RESERVED-3) | 내부 사용 전용으로 예약됨. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+절대 재경로 지정 안 함.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+자유롭게 재경로 지정.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+필요에 따라 재경로 지정.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+교차 시 재경로 지정.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+내부 사용 전용으로 예약됨.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+내부 사용 전용으로 예약됨.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+내부 사용 전용으로 예약됨.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Aspose.Diagram for Java API 참조
+description: 두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다.
+type: docs
+weight: 63
+url: /ko/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다.
+type: docs
+weight: 64
+url: /ko/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+두 커넥터가 교차할 때 커넥터가 점프하는지 여부를 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | 항상 |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | 연결자 점프가 없습니다. |
+| [NEVER](#NEVER) | 절대. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | 다른 연결자 점프. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+항상
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+연결자 점프가 없습니다.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+절대.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+다른 연결자 점프.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+type: docs
+weight: 65
+url: /ko/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+type: docs
+weight: 66
+url: /ko/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DOWN](#DOWN) | 아래. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [UP](#UP) | 위. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+아래.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+위.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+type: docs
+weight: 67
+url: /ko/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+type: docs
+weight: 68
+url: /ko/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LEFT](#LEFT) | Left. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [RIGHT](#RIGHT) | Right. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 라인 점프 스타일을 결정합니다.
+type: docs
+weight: 69
+url: /ko/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+동적 커넥터의 라인 점프 스타일을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 커넥터의 라인 점프 스타일을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 커넥터의 라인 점프 스타일을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터의 라인 점프 스타일을 결정합니다.
+type: docs
+weight: 70
+url: /ko/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+동적 커넥터의 라인 점프 스타일을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ARC](#ARC) | 호. |
+| [GAP](#GAP) | 간격. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | 정사각형. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+호.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+간격.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+정사각형.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/korean/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터의 외관을 결정합니다.
+type: docs
+weight: 71
+url: /ko/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+커넥터의 외관을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 커넥터의 외관을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은, 다음을 참조하십시오 [getValue()](../../com.aspose.diagram/conlinerouteext\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+커넥터의 외관을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은, 다음을 참조하십시오 [getValue()](../../com.aspose.diagram/conlinerouteext\\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/korean/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터의 외관을 결정합니다.
+type: docs
+weight: 72
+url: /ko/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+커넥터의 외관을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CURVED](#CURVED) | 곡선. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [STRAIGHT](#STRAIGHT) | 직선. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+곡선.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+직선.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connect/_index.md
+++ b/korean/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Aspose.Diagram for Java API 참조
+description: 조직도와 같은 도면에서 선과 상자와 같은 두 도형 사이의 연결을 나타냅니다.
+type: docs
+weight: 75
+url: /ko/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+그림에서 두 도형 사이의 연결을 나타내며, 예를 들어 조직도에서 선과 상자를 연결합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Connect()](#Connect--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | 연결이 이루어지는 셀입니다. |
+| [getFromPart()](#getFromPart--) | 연결이 시작되는 셀입니다. |
+| [getFromSheet()](#getFromSheet--) | 연결이 시작되는 도형의 ID입니다. |
+| [getToCell()](#getToCell--) | 연결이 이루어지는 대상 셀입니다. |
+| [getToPart()](#getToPart--) | 연결이 이루어지는 도형의 부분. |
+| [getToSheet()](#getToSheet--) | 하나 이상의 연결이 이루어지는 도형의 ID입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | 이 속성에 대한 설명은 [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)을(를) 참조하십시오. |
+| [setFromPart(int value)](#setFromPart-int-) | 이 속성에 대한 설명은 [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)을(를) 참조하십시오. |
+| [setFromSheet(long value)](#setFromSheet-long-) | 이 속성에 대한 설명은 [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)을(를) 참조하십시오. |
+| [setToCell(String value)](#setToCell-java.lang.String-) | 이 속성에 대한 설명은 [getToCell()](../../com.aspose.diagram/connect\#getToCell--)을(를) 참조하십시오. |
+| [setToPart(int value)](#setToPart-int-) | 이 속성에 대한 설명은 [getToPart()](../../com.aspose.diagram/connect\#getToPart--)을(를) 참조하십시오. |
+| [setToSheet(long value)](#setToSheet-long-) | 이 속성에 대한 설명은 [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+연결이 이루어지는 셀입니다.
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+연결이 시작되는 셀입니다.
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+연결이 시작되는 도형의 ID입니다.
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+연결이 이루어지는 대상 셀입니다.
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+연결이 이루어지는 도형의 부분.
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+하나 이상의 연결이 이루어지는 도형의 ID입니다.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+이 속성에 대한 설명은 [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+이 속성에 대한 설명은 [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+이 속성에 대한 설명은 [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+이 속성에 대한 설명은 [getToCell()](../../com.aspose.diagram/connect\#getToCell--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+이 속성에 대한 설명은 [getToPart()](../../com.aspose.diagram/connect\#getToPart--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+이 속성에 대한 설명은 [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectcollection/_index.md
+++ b/korean/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Connect 컬렉션.
+type: docs
+weight: 76
+url: /ko/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Connect 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | 컬렉션에 연결을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | 컬렉션에서 연결을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+컬렉션에 연결을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+컬렉션에서 연결을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/korean/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터의 방향성을 기준으로 반환된 도형 ID 배열을 필터링합니다.
+type: docs
+weight: 77
+url: /ko/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+커넥터의 방향성을 기준으로 반환된 도형 ID 배열을 필터링합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | 수신 및 발신 연결 모두와 연결된 도형의 ID를 반환합니다. |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | 수신 연결과 연결된 도형의 ID를 반환합니다. |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | 발신 연결과 연결된 도형의 ID를 반환합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+수신 및 발신 연결 모두와 연결된 도형의 ID를 반환합니다.
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+수신 연결과 연결된 도형의 ID를 반환합니다.
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+발신 연결과 연결된 도형의 ID를 반환합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connection/_index.md
+++ b/korean/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: 연결
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 정의된 하나의 연결 지점에 대한 요소를 포함합니다.
+type: docs
+weight: 78
+url: /ko/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+도형에 정의된 하나의 연결 지점에 대한 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Connection()](#Connection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | 연결 지점이 자동으로 생성되는지 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDirX()](#getDirX--) | 일치하는 연결 지점의 필요한 정렬 벡터에 대한 x-성분을 지정합니다. |
+| [getDirY()](#getDirY--) | 일치하는 연결 지점의 필요한 정렬 벡터에 대한 y-성분을 지정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPrompt()](#getPrompt--) | 포함된 요소에 따라 다양한 프롬프트 정보를 포함합니다. |
+| [getType()](#getType--) | 포함된 요소에 따라 다양한 유형을 지정합니다. |
+| [getX()](#getX--) | 로컬 좌표계에서 모양의 x좌표를 지정합니다. |
+| [getY()](#getY--) | 로컬 좌표계에서 모양의 y좌표를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/connection\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/connection\#getID--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/connection\#getIX--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/connection\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/connection\#getNameU--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+연결 지점이 자동으로 생성되는지 지정합니다. 값 1은 연결 지점이 자동으로 생성됨을 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+일치하는 연결 지점의 필요한 정렬 벡터에 대한 x-성분을 지정합니다. DirX 요소는 동적 커넥터의 연결된 다리를 방향 지정하는 데에도 사용됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+일치하는 연결 지점의 필요한 정렬 벡터에 대한 y-성분을 지정합니다. DirY 요소는 동적 커넥터의 연결된 다리를 방향 지정하는 데에도 사용됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+포함된 요소에 따라 다양한 프롬프트 정보를 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+포함된 요소에 따라 다양한 유형을 지정합니다.
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+로컬 좌표계에서 모양의 x좌표를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+로컬 좌표계에서 도형의 y 좌표를 지정합니다. 로컬 좌표계는 페이지가 아니라 도형을 기준으로 하는 좌표계입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/connection\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/connection\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/connection\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/connection\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/connection\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/korean/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Aspose.Diagram for Java API 참조
+description: ConnectionABCD 요소는 Connection 요소의 구식 버전이며 이전 호환성을 위해서만 존재합니다.
+type: docs
+weight: 79
+url: /ko/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+ConnectionABCD 요소는 Connection 요소의 구식 버전이며 이전 호환성을 위해서만 존재합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Represents different information depending on its parent element. |
+| [getB()](#getB--) | Represents different information depending on its parent element. |
+| [getC()](#getC--) | Represents different information based on its parent element. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Represents different information based on its parent element. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getX()](#getX--) | 로컬 좌표계에서 모양의 x좌표를 지정합니다. |
+| [getY()](#getY--) | 로컬 좌표계에서 모양의 y좌표를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) |
+| [setID(int value)](#setID-int-) | For the description of this property, please see [getID()](../../com.aspose.diagram/connectionabcd\#getID--) |
+| [setIX(int value)](#setIX-int-) | For the description of this property, please see [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | For the description of this property, please see [getName()](../../com.aspose.diagram/connectionabcd\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | For the description of this property, please see [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Represents different information depending on its parent element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Represents different information depending on its parent element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Represents different information based on its parent element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Represents different information based on its parent element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+로컬 좌표계에서 도형의 x 좌표를 지정합니다. 다음 표는 이를 포함하는 요소를 기준으로 X 요소를 설명합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+로컬 좌표계에서 도형의 y 좌표를 지정합니다. 로컬 좌표계는 페이지가 아니라 도형을 기준으로 하는 좌표계입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+For the description of this property, please see [getID()](../../com.aspose.diagram/connectionabcd\#getID--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+For the description of this property, please see [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+For the description of this property, please see [getName()](../../com.aspose.diagram/connectionabcd\#getName--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+For the description of this property, please see [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/korean/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Aspose.Diagram for Java API 참조
+description: ConnectionABCD 컬렉션.
+type: docs
+weight: 80
+url: /ko/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+ConnectionABCD 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | 컬렉션에 ConnectionABCD 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | 컬렉션에서 ConnectionABCD 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+컬렉션에 ConnectionABCD 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+컬렉션에서 ConnectionABCD 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/korean/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Connection 컬렉션.
+type: docs
+weight: 81
+url: /ko/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Connection 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | 컬렉션에 Connection 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | 컬렉션에서 Connection 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+컬렉션에 Connection 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+컬렉션에서 Connection 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/korean/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Aspose.Diagram for Java API 참조
+description: 커넥터가 연결될 도형상의 위치를 지정합니다.
+type: docs
+weight: 82
+url: /ko/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+커넥터가 연결될 도형상의 위치를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Bottom of the shape. |
+| [CENTER](#CENTER) | Center of the shape. |
+| [LEFT](#LEFT) | Left of the shape. |
+| [RIGHT](#RIGHT) | Right of the shape. |
+| [TOP](#TOP) | Top of the shape. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Bottom of the shape.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center of the shape.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left of the shape.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right of the shape.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Top of the shape.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectorrule/_index.md
+++ b/korean/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Aspose.Diagram for Java API 참조
+description: 두 도형 사이의 커넥터 규칙을 나타내며, connectorIncluding이 시작되는 도형의 연결점과 끝 도형 및 그 연결점을 포함합니다.
+type: docs
+weight: 83
+url: /ko/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+커넥터를 사용하여 두 도형 사이의 연결 규칙을 나타내며, 시작 도형의 어느 연결 지점에서 시작하는지와 종료 도형 및 그 연결 지점을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | 연결이 이루어지는 도형의 연결점. |
+| [getEndShapeId()](#getEndShapeId--) | 연결이 이루어지는 도형. |
+| [getStartShapeConnection()](#getStartShapeConnection--) | 연결이 시작되는 도형의 연결점. |
+| [getStartShapeId()](#getStartShapeId--) | 연결이 시작되는 도형. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+연결이 이루어지는 도형의 연결점.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+연결이 이루어지는 도형.
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+연결이 시작되는 도형의 연결점.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+연결이 시작되는 도형.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 다음 값 중 하나일 수 있습니다 RightAngle StraightLines 또는 CurvedLines.
+type: docs
+weight: 84
+url: /ko/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+다음 값 중 하나일 수 있습니다: RightAngle, StraightLines, 또는 CurvedLines. WindowType이 Drawing 또는 Sheet로 지정된 경우에만 해당됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 다음 값 중 하나일 수 있습니다: Document, Page 또는 Master.
+type: docs
+weight: 85
+url: /ko/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+다음 값 중 하나일 수 있습니다: Document, Page, 또는 Master. WindowType이 Drawing 또는 Sheet로 지정된 경우에만 해당됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Document. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Page. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Document.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Page.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 비교에 사용할 그룹 또는 도형의 속성을 지정합니다.
+type: docs
+weight: 86
+url: /ko/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+비교에 사용할 그룹 또는 도형의 속성을 지정합니다. 가능한 값은 다음 표에 표시됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DATA_1](#DATA-1) | Data1. |
+| [DATA_2](#DATA-2) | Data2. |
+| [DATA_3](#DATA-3) | Data3. |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | 기하학적 각도. |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | 기하학적 높이. |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | 기하학 너비. |
+| [MASTER_NAME](#MASTER-NAME) | 마스터 이름. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | 도형 데이터 항목(사용자 정의 속성) 레이블. |
+| [SHAPE_ID](#SHAPE-ID) | 도형 ID. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | 도형 로컬 이름. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | 도형 텍스트. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | 도형 유형. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | 사용자 셀 로컬 행 이름. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+Data1.
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+Data2.
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+Data3.
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+기하학적 각도.
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+기하학적 높이.
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+기하학 너비.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+마스터 이름.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+도형 데이터 항목(사용자 정의 속성) 레이블.
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+도형 ID.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+도형 로컬 이름.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+도형 텍스트.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+도형 유형.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+사용자 셀 로컬 행 이름.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/control/_index.md
+++ b/korean/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: 제어
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 정의된 각 제어 핸들의 x 및 y 좌표 요소와 제어 핸들의 동작 방식을 지정하는 요소를 포함합니다.
+type: docs
+weight: 87
+url: /ko/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+도형에 정의된 각 컨트롤 핸들의 x 및 y 좌표에 대한 요소와 컨트롤 핸들의 동작 방식을 지정하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Control()](#Control--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [canGlue()](#canGlue--) | 제어 핸들을 다른 도형에 붙일 수 있는지 여부를 결정합니다. |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPrompt()](#getPrompt--) | 프롬프트 요소는 마우스 포인터가 도형의 제어 핸들 위에 멈출 때 툴팁으로 표시되는 설명 텍스트를 지정합니다. |
+| [getX()](#getX--) | 도형의 제어 핸들 위치를 나타내는 x 좌표입니다. |
+| [getXCon()](#getXCon--) | 핸들을 이동한 후 제어 핸들의 x 좌표가 나타내는 동작 유형을 지정합니다. |
+| [getXDyn()](#getXDyn--) | 제어 핸들의 기준점에 대한 x 좌표를 로컬 좌표계로 지정합니다. |
+| [getY()](#getY--) | 도형의 제어 핸들 위치를 나타내는 y 좌표입니다. |
+| [getYCon()](#getYCon--) | 핸들을 이동한 후 제어 핸들의 x 좌표가 나타내는 동작 유형을 지정합니다. |
+| [getYDyn()](#getYDyn--) | 제어 핸들의 기준점에 대한 y 좌표를 로컬 좌표계로 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [canGlue()](../../com.aspose.diagram/control\#canGlue--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/control\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/control\#getID--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/control\#getIX--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/control\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/control\#getNameU--)을(를) 참조하십시오. |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | 이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/control\#getX--)을(를) 참조하십시오. |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | 이 속성에 대한 설명은 [getXCon()](../../com.aspose.diagram/control\#getXCon--)을(를) 참조하십시오. |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/control\#getY--)을(를) 참조하십시오. |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | 이 속성에 대한 설명은 [getYCon()](../../com.aspose.diagram/control\#getYCon--)을(를) 참조하십시오. |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+생성자.
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+제어 핸들을 다른 도형에 붙일 수 있는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+프롬프트 요소는 마우스 포인터가 도형의 제어 핸들 위에 멈출 때 툴팁으로 표시되는 설명 텍스트를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+도형의 제어 핸들 위치를 나타내는 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+핸들을 이동한 후 제어 핸들의 x 좌표가 나타내는 동작 유형을 지정합니다.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+제어 핸들의 앵커 포인트에 대한 x 좌표를 로컬 좌표계에서 지정합니다. 앵커 포인트는 동적 처리 중 고무 밴딩에 사용됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+도형의 제어 핸들 위치를 나타내는 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+핸들을 이동한 후 제어 핸들의 x 좌표가 나타내는 동작 유형을 지정합니다.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+제어 핸들의 앵커 포인트에 대한 y 좌표를 로컬 좌표계에서 지정합니다. 앵커 포인트는 동적 처리 중 고무 밴딩에 사용됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [canGlue()](../../com.aspose.diagram/control\#canGlue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/control\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/control\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/control\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/control\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/control\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/control\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+이 속성에 대한 설명은 [getXCon()](../../com.aspose.diagram/control\#getXCon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/control\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+이 속성에 대한 설명은 [getYCon()](../../com.aspose.diagram/control\#getYCon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/korean/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Aspose.Diagram for Java API 참조
+description: ActiveX 컨트롤의 테두리 유형을 나타냅니다.
+type: docs
+weight: 88
+url: /ko/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+ActiveX 컨트롤의 테두리 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [NONE](#NONE) | 테두리 없음. |
+| [SINGLE](#SINGLE) | 단일 선. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+테두리 없음.
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+단일 선.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/korean/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Aspose.Diagram for Java API 참조
+description: Caption이 컨트롤에 대해 상대적으로 위치하는 방식을 나타냅니다.
+type: docs
+weight: 89
+url: /ko/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+Caption이 컨트롤에 대해 상대적으로 위치하는 방식을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LEFT](#LEFT) | 컨트롤의 왼쪽. |
+| [RIGHT](#RIGHT) | 컨트롤의 오른쪽. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+컨트롤의 왼쪽.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+컨트롤의 오른쪽.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlcollection/_index.md
+++ b/korean/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Control 컬렉션.
+type: docs
+weight: 90
+url: /ko/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Control 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | 컬렉션에 Control 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | 지정된 인덱스 IX에 있는 요소를 가져옵니다. |
+| [getControlFromId(int ID)](#getControlFromId-int-) | Gets the element at the specified ID. |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | Gets the element at the specified name. |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | 컬렉션에서 Control 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+컬렉션에 Control 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+지정된 인덱스 IX에 있는 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+Gets the element at the specified name.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+컬렉션에서 Control 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/korean/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Aspose.Diagram for Java API 참조
+description: ListBox 또는 ComboBox에 있는 목록의 시각적 외관을 나타냅니다.
+type: docs
+weight: 91
+url: /ko/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+ListBox 또는 ComboBox에 있는 목록의 시각적 외관을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [OPTION](#OPTION) | 각 항목 옆에 옵션 버튼 또는 체크박스가 표시되어 해당 항목의 선택 상태를 나타내는 목록을 표시합니다. |
+| [PLAIN](#PLAIN) | 항목이 선택될 때 배경이 강조 표시되는 목록을 표시합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+각 항목 옆에 옵션 버튼 또는 체크박스가 표시되어 해당 항목의 선택 상태를 나타내는 목록을 표시합니다.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+항목이 선택될 때 배경이 강조 표시되는 목록을 표시합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/korean/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다.
+type: docs
+weight: 92
+url: /ko/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | 각 문자를 입력할 때마다, 컨트롤은 입력된 모든 문자와 일치하는 항목을 검색합니다. |
+| [FIRST_LETTER](#FIRST-LETTER) | 컨트롤은 입력된 문자로 시작하는 다음 항목을 검색합니다. |
+| [NONE](#NONE) | 문자를 입력할 때 목록이 검색되지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+각 문자를 입력할 때마다, 컨트롤은 입력된 모든 문자와 일치하는 항목을 검색합니다.
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+컨트롤은 입력된 문자로 시작하는 다음 항목을 검색합니다. 같은 문자를 반복해서 입력하면 해당 문자로 시작하는 모든 항목을 순환합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+문자를 입력할 때 목록이 검색되지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/korean/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Aspose.Diagram for Java API 참조
+description: 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형을 나타냅니다.
+type: docs
+weight: 93
+url: /ko/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | 시계 모래가 있는 화살표. |
+| [ARROW](#ARROW) | 화살표. |
+| [CROSS](#CROSS) | 십자선 포인터. |
+| [CUSTOM](#CUSTOM) | MouseIcon 속성으로 지정된 아이콘을 사용합니다. |
+| [DEFAULT](#DEFAULT) | 표준 포인터. |
+| [HELP](#HELP) | 물음표가 있는 화살표. |
+| [HOUR_GLASS](#HOUR-GLASS) | Hourglass. |
+| [I_BEAM](#I-BEAM) | I-beam. |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | Double arrow pointing northeast and southwest. |
+| [SIZE_NS](#SIZE-NS) | Double arrow pointing north and south. |
+| [SIZE_NWSE](#SIZE-NWSE) | Double arrow pointing northwest and southeast. |
+| [SIZE_WE](#SIZE-WE) | Double arrow pointing west and east. |
+| [UP_ARROW](#UP-ARROW) | Up arrow. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+시계 모래가 있는 화살표.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+화살표.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+십자선 포인터.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+MouseIcon 속성으로 지정된 아이콘을 사용합니다.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+표준 포인터.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+물음표가 있는 화살표.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+Hourglass.
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+I-beam.
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?symbol (circle with a diagonal line) on top of the object being dragged.
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?cursor (arrows pointing north, south, east, and west).
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+Double arrow pointing northeast and southwest.
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+Double arrow pointing north and south.
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+Double arrow pointing northwest and southeast.
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+Double arrow pointing west and east.
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+Up arrow.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/korean/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Aspose.Diagram for Java API 참조
+description: Form 또는 Image 내부의 그림 정렬을 나타냅니다.
+type: docs
+weight: 94
+url: /ko/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Form 또는 Image 내부의 그림 정렬을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | 왼쪽 아래 모서리. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | 오른쪽 아래 모서리. |
+| [CENTER](#CENTER) | 중심. |
+| [TOP_LEFT](#TOP-LEFT) | 왼쪽 위 모서리. |
+| [TOP_RIGHT](#TOP-RIGHT) | 오른쪽 위 모서리. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+왼쪽 아래 모서리.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+오른쪽 아래 모서리.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+중심.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+왼쪽 위 모서리.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+오른쪽 위 모서리.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/korean/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Aspose.Diagram for Java API 참조
+description: 컨트롤 그림이 캡션에 대해 위치하는 방식을 나타냅니다.
+type: docs
+weight: 95
+url: /ko/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+컨트롤 캡션에 대한 그림 위치를 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | 그림이 캡션 위에 표시됩니다. |
+| [ABOVE_LEFT](#ABOVE-LEFT) | 그림이 캡션 위에 표시됩니다. |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | 그림이 캡션 위에 표시됩니다. |
+| [BELOW_CENTER](#BELOW-CENTER) | 그림이 캡션 아래에 표시됩니다. |
+| [BELOW_LEFT](#BELOW-LEFT) | 그림이 캡션 아래에 표시됩니다. |
+| [BELOW_RIGHT](#BELOW-RIGHT) | 그림이 캡션 아래에 표시됩니다. |
+| [CENTER](#CENTER) | 그림이 컨트롤 중앙에 표시됩니다. |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | 그림이 캡션 왼쪽에 표시됩니다. |
+| [LEFT_CENTER](#LEFT-CENTER) | 그림이 캡션 왼쪽에 표시됩니다. |
+| [LEFT_TOP](#LEFT-TOP) | 그림이 캡션 왼쪽에 표시됩니다. |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | 그림이 캡션 오른쪽에 표시됩니다. |
+| [RIGHT_CENTER](#RIGHT-CENTER) | 그림이 캡션 오른쪽에 표시됩니다. |
+| [RIGHT_TOP](#RIGHT-TOP) | 그림이 캡션 오른쪽에 표시됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+그림이 캡션 위에 표시됩니다. 캡션은 그림 아래에 중앙 정렬됩니다.
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+그림이 캡션 위에 표시됩니다. 캡션은 그림의 왼쪽 가장자리에 맞춰 정렬됩니다.
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+그림이 캡션 위에 표시됩니다. 캡션은 그림의 오른쪽 가장자리에 맞춰 정렬됩니다.
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+그림이 캡션 아래에 표시됩니다. 캡션은 그림 위에 중앙 정렬됩니다.
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+그림은 캡션 아래에 표시됩니다. 캡션은 그림의 왼쪽 가장자리에 맞춰져 있습니다.
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+그림은 캡션 아래에 표시됩니다. 캡션은 그림의 오른쪽 가장자리에 맞춰져 있습니다.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+그림은 컨트롤 중앙에 표시됩니다. 캡션은 그림 위에 수평 및 수직으로 중앙에 배치됩니다.
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+그림은 캡션의 왼쪽에 표시됩니다. 캡션은 그림의 아래쪽에 맞춰져 있습니다.
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+그림은 캡션의 왼쪽에 표시됩니다. 캡션은 그림을 기준으로 중앙에 배치됩니다.
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+그림은 캡션의 왼쪽에 표시됩니다. 캡션은 그림의 위쪽에 맞춰져 있습니다.
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+그림은 캡션의 오른쪽에 표시됩니다. 캡션은 그림의 아래쪽에 맞춰져 있습니다.
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+그림은 캡션의 오른쪽에 표시됩니다. 캡션은 그림을 기준으로 중앙에 배치됩니다.
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+그림은 캡션의 오른쪽에 표시됩니다. 캡션은 그림의 위쪽에 맞춰져 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/korean/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Aspose.Diagram for Java API 참조
+description: 그림을 표시하는 방법을 나타냅니다.
+type: docs
+weight: 96
+url: /ko/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+그림을 표시하는 방법을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CLIP](#CLIP) | 컨트롤 경계보다 큰 그림의 모든 부분을 잘라냅니다. |
+| [STRETCH](#STRETCH) | 그림을 늘려서 컨트롤 영역을 채웁니다. |
+| [ZOOM](#ZOOM) | 그림을 확대하지만 가로나 세로 방향으로 왜곡되지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+컨트롤 경계보다 큰 그림의 모든 부분을 잘라냅니다.
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+그림을 늘려서 컨트롤 영역을 채웁니다. 이 설정은 가로나 세로 방향으로 그림을 왜곡합니다.
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+그림을 확대하지만 가로나 세로 방향으로 왜곡되지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/korean/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Aspose.Diagram for Java API 참조
+description: 스크롤 바 유형을 나타냅니다.
+type: docs
+weight: 97
+url: /ko/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+스크롤 바 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | 가로 및 세로 스크롤 막대를 모두 표시합니다. |
+| [BARS_VERTICAL](#BARS-VERTICAL) | 세로 스크롤 막대를 표시합니다. |
+| [HORIZONTAL](#HORIZONTAL) | 가로 스크롤 막대를 표시합니다. |
+| [NONE](#NONE) | 스크롤 막대를 표시하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+가로 및 세로 스크롤 막대를 모두 표시합니다.
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+세로 스크롤 막대를 표시합니다.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+가로 스크롤 막대를 표시합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+스크롤 막대를 표시하지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/korean/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Aspose.Diagram for Java API 참조
+description: 스크롤 방향 유형을 나타냅니다.
+type: docs
+weight: 98
+url: /ko/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+스크롤 방향 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AUTO](#AUTO) | 컨트롤의 너비가 높이보다 클 때 컨트롤이 가로로 렌더링됩니다. |
+| [HORIZONTAL](#HORIZONTAL) | 컨트롤이 가로로 렌더링됩니다. |
+| [VERTICAL](#VERTICAL) | 컨트롤이 세로로 렌더링됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+컨트롤의 너비가 높이보다 클 때 컨트롤은 가로로 렌더링됩니다. 그렇지 않으면 컨트롤은 세로로 렌더링됩니다.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+컨트롤이 가로로 렌더링됩니다.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+컨트롤이 세로로 렌더링됩니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/korean/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Aspose.Diagram for Java API 참조
+description: 특수 효과 유형을 나타냅니다.
+type: docs
+weight: 99
+url: /ko/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+특수 효과 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/controltype/_index.md
+++ b/korean/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Aspose.Diagram for Java API 참조
+description: 모든 유형의 ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 100
+url: /ko/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+모든 유형의 ActiveX 컨트롤을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | 이미지 |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | 알 수 없음 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+이미지
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+알 수 없음
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/contype/_index.md
+++ b/korean/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Aspose.Diagram for Java API 참조
+description: 핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다.
+type: docs
+weight: 73
+url: /ko/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/contype\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/contype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/contype\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/contype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/convalue/_index.md
+++ b/korean/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Aspose.Diagram for Java API 참조
+description: 핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다.
+type: docs
+weight: 74
+url: /ko/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+핸들을 이동한 후 컨트롤 핸들의 x 또는 y 좌표가 나타내는 동작 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | 중심으로부터의 오프셋. |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | 중심으로부터의 오프셋, 숨김. |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | 왼쪽 가장자리로부터의 오프셋. |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | 왼쪽 가장자리로부터의 오프셋, 숨김. |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | 오른쪽 가장자리로부터의 오프셋. |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | 오른쪽 가장자리에서 오프셋, 숨김. |
+| [PROPORTIONAL](#PROPORTIONAL) | 비례. |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | 비례, 숨김. 0과 동일하지만 제어 핸들이 보이지 않습니다. |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | 비례 잠김. |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | 비례 잠김, 숨김. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+중심에서 오프셋. 제어 핸들은 도형의 중심에서 일정 거리만큼 오프셋됩니다.
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+중심에서 오프셋, 숨김. 3과 동일하지만 제어 핸들이 보이지 않습니다.
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+왼쪽 가장자리에서 오프셋. 제어 핸들은 도형의 왼쪽 측면에서 일정 거리만큼 오프셋됩니다.
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+왼쪽 가장자리에서 오프셋, 숨김. 2와 동일하지만 제어 핸들이 보이지 않습니다.
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+오른쪽 가장자리에서 오프셋. 제어 핸들은 도형의 오른쪽 측면에서 일정 거리만큼 오프셋됩니다.
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+오른쪽 가장자리에서 오프셋, 숨김. 4와 동일하지만 제어 핸들이 보이지 않습니다.
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+비례. 제어 핸들을 이동할 수 있으며, 도형이 늘어날 때 도형과 비례하여 움직입니다.
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+비례, 숨김. 0과 동일하지만 제어 핸들이 보이지 않습니다.
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+비례 잠김. 제어 핸들은 도형과 비례하여 움직이지만, 제어 핸들 자체는 이동할 수 없습니다.
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+비례 잠김, 숨김. 1과 동일하지만 제어 핸들이 보이지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/coordinate/_index.md
+++ b/korean/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: 좌표
+second_title: Aspose.Diagram for Java API 참조
+description: x 및 y 좌표에 대한 추상 클래스입니다.
+type: docs
+weight: 101
+url: /ko/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+x 및 y 좌표에 대한 추상 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 @PREF1\_을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 @PREF0\_을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 @PREF1\_을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 @PREF0\_을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/korean/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 좌표 컬렉션입니다.
+type: docs
+weight: 102
+url: /ko/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+좌표 컬렉션입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | 컬렉션에 ArcTo 객체를 추가합니다. |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | 컬렉션에 Coordinate 객체를 추가합니다. |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | 컬렉션에 Ellipse 객체를 추가합니다. |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | 컬렉션에 EllipticalArcTo 객체를 추가합니다. |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | 컬렉션에 InfiniteLine 객체를 추가합니다. |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | 컬렉션에 LineTo 객체를 추가합니다. |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | 컬렉션에 MoveTo 객체를 추가합니다. |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | 컬렉션에 NURBSTo 객체를 추가합니다. |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | 컬렉션에 PolylineTo 객체를 추가합니다. |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | 컬렉션에 RelCubBezTo 객체를 추가합니다. |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | 컬렉션에 RelEllipticalArcTo 객체를 추가합니다. |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | 컬렉션에 RelLineTo 객체를 추가합니다. |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | 컬렉션에 RelMoveTo 객체를 추가합니다. |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | 컬렉션에 RelQuadBezTo 객체를 추가합니다. |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | 컬렉션에 SplineKnot 객체를 추가합니다. |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | 컬렉션에 SplineStart 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getArcToCol()](#getArcToCol--) | X, Y 및 A 요소에 각각 의해 표현되는 원호의 x 및 y 좌표와 활을 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getEllipseCol()](#getEllipseCol--) | 타원의 중심점 및 타원 위의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | 타원 호에 대한 정보를 지정하는 요소를 포함합니다. |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | 무한선상의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. |
+| [getLineToCol()](#getLineToCol--) | 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다. |
+| [getMoveToCol()](#getMoveToCol--) | 도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로 중단 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. |
+| [getNURBSToCol()](#getNURBSToCol--) | x 및 y 좌표, 두 번째에서 마지막 매듭의 위치, 마지막 가중치의 위치, 첫 번째 매듭의 위치, 첫 번째 가중치의 위치 및 비균일 유리 B-스플라인(NURBS)의 수식을 포함합니다. |
+| [getPolylineToCol()](#getPolylineToCol--) | 폴리라인의 마지막 점과 폴리라인 수식의 x 및 y 좌표를 포함합니다. |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | RelCubBezTo의 점에 대한 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | 타원 호에 대한 정보를 지정하는 요소를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [getRelLineToCol()](#getRelLineToCol--) | 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다. |
+| [getRelMoveToCol()](#getRelMoveToCol--) | 도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로에서 끊김 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | RelQuadBezTo의 점에 대한 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다. |
+| [getSplineKnotCol()](#getSplineKnotCol--) | 스플라인의 제어점 및 스플라인의 매듭에 대한 x 및 y 좌표를 포함하며, 각각 X, Y 및 A 요소로 표시됩니다. |
+| [getSplineStartCol()](#getSplineStartCol--) | 스플라인의 두 번째 제어점, 두 번째 매듭, 첫 번째 매듭, 마지막 매듭 및 스플라인 차수에 대한 x 및 y 좌표를 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | 컬렉션에서 ArcTo 객체를 제거합니다. |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | 컬렉션에서 Coordinate 객체를 제거합니다. |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | 컬렉션에서 Ellipse 객체를 제거합니다. |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | 컬렉션에서 EllipticalArcTo 객체를 제거합니다. |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | 컬렉션에서 InfiniteLine 객체를 제거합니다. |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | 컬렉션에서 LineTo 객체를 제거합니다. |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | 컬렉션에서 MoveTo 객체를 제거합니다. |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | 컬렉션에서 NURBSTo 객체를 제거합니다. |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | 컬렉션에서 PolylineTo 객체를 제거합니다. |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | 컬렉션에서 RelCubBezTo 객체를 제거합니다. |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | 컬렉션에서 RelEllipticalArcTo 객체를 제거합니다. |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | 컬렉션에서 RelLineTo 객체를 제거합니다. |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | 컬렉션에서 RelMoveTo 객체를 제거합니다. |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | 컬렉션에서 RelQuadBezTo 객체를 제거합니다. |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | 컬렉션에서 SplineKnot 객체를 제거합니다. |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | 컬렉션에서 SplineStart 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+컬렉션에 ArcTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+컬렉션에 Coordinate 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+컬렉션에 Ellipse 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+컬렉션에 EllipticalArcTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+컬렉션에 InfiniteLine 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+컬렉션에 LineTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+컬렉션에 MoveTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+컬렉션에 NURBSTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+컬렉션에 PolylineTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+컬렉션에 RelCubBezTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+컬렉션에 RelEllipticalArcTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+컬렉션에 RelLineTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+컬렉션에 RelMoveTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+컬렉션에 RelQuadBezTo 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+컬렉션에 SplineKnot 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+컬렉션에 SplineStart 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+X, Y 및 A 요소에 각각 의해 표현되는 원호의 x 및 y 좌표와 활을 포함합니다.
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+타원의 중심점 및 타원 위의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+타원 호에 대한 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+무한선상의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. X와 Y 요소는 첫 번째 점의 x 및 y 좌표를 지정하고, A와 B 요소는 두 번째 점의 x 및 y 좌표를 지정합니다.
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+직선 세그먼트의 끝 정점에 대한 x 및 y 좌표를 포함합니다. 이러한 좌표는 각각 X 및 Y 요소에 포함됩니다.
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로 중단 후 첫 번째 정점의 x 및 y 좌표를 포함합니다.
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+x 및 y 좌표, 두 번째 마지막 매듭 위치, 마지막 가중치 위치, 첫 번째 매듭 위치, 첫 번째 가중치 위치 및 비균일 유리 B-스플라인(NURBS) 공식을 포함합니다. 이 정보는 각각 X, Y, A, B, C, D, E 요소에 지정됩니다.
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+폴리라인의 마지막 점의 x 및 y 좌표와 폴리라인 수식을 포함합니다. 좌표는 X 및 Y 요소에 지정되고, 수식은 A 요소에 지정됩니다.
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+RelCubBezTo의 점에 대한 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+타원 호에 대한 정보를 지정하는 요소를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+직선 세그먼트의 끝 정점에 대한 x 및 y 좌표를 포함합니다. 이러한 좌표는 각각 X 및 Y 요소에 포함됩니다. 좌표는 상대 좌표로 지정됩니다.
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로에서 끊김 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+RelQuadBezTo의 점에 대한 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+스플라인의 제어점 및 스플라인의 매듭에 대한 x 및 y 좌표를 포함하며, 각각 X, Y 및 A 요소로 표시됩니다.
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+스플라인의 두 번째 제어점, 두 번째 매듭, 첫 번째 매듭, 마지막 매듭 및 스플라인 차수에 대한 x 및 y 좌표를 포함합니다. 이 정보는 각각 X, Y, A, B, C, D 요소에 포함됩니다.
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+컬렉션에서 ArcTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+컬렉션에서 Coordinate 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+컬렉션에서 Ellipse 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+컬렉션에서 EllipticalArcTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+컬렉션에서 InfiniteLine 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+컬렉션에서 LineTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+컬렉션에서 MoveTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+컬렉션에서 NURBSTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+컬렉션에서 PolylineTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+컬렉션에서 RelCubBezTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+컬렉션에서 RelEllipticalArcTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+컬렉션에서 RelLineTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+컬렉션에서 RelMoveTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+컬렉션에서 RelQuadBezTo 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+컬렉션에서 SplineKnot 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+컬렉션에서 SplineStart 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/countrycode/_index.md
+++ b/korean/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: CountryCode
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 국가 식별자를 나타냅니다.
+type: docs
+weight: 103
+url: /ko/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+다이어그램 국가 식별자를 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | 알제리 |
+| [AUSTRALIA](#AUSTRALIA) | 오스트레일리아 |
+| [AUSTRIA](#AUSTRIA) | 오스트리아 |
+| [BELGIUM](#BELGIUM) | 벨기에 |
+| [BRAZIL](#BRAZIL) | 브라질 |
+| [CANADA](#CANADA) | 캐나다 |
+| [CHINA](#CHINA) | 중화인민공화국 |
+| [CZECH](#CZECH) | 체코 |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | 덴마크 |
+| [EGYPT](#EGYPT) | 이집트 |
+| [FINLAND](#FINLAND) | 핀란드 |
+| [FRANCE](#FRANCE) | 프랑스 |
+| [GERMANY](#GERMANY) | 독일 |
+| [GREECE](#GREECE) | 그리스 |
+| [HUNGARY](#HUNGARY) | 헝가리 |
+| [ICELAND](#ICELAND) | 아이슬란드 |
+| [INDIA](#INDIA) | 인도 |
+| [IRAN](#IRAN) | 이란 |
+| [IRAQ](#IRAQ) | 이라크 |
+| [ISRAEL](#ISRAEL) | 이스라엘 |
+| [ITALY](#ITALY) | 이탈리아 |
+| [JAPAN](#JAPAN) | 일본 |
+| [JORDAN](#JORDAN) | 요르단 |
+| [KUWAIT](#KUWAIT) | 쿠웨이트 |
+| [LATIN_AMERIC](#LATIN-AMERIC) | 라틴아메리카, 브라질 제외 |
+| [LEBANON](#LEBANON) | 레바논 |
+| [LIBYA](#LIBYA) | 리비아 |
+| [MEXICO](#MEXICO) | 멕시코 |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+알제리
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+오스트레일리아
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+오스트리아
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+벨기에
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+브라질
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+캐나다
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+중화인민공화국
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+체코
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+덴마크
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+이집트
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+핀란드
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+프랑스
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+독일
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+그리스
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+헝가리
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+아이슬란드
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+인도
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+이란
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+이라크
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+이스라엘
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+이탈리아
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+일본
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+요르단
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+쿠웨이트
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+라틴아메리카, 브라질 제외
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+레바논
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+리비아
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+멕시코
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/cp/_index.md
+++ b/korean/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Aspose.Diagram for Java API 참조
+description: 해당 Char 요소에 따라 서식이 지정된 문자 속성 실행의 시작을 표시합니다.
+type: docs
+weight: 104
+url: /ko/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+해당 Char 요소에 따라 서식이 지정된 문자 속성 실행의 시작을 표시합니다. 실행은 텍스트 끝까지 또는 다음까지 정의됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | 생성자 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+생성자
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int | 이 속성 실행이 나타내는 Char 요소 인덱스입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/customprop/_index.md
+++ b/korean/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Aspose.Diagram for Java API 참조
+description: CustomProp 구조체입니다.
+type: docs
+weight: 105
+url: /ko/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+CustomProp 구조체입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | 속성 값입니다. |
+| [getName()](#getName--) | 사용자 정의 속성의 이름입니다. |
+| [getPropType()](#getPropType--) | 사용자 정의 속성의 데이터 유형입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | 이 속성에 대한 설명은 [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/customprop\#getName--)을(를) 참조하십시오. |
+| [setPropType(int value)](#setPropType-int-) | 이 속성에 대한 설명은 [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+속성 값입니다.
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+사용자 정의 속성의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+사용자 정의 속성의 데이터 유형입니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+이 속성에 대한 설명은 [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/customprop\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+이 속성에 대한 설명은 [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/korean/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Aspose.Diagram for Java API 참조
+description: CustomProps 컬렉션입니다.
+type: docs
+weight: 106
+url: /ko/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+CustomProps 컬렉션입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | 컬렉션에 CustomProp 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | 컬렉션에서 CustomProp 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+생성자.
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+컬렉션에 CustomProp 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+컬렉션에서 CustomProp 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/customvalue/_index.md
+++ b/korean/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Aspose.Diagram for Java API 참조
+description: 속성 값입니다.
+type: docs
+weight: 107
+url: /ko/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+속성 값입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | 불리언 값. |
+| [getValueDate()](#getValueDate--) | 날짜 및 시간 값입니다. |
+| [getValueNumber()](#getValueNumber--) | 숫자 값. |
+| [getValueString()](#getValueString--) | 문자열 값. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | 이 속성에 대한 설명은 [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)을(를) 참조하십시오. |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)을(를) 참조하십시오. |
+| [setValueNumber(double value)](#setValueNumber-double-) | 이 속성에 대한 설명은 [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)을(를) 참조하십시오. |
+| [setValueString(String value)](#setValueString-java.lang.String-) | 이 속성에 대한 설명은 [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+불리언 값.
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+날짜 및 시간 값입니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+숫자 값.
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+문자열 값.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+이 속성에 대한 설명은 [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+이 속성에 대한 설명은 [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datacolumn/_index.md
+++ b/korean/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Aspose.Diagram for Java API 참조
+description: Visio 사용자 인터페이스의 외부 데이터 창에 데이터 열이 표시되는 방식을 정의하고, 데이터 유형 및 서식을 정의하여 열의 데이터를 지정합니다.
+type: docs
+weight: 108
+url: /ko/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Visio 사용자 인터페이스의 외부 데이터 창에 데이터 열이 표시되는 방식을 정의하고, 데이터 유형 및 서식을 정의하여 열의 데이터를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | 데이터 열의 캘린더 ID. |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | 데이터 열의 외부 이름. |
+| [getCurrency()](#getCurrency--) | 데이터 열의 통화 ID. |
+| [getDataType()](#getDataType--) | 데이터 열의 데이터 유형. |
+| [getDegree()](#getDegree--) | 단위의 차수(거듭제곱)를 지정합니다. 예: 제곱 또는 세제곱. |
+| [getDisplayOrder()](#getDisplayOrder--) | 외부 데이터 창에서 데이터 열의 표시 위치를 정의합니다. 가장 왼쪽 열(0)부터 가장 오른쪽 열(최대값)까지. |
+| [getDisplayWidth()](#getDisplayWidth--) | 외부 데이터 창에서 데이터 열의 너비. |
+| [getHyperlink()](#getHyperlink--) | 데이터에 연결된 도형에서 데이터 열이 하이퍼링크를 생성하는지 여부. |
+| [getLabel()](#getLabel--) | 데이터 열의 레이블. |
+| [getLangID()](#getLangID--) | 데이터 열의 언어 ID |
+| [getMapped()](#getMapped--) | 열이 외부 데이터 창에 표시되는지 여부를 지정합니다. |
+| [getName()](#getName--) | 데이터 열의 내부 이름. |
+| [getOrigLabel()](#getOrigLabel--) | 기본 ADO 인터페이스에 의해 Visio에 반환되는 열 레이블입니다. |
+| [getUnitType()](#getUnitType--) | 데이터 열에 있는 데이터의 단위 유형입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | 이 속성에 대한 설명은 \{@link DataColumn\#(getCalendar() & 0xFFFF)\}을(를) 참조하십시오. |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | 이 속성에 대한 설명은 [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)을(를) 참조하십시오. |
+| [setCurrency(int value)](#setCurrency-int-) | 이 속성에 대한 설명은 \{@link DataColumn\#(getCurrency() & 0xFFFF)\}을(를) 참조하십시오. |
+| [setDataType(int value)](#setDataType-int-) | 이 속성에 대한 설명은 \{@link DataColumn\#(getDataType() & 0xFFFF)\}을(를) 참조하십시오. |
+| [setDegree(long value)](#setDegree-long-) | 이 속성에 대한 설명은 [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)을(를) 참조하십시오. |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | 이 속성에 대한 설명은 [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)을(를) 참조하십시오. |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | 이 속성에 대한 설명은 [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)을(를) 참조하십시오. |
+| [setHyperlink(int value)](#setHyperlink-int-) | 이 속성에 대한 설명은 [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)을(를) 참조하십시오. |
+| [setLabel(String value)](#setLabel-java.lang.String-) | 이 속성에 대한 설명은 [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)을(를) 참조하십시오. |
+| [setLangID(long value)](#setLangID-long-) | 이 속성에 대한 설명은 [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)을(를) 참조하십시오. |
+| [setMapped(int value)](#setMapped-int-) | 이 속성에 대한 설명은 [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/datacolumn\#getName--)을(를) 참조하십시오. |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | 이 속성에 대한 설명은 [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)을(를) 참조하십시오. |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | 이 속성에 대한 설명은 [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+데이터 열의 캘린더 ID.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+데이터 열의 외부 이름입니다. 외부 데이터 창의 헤더와 데이터 그래픽의 레이블에 표시됩니다.
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+데이터 열의 통화 ID.
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+데이터 열의 데이터 유형.
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+단위의 차수(거듭제곱)를 지정합니다. 예를 들어 제곱 또는 세제곱입니다. 기본값(속성 없음)은 1입니다.
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+외부 데이터 창에서 데이터 열의 표시 위치를 정의합니다. 가장 왼쪽 열(0)부터 가장 오른쪽 열(최대값)까지.
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+외부 데이터 창에서 데이터 열의 너비.
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+데이터에 연결된 도형에서 데이터 열이 하이퍼링크를 생성하는지 여부.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+데이터 열의 레이블.
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+데이터 열의 언어 ID
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+열이 외부 데이터 창에 표시되는지 여부를 지정합니다. 열이 표시되려면 True(1), 표시되지 않으려면 false(0)입니다. 기본값(속성 없음)은 열이 표시되는 것입니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+데이터 열의 내부 이름입니다. 도형이 데이터 행에 연결될 때 도형에 추가되는 shape-data 항목(사용자 정의 속성)의 행 이름으로 사용됩니다.
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+기본 ADO 인터페이스에 의해 Visio에 반환되는 열 레이블입니다.
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+데이터 열에 있는 데이터의 단위 유형입니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataColumn\#(getCalendar() & 0xFFFF)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+이 속성에 대한 설명은 [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataColumn\#(getCurrency() & 0xFFFF)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataColumn\#(getDataType() & 0xFFFF)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+이 속성에 대한 설명은 [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+이 속성에 대한 설명은 [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+이 속성에 대한 설명은 [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+이 속성에 대한 설명은 [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+이 속성에 대한 설명은 [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+이 속성에 대한 설명은 [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+이 속성에 대한 설명은 [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/datacolumn\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+이 속성에 대한 설명은 [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+이 속성에 대한 설명은 [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/korean/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Aspose.Diagram for Java API 참조
+description: DataColumn 컬렉션입니다.
+type: docs
+weight: 109
+url: /ko/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+DataColumn 컬렉션입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | 컬렉션에 dataColumn을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getSortAsc()](#getSortAsc--) | SortColumn 열을 오름차순(1) 또는 내림차순(0)으로 정렬할지 여부. |
+| [getSortColumn()](#getSortColumn--) | 데이터를 정렬할 열. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | 컬렉션에서 dataColumn을 제거합니다. |
+| [setSortAsc(int value)](#setSortAsc-int-) | 이 속성에 대한 설명은 [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)을(를) 참조하십시오. |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | 이 속성에 대한 설명은 [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+컬렉션에 dataColumn을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+SortColumn 열을 오름차순(1) 또는 내림차순(0)으로 정렬할지 여부.
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+데이터를 정렬할 열.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+컬렉션에서 dataColumn을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+이 속성에 대한 설명은 [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+이 속성에 대한 설명은 [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dataconnection/_index.md
+++ b/korean/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Aspose.Diagram for Java API 참조
+description: 하나 이상의 DataRecordset 요소와 비 XML 데이터 소스 간의 통신을 추상화합니다.
+type: docs
+weight: 110
+url: /ko/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+하나 이상의 DataRecordset 요소와 비 XML 데이터 소스 간의 통신을 추상화합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | 기본값은 false입니다. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | 데이터 소스를 쿼리하는 데 사용되는 명령 문자열입니다. |
+| [getConnectionString()](#getConnectionString--) | 데이터 소스에 연결하는 데 필요한 매개변수를 정의하는 연결 문자열입니다. |
+| [getFileName()](#getFileName--) | 연결 파일의 이름입니다. |
+| [getID()](#getID--) | Visio에서 지정한 해당 연결의 ID이며, 문서 내에서 고유합니다. |
+| [getTimeout()](#getTimeout--) | 연결을 시도하는 동안 종료하기 전까지 기다리는 시간(분)입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | 이 속성에 대한 설명은 [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)을(를) 참조하십시오. |
+| [setCommand(String value)](#setCommand-java.lang.String-) | 이 속성에 대한 설명은 [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)을(를) 참조하십시오. |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | 이 속성에 대한 설명은 [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)을(를) 참조하십시오. |
+| [setFileName(String value)](#setFileName-java.lang.String-) | 이 속성에 대한 설명은 [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)을(를) 참조하십시오. |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setTimeout(long value)](#setTimeout-long-) | 이 속성에 대한 설명은 [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+기본값은 false입니다. 자세한 내용은 Remarks를 참조하십시오.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+데이터 소스를 쿼리하는 데 사용되는 명령 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+데이터 소스에 연결하는 데 필요한 매개변수를 정의하는 연결 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+연결 파일의 이름입니다. 자세한 내용은 Remarks를 참조하십시오.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Visio에서 지정한 해당 연결의 ID이며, 문서 내에서 고유합니다.
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+연결을 시도하는 동안 종료하기 전까지 기다리는 시간(분)입니다.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+이 속성에 대한 설명은 [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+이 속성에 대한 설명은 [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+이 속성에 대한 설명은 [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+이 속성에 대한 설명은 [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+이 속성에 대한 설명은 [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/korean/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Aspose.Diagram for Java API 참조
+description: DataConnection 컬렉션입니다.
+type: docs
+weight: 111
+url: /ko/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+DataConnection 컬렉션입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | 컬렉션에 dataConnection을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getDataConnection(long ID)](#getDataConnection-long-) | Gets the element at the specified ID. |
+| [getNextID()](#getNextID--) | 새 연결에 사용할 다음 사용 가능한 ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | 컬렉션에서 dataConnection을 제거합니다. |
+| [setNextID(long value)](#setNextID-long-) | 이 속성에 대한 설명은 \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+컬렉션에 dataConnection을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | long | DataConnectionUInt32의 ID. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+새 연결에 사용할 다음 사용 가능한 ID.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+컬렉션에서 dataConnection을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/korean/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Aspose.Diagram for Java API 참조
+description: 데이터베이스 연결 옵션을 구성할 수 있게 합니다.
+type: docs
+weight: 112
+url: /ko/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+데이터베이스 연결 옵션을 구성할 수 있게 합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ODBC](#ODBC) | 사용 System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | 사용 System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | 사용 System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | 알 수 없는 연결 유형입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+사용 System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+사용 System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+사용 System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+알 수 없는 연결 유형입니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datarecordset/_index.md
+++ b/korean/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio에서 데이터베이스에서 쿼리된 데이터를 저장하고, 형식을 새로 고치며, 노출합니다.
+type: docs
+weight: 113
+url: /ko/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Microsoft Visio에서 데이터베이스에 질의한 데이터를 저장, 서식 지정, 새로 고침 및 노출합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | ADO 레코드셋에 대한 ADO 클래식 XML 스키마에 부합하고 데이터 레코드셋의 데이터를 설명하는 XML을 포함합니다. |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | 사용자 인터페이스에서 수행된 마지막 성공적인 자동 연결 작업의 도형 데이터 항목과 상위 DataRecordset 요소의 열을 비교하는 규칙을 정의합니다. |
+| [getChecksum()](#getChecksum--) | Visio에서 생성된 체크섬 값이며, data-recordset 속성을 기반으로 합니다. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | 데이터 소스에서 데이터를 쿼리하는 데 사용되는 명령 문자열입니다. |
+| [getConnectionID()](#getConnectionID--) | 연관된 DataConnection 객체의 연결 ID입니다. |
+| [getDataColumns()](#getDataColumns--) | 데이터 레코드셋에 포함된 모든 DataColumn 요소를 포함합니다. |
+| [getID()](#getID--) | 문서 내에서 고유한 데이터 레코드셋 ID입니다. |
+| [getName()](#getName--) | 데이터 레코드셋의 표시(또는 \"친숙한\") 이름입니다. |
+| [getNextRowID()](#getNextRowID--) | 다음 사용 가능한 Visio 행 ID입니다. |
+| [getOptions()](#getOptions--) | 데이터 레코드셋에 적용할 옵션입니다. |
+| [getPrimaryKeys()](#getPrimaryKeys--) | 데이터 레코드셋에서 하나 이상의 기본 키 열을 식별합니다. |
+| [getRefreshConflicts()](#getRefreshConflicts--) | 데이터 레코드셋이 새로 고쳐진 후 충돌이 발생한 모양에 연결된 데이터 레코드셋의 행을 나타냅니다. |
+| [getRefreshInterval()](#getRefreshInterval--) | Visio가 데이터 레코드셋을 자동으로 새로 고치는 빈도(분)입니다. |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | 데이터 조정 사용자 인터페이스를 비활성화해야 하는지 여부입니다. |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | 데이터 레코드셋이 새로 고쳐질 때 데이터에 연결된 모양의 모양 데이터 항목에 대한 사용자 변경을 덮어쓸지 여부입니다. |
+| [getReplaceLinks()](#getReplaceLinks--) | 모양을 복사하거나 잘라낼 때 shape-data 링크가 처리되는 방식을 정의합니다. 대상 모양의 기존 링크를 교체하려면 1, 기존 링크를 유지하려면 0을 사용합니다. |
+| [getRowMaps()](#getRowMaps--) | 데이터 레코드셋 행을 모양에 매핑합니다. |
+| [getRowOrder()](#getRowOrder--) | 데이터 레코드셋의 행 순서를 기본 키로 사용할지 여부입니다. |
+| [getTimeRefreshed()](#getTimeRefreshed--) | 데이터 레코드셋이 마지막으로 새로 고쳐진 날짜와 시간입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | 연결된 (XML 기반이 아닌) DataRecordset과 연관된 쿼리 문자열을 실행하고, 쿼리에서 반환된 데이터 소스의 새 데이터로 연결된 모양을 업데이트합니다. |
+| [setADOData(String value)](#setADOData-java.lang.String-) | 이 속성에 대한 설명은 [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)을(를) 참조하십시오. |
+| [setChecksum(long value)](#setChecksum-long-) | 이 속성에 대한 설명은 \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setCommand(String value)](#setCommand-java.lang.String-) | 이 속성에 대한 설명은 [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)을(를) 참조하십시오. |
+| [setConnectionID(long value)](#setConnectionID-long-) | 이 속성에 대한 설명은 \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/datarecordset\#getName--)을(를) 참조하십시오. |
+| [setNextRowID(long value)](#setNextRowID-long-) | 이 속성에 대한 설명은 \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setOptions(int value)](#setOptions-int-) | 이 속성에 대한 설명은 [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)을(를) 참조하십시오. |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | 이 속성에 대한 설명은 \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | 이 속성에 대한 설명은 [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)을(를) 참조하십시오. |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | 이 속성에 대한 설명은 [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)을(를) 참조하십시오. |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | 이 속성에 대한 설명은 [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)을(를) 참조하십시오. |
+| [setRowOrder(int value)](#setRowOrder-int-) | 이 속성에 대한 설명은 [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)을(를) 참조하십시오. |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+ADO 레코드셋에 대한 ADO 클래식 XML 스키마에 부합하고 데이터 레코드셋의 데이터를 설명하는 XML을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+사용자 인터페이스에서 수행된 마지막 성공적인 자동 연결 작업의 도형 데이터 항목과 상위 DataRecordset 요소의 열을 비교하는 규칙을 정의합니다.
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+Visio에서 생성된 체크섬 값이며 data-recordset 속성을 기반으로 합니다. 이 속성을 0으로 설정하십시오; Visio는 런타임에 이 값을 다시 계산합니다.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+데이터 소스에서 데이터를 쿼리하는 데 사용되는 명령 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+연관된 DataConnection 객체의 연결 ID입니다. XML 데이터 소스에는 존재하지 않습니다.
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+데이터 레코드셋에 포함된 모든 DataColumn 요소를 포함합니다.
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+문서 내에서 고유한 데이터 레코드셋 ID입니다.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+데이터 레코드셋의 표시(또는 \"친숙한\") 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+다음 사용 가능한 Visio 행 ID입니다.
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+데이터 레코드셋에 적용할 옵션입니다. 가능한 값은 아래 표에 표시된 하나 이상의 옵션을 조합한 것이 될 수 있습니다.
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+데이터 레코드셋에서 하나 이상의 기본 키 열을 식별합니다.
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+데이터 레코드셋이 새로 고쳐진 후 충돌이 발생한 도형에 연결된 레코드셋 행을 나타냅니다. RowID - 데이터 레코드셋이 새로 고쳐진 후 충돌이 발생한 도형에 연결된 레코드셋 행을 나타냅니다. ShapeID - 충돌에 연관된 도형의 Shape ID입니다. PageID - 충돌에 연관된 도형의 Page ID입니다.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+Visio가 데이터 레코드셋을 자동으로 새로 고치는 빈도(분)입니다. 이 값은 1 이상이어야 합니다.
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+데이터 조정 사용자 인터페이스를 비활성화할지 여부입니다. 사용자 인터페이스(UI)를 비활성화하려면 True(1)를, 활성화하려면 False(0)를 사용하십시오.
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+데이터 레코드셋이 새로 고쳐질 때 데이터에 연결된 모양의 모양 데이터 항목에 대한 사용자 변경을 덮어쓸지 여부입니다.
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+도형을 복사하거나 잘라낼 때 shape-data 링크가 어떻게 처리되는지를 정의합니다. 대상 도형의 기존 링크를 교체하려면 1, 기존 링크를 유지하려면 0을 사용합니다. 이 속성이 없으면 Visio는 복사 또는 잘라내기 시 링크를 교체할지 사용자에게 묻습니다.
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+데이터 레코드셋 행을 도형에 매핑합니다. RowID - 데이터 레코드셋 내에서 고유한 행의 Row ID입니다. ShapeID - RowID로 식별된 데이터 레코드셋 행의 데이터에 연결된 도형의 Shape ID입니다. PageID - RowID로 식별된 데이터 레코드셋 행의 데이터에 연결된 도형의 Page ID입니다.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+데이터 레코드셋의 행 순서를 기본 키로 사용할지 여부입니다. 행 ID가 행 순서에 의해 결정되면 True(1), 데이터 레코드셋의 기본 키 열 값에 의해 결정되면 False(0)를 사용합니다.
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+데이터 레코드셋이 마지막으로 새로 고쳐진 날짜와 시간입니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+연결된 (XML 기반이 아닌) DataRecordset과 연관된 쿼리 문자열을 실행하고, 쿼리에서 반환된 데이터 소스의 새 데이터로 연결된 모양을 업데이트합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| connectionType | int | 연결에 사용될 공급자 유형은 Aspose.Diagram.Manipulation.DataConnectionType입니다. |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+이 속성에 대한 설명은 [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+이 속성에 대한 설명은 [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/datarecordset\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+이 속성에 대한 설명은 [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+이 속성에 대한 설명은 [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+이 속성에 대한 설명은 [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+이 속성에 대한 설명은 [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+이 속성에 대한 설명은 [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/korean/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Aspose.Diagram for Java API 참조
+description: DataRecordSet 컬렉션입니다.
+type: docs
+weight: 114
+url: /ko/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+DataRecordSet 컬렉션입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | 컬렉션에 dataRecordSet을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | 컬렉션에서 dataRecordSet을 제거합니다. |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | 이 속성에 대한 설명은 [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)를 참조하십시오. |
+| [setNextId(String value)](#setNextId-java.lang.String-) | 이 속성에 대한 설명은 [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+컬렉션에 dataRecordSet을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+컬렉션에서 dataRecordSet을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+이 속성에 대한 설명은 [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+이 속성에 대한 설명은 [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datetime/_index.md
+++ b/korean/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Aspose.Diagram for Java API 참조
+description: 일반적으로 날짜와 시간으로 표현되는 순간을 나타냅니다.
+type: docs
+weight: 115
+url: /ko/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+일반적으로 날짜와 시간으로 표현되는 특정 시점을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | 지정된 연도, 월 및 일로 DateTime 객체의 새 인스턴스를 초기화합니다. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | 지정된 연도, 월, 일, 시, 분 및 초로 DateTime 객체의 새 인스턴스를 초기화합니다. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | 지정된 연도, 월, 일, 시, 분, 초 및 밀리초로 DateTime 객체의 새 인스턴스를 초기화합니다. |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | 지정된 Date 객체로 DateTime 객체의 새 인스턴스를 초기화합니다. |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | 지정된 Calendar 객체로 DateTime 객체의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | 이 인스턴스의 값에 지정된 일 수를 더합니다. |
+| [addHours(double value)](#addHours-double-) | 이 인스턴스의 값에 지정된 시간 수를 더합니다. |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | 이 인스턴스의 값에 지정된 밀리초 수를 더합니다. |
+| [addMinutes(double value)](#addMinutes-double-) | 이 인스턴스의 값에 지정된 분 수를 더합니다. |
+| [addMonths(int months)](#addMonths-int-) | 이 인스턴스의 값에 지정된 개월 수를 더합니다. |
+| [addSeconds(double value)](#addSeconds-double-) | 이 인스턴스의 값에 지정된 초 수를 더합니다. |
+| [addYears(int value)](#addYears-int-) | 이 인스턴스의 값에 지정된 연 수를 더합니다. |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | 이 인스턴스의 값을 지정된 DateTime 값과 비교하고, 이 인스턴스가 지정된 DateTime 값보다 이전인지, 같은지, 이후인지를 나타내는 정수를 반환합니다. |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | 이 인스턴스의 값을 지정된 DateTime 값을 포함하는 객체와 비교하고, 이 인스턴스가 지정된 DateTime 값보다 이전인지, 같은지, 이후인지를 나타내는 정수를 반환합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 이 인스턴스가 지정된 객체와 같은지 여부를 나타내는 값을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | 이 인스턴스가 나타내는 월의 일을 가져옵니다. |
+| [getDayOfWeek()](#getDayOfWeek--) | 이 인스턴스가 나타내는 요일을 가져옵니다. |
+| [getDayOfYear()](#getDayOfYear--) | 이 인스턴스가 나타내는 연도의 일을 가져옵니다. |
+| [getHour()](#getHour--) | 이 인스턴스가 나타내는 날짜의 시 구성 요소를 가져옵니다. |
+| [getMillisecond()](#getMillisecond--) | 이 인스턴스가 나타내는 날짜의 밀리초 구성 요소를 가져옵니다. |
+| [getMinute()](#getMinute--) | 이 인스턴스가 나타내는 날짜의 분 구성 요소를 가져옵니다. |
+| [getMonth()](#getMonth--) | 이 인스턴스가 나타내는 날짜의 월 구성 요소를 가져옵니다. |
+| [getNow()](#getNow--) | 이 컴퓨터의 현재 날짜와 시간으로 설정된 DateTime 객체를 로컬 시간으로 가져옵니다. |
+| [getSecond()](#getSecond--) | 이 인스턴스가 나타내는 날짜의 초 구성 요소를 가져옵니다. |
+| [getYear()](#getYear--) | 이 인스턴스가 나타내는 날짜의 연도 구성 요소를 가져옵니다. |
+| [hashCode()](#hashCode--) | 이 인스턴스의 해시 코드를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | 현재 DateTime 객체의 값을 Calendar 객체로 변환합니다. |
+| [toDate()](#toDate--) | 현재 DateTime 객체의 값을 Date 객체로 변환합니다. |
+| [toLocalTime()](#toLocalTime--) | 현재 DateTime 객체의 값을 로컬 시간으로 변환합니다. |
+| [toString()](#toString--) | 현재 DateTime 객체의 값을 해당 문자열 표현으로 변환합니다. |
+| [toUniversalTime()](#toUniversalTime--) | 현재 DateTime 객체의 값을 협정 세계시(UTC)로 변환합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+지정된 연도, 월 및 일로 DateTime 객체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 연도 | int | 연도(1~9999). |
+| 월 | int | 월(1~12). |
+| 일 | int | 일(1~해당 월의 일 수). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+지정된 연도, 월, 일, 시, 분 및 초로 DateTime 객체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 연도 | int | 연도(1~9999). |
+| 월 | int | 월(1~12). |
+| 일 | int | 일(1~해당 월의 일 수). |
+| 시 | int | 시(0~23). |
+| 분 | int | 분(0~59). |
+| 초 | int | 초 (0부터 59). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+지정된 연도, 월, 일, 시, 분, 초 및 밀리초로 DateTime 객체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 연도 | int | 연도(1~9999). |
+| 월 | int | 월(1~12). |
+| 일 | int | 일(1~해당 월의 일 수). |
+| 시 | int | 시(0~23). |
+| 분 | int | 분(0~59). |
+| 초 | int | 초 (0부터 59). |
+| 밀리초 | int | 밀리초 (0부터 999). |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+지정된 Date 객체로 DateTime 객체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 날짜 | java.util.Date | Date 객체 |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+지정된 Calendar 객체로 DateTime 객체의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| cld | java.util.Calendar | Calendar 객체 |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+이 인스턴스의 값에 지정된 일 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double | 전체 및 소수 부분을 포함한 일 수. value 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+이 인스턴스의 값에 지정된 시간 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double | 전체 및 소수 부분을 포함한 시간 수. value 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+이 인스턴스의 값에 지정된 밀리초 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double | 전체 및 소수 부분을 포함한 밀리초 수. value 매개변수는 음수이거나 양수일 수 있습니다. 이 값은 가장 가까운 정수로 반올림된다는 점에 유의하십시오. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+이 인스턴스의 값에 지정된 분 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double | 전체 및 소수 부분을 포함한 분 수. value 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+이 인스턴스의 값에 지정된 개월 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 개월 | int | 개월 수. months 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+이 인스턴스의 값에 지정된 초 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double | 전체 및 소수 부분을 포함한 초 수. value 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+이 인스턴스의 값에 지정된 연 수를 더합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int | 년 수. value 매개변수는 음수이거나 양수일 수 있습니다. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+이 인스턴스의 값을 지정된 DateTime 값과 비교하고, 이 인스턴스가 지정된 DateTime 값보다 이전인지, 같은지, 이후인지를 나타내는 정수를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | 비교할 DateTime 객체. |
+
+**Returns:**
+int - 이 인스턴스와 value 매개변수의 상대 값을 나타내는 부호 있는 숫자. Value Description 0보다 작음 이 인스턴스가 value보다 이전입니다. 0 이 인스턴스가 value와 동일합니다. 0보다 큼 이 인스턴스가 value보다 이후입니다.
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+이 인스턴스의 값을 지정된 DateTime 값을 포함하는 객체와 비교하고, 이 인스턴스가 지정된 DateTime 값보다 이전인지, 같은지, 이후인지를 나타내는 정수를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object | 비교할 박싱된 DateTime 객체 또는 null. |
+
+**Returns:**
+int - 이 인스턴스와 value의 상대 값을 나타내는 부호 있는 숫자. Value Description 0보다 작음 이 인스턴스가 value보다 이전입니다. 0 이 인스턴스가 value와 동일합니다. 0보다 큼 이 인스턴스가 value보다 이후이거나 value가 null입니다.
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+이 인스턴스가 지정된 객체와 같은지 여부를 나타내는 값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object | 이 인스턴스와 비교할 객체. |
+
+**Returns:**
+boolean - value가 DateTime 인스턴스이며 이 인스턴스의 값과 동일하면 true; 그렇지 않으면 false.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+이 인스턴스가 나타내는 월의 일을 가져옵니다.
+
+**Returns:**
+int - 1에서 31 사이의 값으로 표현된 일 구성 요소.
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+이 인스턴스가 나타내는 요일을 가져옵니다.
+
+**Returns:**
+int - 이 DateTime 값의 요일.
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+이 인스턴스가 나타내는 연도의 일을 가져옵니다.
+
+**Returns:**
+int - 연도 내의 일, 1에서 366 사이의 값으로 표현됩니다.
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+이 인스턴스가 나타내는 날짜의 시 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 시간 구성 요소, 0에서 23 사이의 값으로 표현됩니다.
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+이 인스턴스가 나타내는 날짜의 밀리초 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 밀리초 구성 요소, 0에서 999 사이의 값으로 표현됩니다.
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+이 인스턴스가 나타내는 날짜의 분 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 분 구성 요소, 0에서 59 사이의 값으로 표현됩니다.
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+이 인스턴스가 나타내는 날짜의 월 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 월 구성 요소, 1에서 12 사이의 값으로 표현됩니다.
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+이 컴퓨터의 현재 날짜와 시간으로 설정된 DateTime 객체를 로컬 시간으로 가져옵니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+이 인스턴스가 나타내는 날짜의 초 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 초, 0에서 59 사이입니다.
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+이 인스턴스가 나타내는 날짜의 연도 구성 요소를 가져옵니다.
+
+**Returns:**
+int - 연도, 1에서 9999 사이입니다.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+이 인스턴스의 해시 코드를 반환합니다.
+
+**Returns:**
+int - 32비트 부호 있는 정수 해시 코드.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+현재 DateTime 객체의 값을 Calendar 객체로 변환합니다.
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+현재 DateTime 객체의 값을 Date 객체로 변환합니다.
+
+**Returns:**
+java.util.Date - 날짜 객체
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+현재 DateTime 객체의 값을 로컬 시간으로 변환합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+현재 DateTime 객체의 값을 해당 문자열 표현으로 변환합니다.
+
+**Returns:**
+java.lang.String - 현재 DateTime 객체의 값을 문자열로 표현한 것입니다.
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+현재 DateTime 객체의 값을 협정 세계시(UTC)로 변환합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/datevalue/_index.md
+++ b/korean/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Aspose.Diagram for Java API 참조
+description: 날짜 및 시간 값입니다.
+type: docs
+weight: 116
+url: /ko/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+날짜 및 시간 값입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 날짜 및 시간 값입니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/datevalue\\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| 단위 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+날짜 및 시간 값입니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/datevalue\\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/diagram/_index.md
+++ b/korean/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: 다이어그램
+second_title: Aspose.Diagram for Java API 참조
+description: Visio 개체 계층 구조의 루트 요소.
+type: docs
+weight: 117
+url: /ko/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Visio 개체 계층 구조의 루트 요소.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | Public 클래스 생성자, 파일에서 다이어그램을 로드합니다. |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | Public 클래스 생성자, 스트림에서 다이어그램을 로드합니다. |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | Public 클래스 생성자, 미리 정의된 형식을 사용하여 스트림에서 다이어그램을 로드합니다. |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | Public 클래스 생성자, 미리 정의된 로드 파일 옵션을 사용하여 스트림에서 다이어그램을 로드합니다. |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | Public 클래스 생성자, 미리 정의된 형식을 사용하여 파일에서 다이어그램을 로드합니다. |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | Public 클래스 생성자, 미리 정의된 로드 파일 옵션을 사용하여 파일에서 다이어그램을 로드합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | 마스터의 Name 또는 NameU를 사용하여 소스 다이어그램에서 마스터를 다이어그램에 추가합니다. |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | 마스터의 ID를 사용하여 템플릿 스트림에서 마스터를 다이어그램에 추가합니다. |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | 마스터의 Name 또는 NameU를 사용하여 템플릿 스트림에서 마스터를 다이어그램에 추가합니다. |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | 마스터의 ID를 사용하여 템플릿 파일에서 마스터를 다이어그램에 추가합니다. |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | 마스터의 Name 또는 NameU를 사용하여 템플릿 파일에서 마스터를 다이어그램에 추가합니다. |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | 마스터에서 만든 도형을 특정 페이지에 추가합니다. |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | 정의된 PinX, PinY, Width 및 Height를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다. |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | 정의된 PinX 및 PinY를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다. |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | 다른 Diagram 객체와 결합합니다. |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | 소스 Diagram에서 테마를 복사합니다. |
+| [dispose()](#dispose--) | 관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | vsd 스트림에서 vdw 스트림 형식으로 다이어그램을 내보냅니다. |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | vsd 스트림에서 *.vdw 파일 형식으로 다이어그램을 내보냅니다. |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | vsd 파일에서 vdw 스트림 형식으로 다이어그램을 내보냅니다. |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | vsd에서 vdw 형식으로 다이어그램을 내보냅니다. |
+| [getActivePage()](#getActivePage--) | 활성 페이지를 지정합니다. |
+| [getBuildnum()](#getBuildnum--) | 문서를 만드는 데 사용된 Visio 인스턴스의 빌드 번호입니다. |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | 문서의 색상표를 포함합니다. |
+| [getDataConnections()](#getDataConnections--) | 문서에 대한 DataConnection 요소를 포함합니다. |
+| [getDataRecordSets()](#getDataRecordSets--) | Document 객체와 연결된 DataRecordset 객체 컬렉션입니다. |
+| [getDefaultFontDir()](#getDefaultFontDir--) | 기본 글꼴 폴더 경로를 가져옵니다. |
+| [getDocLangID()](#getDocLangID--) | 사용자가 Microsoft Office 2010 언어 기본 설정에서 지정한 사용자 인터페이스 언어의 고유 ID입니다. |
+| [getDocumentProps()](#getDocumentProps--) | 문서의 제목, 작성자 등과 같은 문서 속성 요소를 포함합니다. |
+| [getDocumentSettings()](#getDocumentSettings--) | 문서 설정을 지정하는 요소를 포함합니다. |
+| [getDocumentSheet()](#getDocumentSheet--) | 문서의 ShapeSheet 구조를 지정합니다. |
+| [getEmailRoutingData()](#getEmailRoutingData--) | 문서에 대한 MIME (Multipurpose Internet Mail Extensions) 인코딩된 MAPI 이메일 라우팅 슬립을 포함합니다. |
+| [getEventItems()](#getEventItems--) | 각 이벤트에 대해 객체가 응답해야 하는 EventItem 요소를 포함합니다. |
+| [getFonts()](#getFonts--) | Font 요소들의 컬렉션을 포함합니다. |
+| [getHeaderFooter()](#getHeaderFooter--) | 문서의 머리글 및 바닥글 요소를 포함합니다. |
+| [getInterruptMonitor()](#getInterruptMonitor--) | 인터럽트 모니터. |
+| [getKey()](#getKey--) | 문서가 Visio 외부에서 수정되었는지 여부를 나타냅니다. |
+| [getMasters()](#getMasters--) | Master 객체들의 컬렉션입니다. |
+| [getMetric()](#getMetric--) | 도면에서 미터법 단위를 사용할지 여부입니다. |
+| [getPages()](#getPages--) | Page 객체들의 컬렉션입니다. |
+| [getRibbonX()](#getRibbonX--) | 리본 사용자 인터페이스를 사용자 지정하기 위해 문서에 전달되는 Ribbon XML 문자열입니다. |
+| [getSolutionXMLs()](#getSolutionXMLs--) | XML 값입니다. |
+| [getStart()](#getStart--) | 문서가 Visio 외부에서 수정되었는지 여부를 나타냅니다. |
+| [getStyleSheets()](#getStyleSheets--) | StyleSheet 객체들의 컬렉션입니다. |
+| [getUnusedStyles()](#getUnusedStyles--) | 사용되지 않은 스타일을 가져옵니다. |
+| [getUserCustomUI()](#getUserCustomUI--) | 리본 또는 빠른 실행 도구 모음을 사용자 지정하기 위해 문서에 전달되는 Ribbon XML 문자열입니다. |
+| [getValidation()](#getValidation--) | 문서에 대한 다이어그램 검증 정보를 저장합니다. |
+| [getVbProjectData()](#getVbProjectData--) | MIME (Multipurpose Internet Mail Extensions) 인코딩 형식의 Microsoft Visual Basic for Applications 프로젝트 데이터를 포함합니다. |
+| [getVbaProject()](#getVbaProject--) | VbaProject을 가져옵니다[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--). |
+| [getVersion()](#getVersion--) | Visio 인스턴스의 버전 번호입니다. |
+| [getWindows()](#getWindows--) | 문서에 대한 Window 요소들을 포함합니다. |
+| [hasHiddenInfo()](#hasHiddenInfo--) | 이 다이어그램에 숨겨진 정보가 있는지 여부를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | 다이어그램의 모든 페이지에 대해 도형을 배치하고/또는 연결기를 재배치합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | 전체 문서를 지정된 프린터에 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러를 사용하여. |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | 전체 문서를 지정된 프린터에 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러를 사용하여. |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | 문서를 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러와 문서 이름을 사용하여. |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | 문서를 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러와 문서 이름을 사용하여. |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | 사용되지 않은 정보를 제거합니다. |
+| [removeMacro()](#removeMacro--) | 이 다이어그램에서 VBA/매크로를 제거합니다. |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | 다이어그램을 스트림에 저장합니다. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | 다이어그램을 스트림에 저장합니다. |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | 지정된 저장 옵션을 사용하여 파일에 문서를 저장합니다. |
+| [save(String filename, int format)](#save-java.lang.String-int-) | 다이어그램 데이터를 파일에 저장합니다. |
+| [setBuildnum(long value)](#setBuildnum-long-) | 이 속성에 대한 설명은 [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)을(를) 참조하십시오. |
+| [setDocLangID(int value)](#setDocLangID-int-) | 이 속성에 대한 설명은 [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)을(를) 참조하십시오. |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | 이 속성에 대한 설명은 [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)을(를) 참조하십시오. |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | 폰트 폴더 경로를 나타냅니다. |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | 이 속성에 대한 설명은 [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)을(를) 참조하십시오. |
+| [setKey(String value)](#setKey-java.lang.String-) | 이 속성에 대한 설명은 [getKey()](../../com.aspose.diagram/diagram\#getKey--)을(를) 참조하십시오. |
+| [setMetric(int value)](#setMetric-int-) | 이 속성에 대한 설명은 [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)을(를) 참조하십시오. |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | 이 속성에 대한 설명은 [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)을(를) 참조하십시오. |
+| [setStart(long value)](#setStart-long-) | 이 속성에 대한 설명은 [getStart()](../../com.aspose.diagram/diagram\#getStart--)을(를) 참조하십시오. |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | 이 속성에 대한 설명은 [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)을(를) 참조하십시오. |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | 이 속성에 대한 설명은 [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)을(를) 참조하십시오. |
+| [setVersion(String value)](#setVersion-java.lang.String-) | 이 속성에 대한 설명은 [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+Public 클래스 생성자, 파일에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 파일 이름 | java.lang.String | 파일 이름입니다. |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+Public 클래스 생성자, 스트림에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 데이터 스트림입니다. |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+Public 클래스 생성자, 미리 정의된 형식을 사용하여 스트림에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 데이터 스트림입니다. |
+| 형식 | int | 데이터 Aspose.Diagram.LoadFileFormat. |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+Public 클래스 생성자, 미리 정의된 로드 파일 옵션을 사용하여 스트림에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 데이터 스트림입니다. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | 데이터 [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+Public 클래스 생성자, 미리 정의된 형식을 사용하여 파일에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 파일 이름 | java.lang.String | 파일 이름입니다. |
+| 형식 | int | 파일 형식입니다. |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+Public 클래스 생성자, 미리 정의된 로드 파일 옵션을 사용하여 파일에서 다이어그램을 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 파일 이름 | java.lang.String | 파일 이름입니다. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | 데이터 [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+마스터의 Name 또는 NameU를 사용하여 소스 다이어그램에서 마스터를 다이어그램에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | 소스 다이어그램입니다. |
+| masterName | java.lang.String | 마스터의 Name 또는 NameU. |
+
+**Returns:**
+int - 이 다이어그램의 마스터 컬렉션 내 마스터의 고유 ID입니다.
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+마스터의 ID를 사용하여 템플릿 스트림에서 마스터를 다이어그램에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | 템플릿 스트림입니다. |
+| masterID | int | 템플릿의 마스터 컬렉션 내 마스터의 고유 ID입니다. |
+
+**Returns:**
+int - 이 다이어그램의 마스터 컬렉션 내 마스터의 고유 ID입니다.
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+마스터의 Name 또는 NameU를 사용하여 템플릿 스트림에서 마스터를 다이어그램에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | 템플릿 스트림입니다. |
+| masterName | java.lang.String | 마스터의 Name 또는 NameU. |
+
+**Returns:**
+int - 이 다이어그램의 마스터 컬렉션 내 마스터의 고유 ID입니다.
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+마스터의 ID를 사용하여 템플릿 파일에서 마스터를 다이어그램에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | 템플릿 파일 경로(vdx, vst 또는 vsd 형식일 수 있음). |
+| masterID | int | 템플릿의 마스터 컬렉션 내 마스터의 고유 ID입니다. |
+
+**Returns:**
+int - 이 다이어그램의 마스터 컬렉션 내 마스터의 고유 ID입니다.
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+마스터의 Name 또는 NameU를 사용하여 템플릿 파일에서 마스터를 다이어그램에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | 템플릿 파일 경로(vdx, vst 또는 vsd 형식일 수 있음). |
+| masterName | java.lang.String | 마스터의 Name 또는 NameU. |
+
+**Returns:**
+int - 이 다이어그램의 마스터 컬렉션 내 마스터의 고유 ID입니다.
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+마스터에서 만든 도형을 특정 페이지에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | 새 도형 객체[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | 마스터 이름입니다. |
+| pageNumber | int | 페이지 인덱스. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+정의된 PinX, PinY, Width 및 Height를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 인치 단위로 지정합니다. |
+| height | double | 도형의 높이를 인치 단위로 지정합니다. |
+| masterName | java.lang.String | 마스터 이름입니다. |
+| pageNumber | int | 페이지 인덱스. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+정의된 PinX 및 PinY를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| masterName | java.lang.String | 마스터 이름입니다. |
+| pageNumber | int | 페이지 인덱스. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+다른 Diagram 객체와 결합합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | 다른 Diagram 객체. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+소스 Diagram에서 테마를 복사합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | 소스 다이어그램입니다. |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+vsd 스트림에서 vdw 스트림 형식으로 다이어그램을 내보냅니다. 아직 구현되지 않았습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | vsd 스트림. |
+| outputVdw | java.io.InputStream | vdw 스트림. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+vsd 스트림에서 \*.vdw 파일 형식으로 다이어그램을 내보냅니다. 아직 구현되지 않았습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | \*.vsd 파일 이름. |
+| outputVdw | java.lang.String | vdw 스트림. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+vsd 파일에서 vdw 스트림 형식으로 다이어그램을 내보냅니다. 아직 구현되지 않았습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd 파일 이름. |
+| outputVdw | java.io.InputStream | vdw 스트림. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+vsd에서 vdw 형식으로 다이어그램을 내보냅니다. 아직 구현되지 않았습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd 파일 이름. |
+| outputVdw | java.lang.String | \*.vdw 파일 이름. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+활성 페이지를 지정합니다.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+문서를 만드는 데 사용된 Visio 인스턴스의 빌드 번호입니다.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+문서의 색상 테이블을 포함합니다. 각 문서는 단일 색상 테이블을 가지고 있으며, 여기에는 도형, 텍스트 및 레이어와 같은 객체에 적용할 수 있는 24가지 표준 색상이 나열됩니다.
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+문서에 대한 DataConnection 요소를 포함합니다.
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+Document 객체와 연결된 DataRecordset 객체 컬렉션입니다.
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+기본 글꼴 폴더 경로를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+사용자가 Microsoft Office 2010 언어 기본 설정에서 지정한 사용자 인터페이스 언어의 고유 ID입니다.
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+문서의 제목, 작성자 등과 같은 문서 속성 요소를 포함합니다.
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+문서 설정을 지정하는 요소를 포함합니다.
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+문서의 ShapeSheet 구조를 지정합니다.
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+문서에 대한 MIME (Multipurpose Internet Mail Extensions) 인코딩된 MAPI 이메일 라우팅 슬립을 포함합니다.
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+각 이벤트에 대해 객체가 응답해야 하는 EventItem 요소를 포함합니다.
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Font 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+문서의 머리글 및 바닥글 요소를 포함합니다.
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+인터럽트 모니터.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+문서가 Visio 외부에서 수정되었는지 여부를 나타냅니다. 이 값이 있으면 Visio가 파일 내용을 완전히 검사합니다. Visio 외부에서 만든 파일의 경우 생략하십시오.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Master 객체들의 컬렉션입니다.
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+도면에서 미터법 단위를 사용할지 여부입니다. 이 속성을 True(1)로 설정하면 미터법 단위를 사용하고, False(0)로 설정하면 영국식 단위를 사용합니다.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Page 객체들의 컬렉션입니다.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+리본 사용자 인터페이스를 사용자 지정하기 위해 문서에 전달되는 Ribbon XML 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+XML 값입니다.
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+문서가 Visio 외부에서 수정되었는지 여부를 나타냅니다. 이 값이 있으면 Visio가 파일 내용을 완전히 검사합니다. Visio 외부에서 만든 파일의 경우 생략하십시오.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+StyleSheet 객체들의 컬렉션입니다.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+사용되지 않은 스타일을 가져옵니다.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+리본 또는 빠른 실행 도구 모음을 사용자 지정하기 위해 문서에 전달되는 Ribbon XML 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+문서에 대한 다이어그램 검증 정보를 저장합니다.
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+MIME (Multipurpose Internet Mail Extensions) 인코딩 형식의 Microsoft Visual Basic for Applications 프로젝트 데이터를 포함합니다.
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+VbaProject을 가져옵니다[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--).
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+Visio 인스턴스의 버전 번호입니다. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+문서에 대한 Window 요소들을 포함합니다.
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+이 다이어그램에 숨겨진 정보가 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+다이어그램의 모든 페이지에 대해 도형을 배치하고/또는 연결기를 재배치합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | [LayoutOptions](../../com.aspose.diagram/layoutoptions)를 사용하여 레이아웃 옵션을 구성합니다. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+표준(사용자 인터페이스 없음) 인쇄 컨트롤러를 사용하여 전체 문서를 지정된 프린터에 인쇄합니다. printerName이 Null이거나 비어 있으면 기본 프린터가 사용됩니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. Null일 수 있습니다. |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+표준(사용자 인터페이스 없음) 인쇄 컨트롤러를 사용하여 전체 문서를 지정된 프린터에 인쇄합니다. printerName이 Null이거나 비어 있으면 기본 프린터가 사용됩니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. Null일 수 있습니다. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | 인쇄 옵션. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+문서를 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러와 문서 이름을 사용하여.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. Null일 수 있습니다. |
+| documentName | java.lang.String | 문서를 인쇄하는 동안 표시할 문서 이름(예: 인쇄 상태 대화 상자 또는 프린터 대기열에 표시). |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+문서를 인쇄합니다, 표준(사용자 인터페이스 없음) 인쇄 컨트롤러와 문서 이름을 사용하여.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| printerName | java.lang.String | 프린터 이름입니다. Null일 수 있습니다. |
+| documentName | java.lang.String | 문서를 인쇄하는 동안 표시할 문서 이름(예: 인쇄 상태 대화 상자 또는 프린터 대기열에 표시). |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | 인쇄 옵션. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+사용되지 않은 정보를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+이 다이어그램에서 VBA/매크로를 제거합니다.
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+다이어그램을 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 파일 스트림. |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | 저장 옵션. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+다이어그램을 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 파일 스트림. |
+| 형식 | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+지정된 저장 옵션을 사용하여 파일에 문서를 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 파일 이름 | java.lang.String | 파일 이름입니다. |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) 다이어그램 저장 옵션. |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+다이어그램 데이터를 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 파일 이름 | java.lang.String | 파일 이름입니다. |
+| 형식 | int | Aspose.Diagram.SaveFileFormat 파일 형식. |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+이 속성에 대한 설명은 [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+이 속성에 대한 설명은 [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+폰트 폴더 경로를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+이 속성에 대한 설명은 [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+이 속성에 대한 설명은 [getKey()](../../com.aspose.diagram/diagram\#getKey--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+이 속성에 대한 설명은 [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+이 속성에 대한 설명은 [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+이 속성에 대한 설명은 [getStart()](../../com.aspose.diagram/diagram\#getStart--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+이 속성에 대한 설명은 [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+이 속성에 대한 설명은 [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/diagramexception/_index.md
+++ b/korean/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Aspose.Diagram for Java API 참조
+description: 모든 Aspose.Diagram 예외의 기본 클래스
+type: docs
+weight: 118
+url: /ko/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+모든 Aspose.Diagram 예외의 기본 클래스
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: Visio VDXVSX 형식으로 다이어그램을 저장할 때 추가 옵션을 지정하는 데 사용할 수 있습니다.
+type: docs
+weight: 119
+url: /ko/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Visio (VDX\\VSX) 형식으로 다이어그램을 저장할 때 추가 옵션을 지정하는 데 사용할 수 있습니다. 현재는 SaveFormat 속성만 제공하지만, 향후 다른 옵션이 추가될 예정입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | VDX 형식으로 다이어그램을 저장하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | VDX 또는 VSX 형식으로 다이어그램을 저장하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | 그리기 내용에 맞게 페이지를 확대해야 하는지 여부를 정의합니다. |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 개체를 사용하는 경우 렌더링된 다이어그램이 저장될 형식을 지정합니다. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | 이 속성에 대한 설명은 [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)을(를) 참조하십시오. |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+VDX 형식으로 다이어그램을 저장하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+VDX 또는 VSX 형식으로 다이어그램을 저장하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+그리기 내용에 맞게 페이지를 확대해야 하는지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 개체를 사용하는 경우 렌더링된 다이어그램이 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat 또는 Aspose.Diagram.SaveFileFormat일 수 있습니다.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/displaymode/_index.md
+++ b/korean/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Aspose.Diagram for Java API 참조
+description: Group 요소에 포함될 경우 DisplayMode 요소는 그룹 도형 및 그 구성원의 표시 방식을 지정합니다.
+type: docs
+weight: 120
+url: /ko/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원의 표시 방식을 지정합니다. SmartTagDef 요소에 포함될 경우, DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원이 어떻게 표시되는지를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/displaymode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원의 표시 방식을 지정합니다. SmartTagDef 요소에 포함될 경우, DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/displaymode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/korean/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Aspose.Diagram for Java API 참조
+description: DisplayMode 요소는 도형이 선택된 상태에서 사용자가 태그 위에 마우스를 멈추었을 때 스마트 태그가 표시되는지, 아니면 항상 표시되는지를 결정합니다.
+type: docs
+weight: 121
+url: /ko/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/korean/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Aspose.Diagram for Java API 참조
+description: DisplayMode 요소는 도형이 선택된 상태에서 사용자가 태그 위에 마우스를 멈추었을 때 스마트 태그가 표시되는지, 아니면 항상 표시되는지를 결정합니다.
+type: docs
+weight: 122
+url: /ko/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | 그룹 도형을 구성원 도형 앞에 표시합니다. |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | 그룹 도형과 텍스트를 숨깁니다. |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | 그룹 도형을 구성원 도형 뒤에 표시합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+그룹 도형을 구성원 도형 앞에 표시합니다.
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+그룹 도형과 텍스트를 숨깁니다.
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+그룹 도형을 구성원 도형 뒤에 표시합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Aspose.Diagram for Java API 참조
+description: Group 요소에 포함될 경우 DisplayMode 요소는 그룹 도형 및 그 구성원의 표시 방식을 지정합니다.
+type: docs
+weight: 123
+url: /ko/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원의 표시 방식을 지정합니다. SmartTagDef 요소에 포함될 경우, DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | 그룹 도형을 구성원 도형 뒤에 표시합니다. |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | 그룹 도형을 구성원 도형 앞에 표시합니다. |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | 그룹 도형과 텍스트를 숨깁니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+그룹 도형을 구성원 도형 뒤에 표시합니다.
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+그룹 도형을 구성원 도형 앞에 표시합니다.
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+그룹 도형과 텍스트를 숨깁니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/docprops/_index.md
+++ b/korean/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 미리보기 품질 범위 및 출력 형식을 제어하는 요소를 포함합니다.
+type: docs
+weight: 124
+url: /ko/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+문서의 미리보기 품질, 범위 및 출력 형식을 제어하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | 문서가 마크업 검토 중인지 여부를 나타냅니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDocLangID()](#getDocLangID--) | 문서의 기본 언어를 나타냅니다. |
+| [getLockPreview()](#getLockPreview--) | 그림을 저장할 때마다 미리보기가 저장되는지 여부를 지정합니다. |
+| [getOutputFormat()](#getOutputFormat--) | 도면의 출력 형식을 지정합니다. |
+| [getPreviewQuality()](#getPreviewQuality--) | 그림 미리보기가 초안 품질인지 상세 품질인지 여부를 지정합니다. |
+| [getPreviewScope()](#getPreviewScope--) | 문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다. |
+| [getViewMarkup()](#getViewMarkup--) | 그림 창에 마크업이 표시되는지 여부를 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/docprops\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+문서가 마크업 검토 중인지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+문서의 기본 언어를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+그림을 저장할 때마다 미리보기가 저장되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+도면의 출력 형식을 지정합니다.
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+그림 미리보기가 초안 품질인지 상세 품질인지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다.
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+그림 창에 마크업이 표시되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/docprops\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/documentproperties/_index.md
+++ b/korean/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 제목, 저자 등과 같은 문서 속성 요소를 포함합니다.
+type: docs
+weight: 125
+url: /ko/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+문서의 제목, 작성자 등과 같은 문서 속성 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | 문서에 대한 대체 이름을 지정합니다. |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | 문서를 생성하는 데 사용된 인스턴스의 전체 빌드 번호를 포함합니다. |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | 문서를 마지막으로 편집한 인스턴스의 빌드 번호를 포함합니다. |
+| [getCategory()](#getCategory--) | 플로우차트 또는 사무실 레이아웃과 같은 도면 유형에 대한 설명 텍스트를 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | 도면을 만든 회사 또는 도면이 제작되는 회사를 식별하는 사용자가 입력한 정보를 포함합니다. |
+| [getCreator()](#getCreator--) | 파일을 만든 사람 또는 마지막으로 업데이트한 사람을 식별합니다. |
+| [getCustomProps()](#getCustomProps--) | CustomProp 컬렉션. |
+| [getDesc()](#getDesc--) | 문서에 대한 설명 텍스트 문자열을 포함합니다. |
+| [getHyperlinkBase()](#getHyperlinkBase--) | Microsoft Visio 다이어그램과의 관계로 연결된 파일 위치가 설명되는 상대 하이퍼링크에 사용할 경로를 포함합니다 (연결된 파일 위치가 Microsoft Visio 다이어그램과의 관계로 설명되는 상대 하이퍼링크). |
+| [getKeywords()](#getKeywords--) | 프로젝트 이름, 클라이언트 이름 또는 버전 번호와 같이 파일에 대한 주제 또는 기타 중요한 정보를 식별하는 텍스트 문자열을 포함합니다. |
+| [getLanguage()](#getLanguage--) | 언어를 지정합니다. |
+| [getManager()](#getManager--) | 프로젝트 또는 부서의 담당자를 식별하는 사용자가 입력한 텍스트 문자열을 포함합니다. |
+| [getPreviewPicture()](#getPreviewPicture--) | 문서의 미리보기 역할을 하는 메타파일 스트림을 포함합니다. |
+| [getSubject()](#getSubject--) | 문서의 내용을 설명하는 사용자 정의 �스트 문자열을 포함합니다. |
+| [getTemplate()](#getTemplate--) | 문서가 생성된 템플릿의 파일 이름을 지정하는 문자열 값을 포함합니다. |
+| [getTimeCreated()](#getTimeCreated--) | 문서가 생성된 시점을 나타내는 날짜 및 시간 값을 포함합니다. |
+| [getTimeEdited()](#getTimeEdited--) | 문서가 마지막으로 편집된 시점을 나타내는 날짜 및 시간 값을 포함합니다. |
+| [getTimePrinted()](#getTimePrinted--) | 문서가 마지막으로 인쇄된 시점을 나타내는 날짜 및 시간 값을 포함합니다. |
+| [getTimeSaved()](#getTimeSaved--) | 문서가 마지막으로 저장된 시점을 나타내는 날짜 및 시간 값을 포함합니다. |
+| [getTitle()](#getTitle--) | 문서에 대한 설명적 제목으로 사용되는 사용자 정의 텍스트 문자열을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | 이 속성에 대한 설명은 [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)을(를) 참조하십시오. |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | 이 속성에 대한 설명은 [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)을(를) 참조하십시오. |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | 이 속성에 대한 설명은 [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)을(를) 참조하십시오. |
+| [setCategory(String value)](#setCategory-java.lang.String-) | 이 속성에 대한 설명은 [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)을(를) 참조하십시오. |
+| [setCompany(String value)](#setCompany-java.lang.String-) | 이 속성에 대한 설명은 [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)을(를) 참조하십시오. |
+| [setCreator(String value)](#setCreator-java.lang.String-) | 이 속성에 대한 설명은 [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)을(를) 참조하십시오. |
+| [setDesc(String value)](#setDesc-java.lang.String-) | 이 속성에 대한 설명은 [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)을(를) 참조하십시오. |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | 이 속성에 대한 설명은 [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)을(를) 참조하십시오. |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | 이 속성에 대한 설명은 [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)을(를) 참조하십시오. |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | 이 속성에 대한 설명은 [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)을(를) 참조하십시오. |
+| [setManager(String value)](#setManager-java.lang.String-) | 이 속성에 대한 설명은 [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)을(를) 참조하십시오. |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | 이 속성에 대한 설명은 [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)을(를) 참조하십시오. |
+| [setSubject(String value)](#setSubject-java.lang.String-) | 이 속성에 대한 설명은 [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)을(를) 참조하십시오. |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | 이 속성에 대한 설명은 [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)을(를) 참조하십시오. |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)을(를) 참조하십시오. |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)을(를) 참조하십시오. |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)을(를) 참조하십시오. |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)을(를) 참조하십시오. |
+| [setTitle(String value)](#setTitle-java.lang.String-) | 이 속성에 대한 설명은 [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+문서에 대한 대체 이름을 지정합니다.
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+문서를 생성하는 데 사용된 인스턴스의 전체 빌드 번호를 포함합니다.
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+문서를 마지막으로 편집한 인스턴스의 빌드 번호를 포함합니다.
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+플로우차트나 사무실 레이아웃과 같은 도면 유형에 대한 설명 텍스트를 지정합니다. 이 텍스트는 Microsoft Visio 사용자 인터페이스의 속성 대화 상자에 있는 카테고리 상자에도 입력할 수 있습니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+도면을 작성하는 회사 또는 도면이 작성되는 회사를 식별하는 사용자가 입력한 정보를 포함합니다. 최대 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+파일을 만든 사람 또는 마지막으로 업데이트한 사람을 식별합니다. 최대 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+CustomProp 컬렉션.
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+문서에 대한 설명 텍스트 문자열을 포함합니다. 이 요소를 사용하여 문서의 목적, 최근 변경 사항 또는 보류 중인 변경 사항과 같은 중요한 정보를 저장합니다. 최대 길이는 191자입니다.
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+상대 하이퍼링크에 사용할 경로를 포함합니다(링크된 파일 위치가 Microsoft Visio 다이어그램을 기준으로 설명되는 하이퍼링크). 기본적으로 하이퍼링크 경로는 이 요소에 다른 경로가 지정되지 않는 한 현재 문서를 기준으로 상대적입니다. 최대 길이는 256자입니다.
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+프로젝트 이름, 클라이언트 이름 또는 버전 번호와 같이 파일에 대한 주제 또는 기타 중요한 정보를 식별하는 텍스트 문자열을 포함합니다. 최대 문자열 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+언어를 지정합니다.
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+프로젝트 또는 부서를 담당하는 사람을 식별하는 사용자가 입력한 텍스트 문자열을 포함합니다. 최대 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+문서의 미리보기 역할을 하는 메타파일 스트림을 포함합니다.
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+문서의 내용을 설명하는 사용자가 정의한 텍스트 문자열을 포함합니다. 최대 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+문서가 생성된 템플릿의 파일 이름을 지정하는 문자열 값을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+문서가 생성된 시점을 나타내는 날짜 및 시간 값을 포함합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+문서가 마지막으로 편집된 시점을 나타내는 날짜 및 시간 값을 포함합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+문서가 마지막으로 인쇄된 시점을 나타내는 날짜 및 시간 값을 포함합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+문서가 마지막으로 저장된 시점을 나타내는 날짜 및 시간 값을 포함합니다.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+문서에 대한 설명 제목으로 사용되는 사용자가 정의한 텍스트 문자열을 포함합니다. 최대 길이는 63자입니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+이 속성에 대한 설명은 [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+이 속성에 대한 설명은 [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+이 속성에 대한 설명은 [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+이 속성에 대한 설명은 [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+이 속성에 대한 설명은 [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+이 속성에 대한 설명은 [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+이 속성에 대한 설명은 [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+이 속성에 대한 설명은 [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+이 속성에 대한 설명은 [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+이 속성에 대한 설명은 [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+이 속성에 대한 설명은 [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+이 속성에 대한 설명은 [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+이 속성에 대한 설명은 [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+이 속성에 대한 설명은 [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/documentsettings/_index.md
+++ b/korean/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 설정을 지정하는 요소를 포함합니다.
+type: docs
+weight: 126
+url: /ko/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+문서 설정을 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | 사용자 정의 도구 모음을 나타내는 MIME(다목적 인터넷 메일 확장) 인코딩된 Microsoft Visio 사용자 인터페이스(VSU) 파일입니다. |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | 문서에 대한 사용자 정의 메뉴와 단축키를 정의하는 Microsoft Visio 사용자 인터페이스(.vsu) 파일의 이름을 포함합니다. |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | 문서에 대한 사용자 정의 도구 모음 및 상태 표시줄을 정의하는 Microsoft Visio 사용자 인터페이스(.vsu) 파일의 이름을 포함합니다. |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | StyleSheet 요소의 ID를 지정합니다. |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | StyleSheet 요소의 ID를 지정합니다. |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | StyleSheet 요소의 ID를 지정합니다. |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | StyleSheet 요소의 ID를 지정합니다. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | 문서 또는 창에 대해 동적 그리드 기능이 활성화되어 있는지 지정합니다. |
+| [getGlueSettings()](#getGlueSettings--) | 문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다. |
+| [getProtectBkgnds()](#getProtectBkgnds--) | 사용자가 배경 페이지를 삭제하거나 편집하지 못하도록 방지되는지 지정합니다. |
+| [getProtectMasters()](#getProtectMasters--) | 사용자가 마스터를 만들거나 편집하거나 삭제하지 못하도록 방지되는지 지정합니다. |
+| [getProtectShapes()](#getProtectShapes--) | 사용자가 LockSelect 요소가 1로 설정된 도형을 선택하지 못하도록 방지되는지 지정합니다. |
+| [getProtectStyles()](#getProtectStyles--) | 사용자가 스타일을 만들거나 편집하지 못하도록 방지되는지 지정합니다. |
+| [getSnapAngles()](#getSnapAngles--) | SnapAngle 요소들의 컬렉션을 포함합니다. |
+| [getSnapExtensions()](#getSnapExtensions--) | 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다. |
+| [getSnapSettings()](#getSnapSettings--) | 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다. |
+| [getTopPage()](#getTopPage--) | Microsoft Visio에서 문서를 열 때 표시되어야 하는 페이지의 ID를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | 이 속성에 대한 설명은 [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--)을(를) 참조하십시오. |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | 이 속성에 대한 설명은 [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--)을(를) 참조하십시오. |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | 이 속성에 대한 설명은 [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--)을(를) 참조하십시오. |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | 이 속성에 대한 설명은 [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--)을(를) 참조하십시오. |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | 이 속성에 대한 설명은 [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--)을(를) 참조하십시오. |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | 이 속성에 대한 설명은 [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--)을(를) 참조하십시오. |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | 이 속성에 대한 설명은 [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--)을(를) 참조하십시오. |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | 이 속성에 대한 설명은 [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--)을(를) 참조하십시오. |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | 이 속성에 대한 설명은 [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--)을(를) 참조하십시오. |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | 이 속성에 대한 설명은 [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--)을(를) 참조하십시오. |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | 이 속성에 대한 설명은 [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--)을(를) 참조하십시오. |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | 이 속성에 대한 설명은 [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--)을(를) 참조하십시오. |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | 이 속성에 대한 설명은 [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--)을(를) 참조하십시오. |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | 이 속성에 대한 설명은 [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--)을(를) 참조하십시오. |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | 이 속성에 대한 설명은 [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--)을(를) 참조하십시오. |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | 이 속성에 대한 설명은 [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--)을(를) 참조하십시오. |
+| [setTopPage(int value)](#setTopPage-int-) | 이 속성에 대한 설명은 [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+사용자 정의 도구 모음을 나타내는 MIME(다목적 인터넷 메일 확장) 인코딩된 Microsoft Visio 사용자 인터페이스(VSU) 파일입니다.
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+문서에 대한 사용자 정의 메뉴와 단축키를 정의하는 Microsoft Visio 사용자 인터페이스(.vsu) 파일의 이름을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+문서에 대한 사용자 정의 도구 모음 및 상태 표시줄을 정의하는 Microsoft Visio 사용자 인터페이스(.vsu) 파일의 이름을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+StyleSheet 요소의 ID를 지정합니다. 사용자가 그리기 도구를 사용하여 도형을 만들 때, 해당 도형은 지정된 StyleSheet 요소의 채우기 스타일을 상속합니다.
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+StyleSheet 요소의 ID를 지정합니다. 사용자가 가이드를 만들 때, 해당 가이드는 지정된 StyleSheet 요소의 가이드 스타일을 상속합니다.
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+StyleSheet 요소의 ID를 지정합니다. 사용자가 그리기 도구를 사용하여 도형을 만들 때, 해당 도형은 지정된 StyleSheet 요소의 선 스타일을 상속합니다.
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+StyleSheet 요소의 ID를 지정합니다. 사용자가 그리기 도구를 사용하여 도형을 만들 때, 해당 도형은 지정된 StyleSheet 요소의 텍스트 스타일을 상속합니다.
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+문서 또는 창에 대해 동적 그리드 기능이 활성화되어 있는지 지정합니다.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다.
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+사용자가 배경 페이지를 삭제하거나 편집하지 못하도록 방지되는지 지정합니다.
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+사용자가 마스터를 생성, 편집 또는 삭제하지 못하도록 방지하는지 지정합니다. 이 설정과 관계없이 사용자는 여전히 마스터 인스턴스를 생성할 수 있습니다.
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+사용자가 LockSelect 요소가 1로 설정된 도형을 선택하지 못하도록 방지되는지 지정합니다.
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+사용자가 스타일을 생성하거나 편집하지 못하도록 방지하는지 지정합니다. 그러나 이 설정과 관계없이 사용자는 여전히 스타일을 적용할 수 있습니다.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+SnapAngle 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다.
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Microsoft Visio에서 문서를 열 때 표시되어야 하는 페이지의 ID를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+이 속성에 대한 설명은 [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+이 속성에 대한 설명은 [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+이 속성에 대한 설명은 [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+이 속성에 대한 설명은 [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+이 속성에 대한 설명은 [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+이 속성에 대한 설명은 [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+이 속성에 대한 설명은 [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+이 속성에 대한 설명은 [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+이 속성에 대한 설명은 [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+이 속성에 대한 설명은 [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+이 속성에 대한 설명은 [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+이 속성에 대한 설명은 [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/documentsheet/_index.md
+++ b/korean/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 ShapeSheet 구조를 지정합니다.
+type: docs
+weight: 127
+url: /ko/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+문서의 ShapeSheet 구조를 지정합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | 문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 요소의 컬렉션을 포함합니다. |
+| [getConnections()](#getConnections--) | Connection 요소의 컬렉션을 포함합니다. |
+| [getDocProps()](#getDocProps--) | 문서의 미리보기 품질, 범위 및 출력 형식을 제어하는 요소를 포함합니다. |
+| [getFillStyle()](#getFillStyle--) | 이 스타일이 채우기 서식을 상속받는 StyleSheet 요소입니다. |
+| [getForeign()](#getForeign--) | Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다. |
+| [getForeignData()](#getForeignData--) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 요소들의 컬렉션을 포함합니다. |
+| [getLineStyle()](#getLineStyle--) | 이 스타일이 선 서식을 상속받는 StyleSheet 요소입니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getProps()](#getProps--) | Prop 요소들의 컬렉션을 포함합니다. |
+| [getReviewers()](#getReviewers--) | 문서 검토자에 대한 식별 정보를 포함하는 요소를 포함합니다. |
+| [getScratchs()](#getScratchs--) | Scratch 요소의 컬렉션을 포함합니다. |
+| [getTextStyle()](#getTextStyle--) | 이 스타일이 텍스트 서식을 상속받는 StyleSheet 요소입니다. |
+| [getUniqueID()](#getUniqueID--) | 도형을 식별하는 GUID(전역 고유 식별자)입니다. |
+| [getUsers()](#getUsers--) | User 요소의 컬렉션을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)을(를) 확인하십시오. |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)을(를) 확인하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/documentsheet\#getName--)을(를) 확인하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)을(를) 확인하십시오. |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)을(를) 확인하십시오. |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | 이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)을(를) 확인하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+문서의 미리보기 품질, 범위 및 출력 형식을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+이 스타일이 채우기 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체의 너비와 높이를 지정하는 요소를 포함합니다. 또한 객체 이미지가 경계 내에서 오프셋되는 거리를 지정하는 요소도 포함합니다.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+이 스타일이 선 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+문서 검토자에 대한 식별 정보를 포함하는 요소를 포함합니다.
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+이 스타일이 텍스트 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+도형을 식별하는 GUID(전역 고유 식별자)입니다.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/documentsheet\#getName--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/doublevalue/_index.md
+++ b/korean/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Aspose.Diagram for Java API 참조
+description: Double 값
+type: docs
+weight: 128
+url: /ko/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Double 값
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | 생성자. |
+| [DoubleValue()](#DoubleValue--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | Double 값. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | 이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--)을(를) 참조하십시오. |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--)을(를) 참조하십시오. |
+| [setValue(double value)](#setValue-double-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/doublevalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+| 단위 | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Double 값.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/doublevalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/korean/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+type: docs
+weight: 129
+url: /ko/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+type: docs
+weight: 130
+url: /ko/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | 그리기 페이지가 자동으로 크기가 조정됩니다. |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | 페이지가 자동으로 크기가 조정되는지는 DrawingSizeType 셀의 값에 따라 달라집니다. |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | 그리기 페이지가 자동으로 크기가 조정되지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+그리기 페이지가 자동으로 크기가 조정됩니다.
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+페이지가 자동으로 크기가 조정되는지는 DrawingSizeType 셀의 값에 따라 달라집니다. DrawingSizeType = 0인 경우(그리기 페이지 크기가 인쇄 페이지 크기와 동일함), 페이지가 자동으로 크기가 조정됩니다. DrawingSizeType 값이 0이 아닌 경우, 페이지가 자동으로 크기가 조정되지 않습니다.
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+그리기 페이지가 자동으로 크기가 조정되지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/korean/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 사용할 그리기 축척 유형을 지정합니다.
+type: docs
+weight: 131
+url: /ko/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+페이지에 사용할 그리기 축척 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지에 사용할 그리기 축척 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지에 사용할 그리기 축척 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 사용할 그리기 축척 유형을 지정합니다.
+type: docs
+weight: 132
+url: /ko/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+페이지에 사용할 그리기 축척 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | 건축 스케일. |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | 토목 공학 스케일. |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | 사용자 정의 스케일. |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | 기계 공학 스케일. |
+| [METRIC_SCALE](#METRIC-SCALE) | 미터법 스케일. |
+| [NO_SCALE](#NO-SCALE) | 스케일 없음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+건축 스케일.
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+토목 공학 스케일.
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+사용자 정의 스케일.
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+기계 공학 스케일.
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+미터법 스케일.
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+스케일 없음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/korean/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지의 그리기 크기를 지정합니다.
+type: docs
+weight: 133
+url: /ko/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+페이지의 그리기 크기를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지의 그리기 크기를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지의 그리기 크기를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지의 그리기 크기를 지정합니다.
+type: docs
+weight: 134
+url: /ko/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+페이지의 그리기 크기를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI 건축. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI 엔지니어링. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | 사용자 정의 페이지 크기. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | 사용자 정의 스케일 도면 크기. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | 페이지를 도면 내용에 맞게 맞춤. |
+| [METRIC_ISO](#METRIC-ISO) | 미터법 (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | 프린터와 동일. |
+| [STANDARD](#STANDARD) | 표준. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI 건축.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI 엔지니어링.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+사용자 정의 페이지 크기.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+사용자 정의 스케일 도면 크기.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+페이지를 도면 내용에 맞게 맞춤.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+미터법 (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+프린터와 동일.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+표준.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/korean/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 드롭 버튼에 표시되는 기호를 나타냅니다.
+type: docs
+weight: 135
+url: /ko/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+드롭 버튼에 표시되는 기호를 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ARROW](#ARROW) | 아래쪽 화살표가 있는 버튼을 표시합니다. |
+| [ELLIPSIS](#ELLIPSIS) | 줄임표(...)가 있는 버튼을 표시합니다. |
+| [PLAIN](#PLAIN) | 기호가 없는 버튼을 표시합니다. |
+| [REDUCE](#REDUCE) | 밑줄 문자와 같은 가로선이 있는 버튼을 표시합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+아래쪽 화살표가 있는 버튼을 표시합니다.
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+줄임표(...)가 있는 버튼을 표시합니다.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+기호가 없는 버튼을 표시합니다.
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+밑줄 문자와 같은 가로선이 있는 버튼을 표시합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/korean/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Aspose.Diagram for Java API 참조
+description: 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다.
+type: docs
+weight: 136
+url: /ko/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. 마우스 버튼을 놓으면 결과 연결자 모양은 이 설정의 영향을 받지 않습니다. 이 요소는 라우팅 가능한 연결자에는 적용되지 않습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. 마우스 버튼을 놓으면 결과 연결자 모양은 이 설정의 영향을 받지 않습니다. 이 요소는 라우팅 가능한 연결자에는 적용되지 않습니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/korean/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Aspose.Diagram for Java API 참조
+description: 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다.
+type: docs
+weight: 137
+url: /ko/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. 마우스 버튼을 놓으면 결과 연결자 모양은 이 설정의 영향을 받지 않습니다. 이 요소는 라우팅 가능한 연결자에는 적용되지 않습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | 직선 그대로 유지 (다리 없음). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | 드래그할 때 다섯 개의 다리를 표시합니다. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | 드래그할 때 세 개의 다리를 표시합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+직선 그대로 유지 (다리 없음).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+드래그할 때 다섯 개의 다리를 표시합니다.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+드래그할 때 세 개의 다리를 표시합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ellipse/_index.md
+++ b/korean/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: 타원
+second_title: Aspose.Diagram for Java API 참조
+description: 타원의 중심점과 타원 위의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다.
+type: docs
+weight: 138
+url: /ko/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+타원의 중심점 및 타원 위의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | [Ellipse](../../com.aspose.diagram/ellipse) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 타원 위 점의 x 좌표와 B 요소가 나타내는 y 좌표가 쌍을 이룹니다. |
+| [getB()](#getB--) | 타원 위 점의 y 좌표와 A 요소가 나타내는 x 좌표가 쌍을 이룹니다. |
+| [getC()](#getC--) | 타원 위 점의 x 좌표와 D 요소가 나타내는 y 좌표가 쌍을 이룹니다. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 타원 위 점의 y 좌표와 C 요소가 나타내는 x 좌표가 쌍을 이룹니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 타원 중심의 x 좌표입니다. |
+| [getY()](#getY--) | 타원 중심의 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/ellipse\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/ellipse\#getB--)을(를) 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/ellipse\#getC--)을(를) 참조하십시오. |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/ellipse\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/ellipse\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/ellipse\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/ellipse\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/ellipse\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+[Ellipse](../../com.aspose.diagram/ellipse) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+타원 위 점의 x 좌표와 B 요소가 나타내는 y 좌표가 쌍을 이룹니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+타원 위 점의 y 좌표와 A 요소가 나타내는 x 좌표가 쌍을 이룹니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+타원 위 점의 x 좌표와 D 요소가 나타내는 y 좌표가 쌍을 이룹니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+타원 위 점의 y 좌표와 C 요소가 나타내는 x 좌표가 쌍을 이룹니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+타원 중심의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+타원 중심의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/ellipse\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/ellipse\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/ellipse\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/ellipse\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/ellipse\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/ellipse\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/ellipse\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/ellipse\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/korean/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Ellipse 컬렉션.
+type: docs
+weight: 139
+url: /ko/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+Ellipse 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/korean/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Aspose.Diagram for Java API 참조
+description: 타원 호에 대한 정보를 지정하는 요소를 포함합니다.
+type: docs
+weight: 140
+url: /ko/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+타원 호에 대한 정보를 지정하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | 다음 [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 호의 제어점 x좌표. |
+| [getB()](#getB--) | 호의 제어점 y좌표. |
+| [getC()](#getC--) | 부모의 x축에 대한 호의 장축 각도. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 호의 장축과 단축의 비율. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 타원형 호 끝 정점의 x좌표. |
+| [getY()](#getY--) | 타원형 호 끝 정점의 y좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)을(를) 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)을(를) 참조하십시오. |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은, [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) 를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+다음 [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+호의 제어점의 x좌표입니다. 제어점은 호의 시작 정점과 끝 정점 사이 중간 정도에 위치하는 것이 가장 좋습니다. 그렇지 않으면 제어점을 통과하기 위해 호가 극도로 커질 수 있으며, 예측할 수 없는 결과가 발생할 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+호의 제어점 y좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+부모의 x축에 대한 호의 장축 각도.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+호의 장축과 단축의 비율입니다. 일반적인 의미와 달리 장축이 단축보다 크지 않아도 되므로 이 비율이 1보다 커야 할 필요는 없습니다. 이 요소를 0 이하 또는 1000 초과 값으로 설정하면 예측할 수 없는 결과가 발생할 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+타원형 호 끝 정점의 x좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+타원형 호 끝 정점의 y좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은, [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/korean/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: EllipticalArcTo 컬렉션.
+type: docs
+weight: 141
+url: /ko/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+EllipticalArcTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/korean/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Aspose.Diagram for Java API 참조
+description: Emf 메타파일 렌더링 설정.
+type: docs
+weight: 142
+url: /ko/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Emf 메타파일 렌더링 설정.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Only rendering Emf records. |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | Prefer rendering EmfPlus records. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Only rendering Emf records.
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+Prefer rendering EmfPlus records.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/encoding/_index.md
+++ b/korean/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Aspose.Diagram for Java API 참조
+description: 문자 인코딩을 나타냅니다.
+type: docs
+weight: 143
+url: /ko/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+문자 인코딩을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | 지정된 Encoding 객체가 현재 인스턴스와 같은지 여부를 결정합니다. |
+| [equals(Object o)](#equals-java.lang.Object-) | 지정된 Object가 현재 인스턴스와 같은지 여부를 결정합니다. |
+| [getASCII()](#getASCII--) | ASCII (7비트) 문자 집합에 대한 인코딩을 가져옵니다. |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | 빅 엔디안 바이트 순서를 사용한 UTF-16 형식에 대한 인코딩을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | 운영 체제의 현재 ANSI 코드 페이지에 대한 인코딩을 가져옵니다. |
+| [getEncoding(int codePage)](#getEncoding-int-) | 지정된 코드 페이지 식별자와 연결된 인코딩을 반환합니다. |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | 지정된 문자 집합 이름과 연결된 인코딩을 반환합니다. |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | 지정된 문자 집합 객체와 연결된 인코딩을 반환합니다. |
+| [getUTF7()](#getUTF7--) | UTF-7 형식에 대한 인코딩을 가져옵니다. |
+| [getUTF8()](#getUTF8--) | UTF-8 형식에 대한 인코딩을 가져옵니다. |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | UTF-8 식별자 없이 UTF-8 형식에 대한 인코딩을 가져옵니다. |
+| [getUnicode()](#getUnicode--) | 리틀 엔디안 바이트 순서를 사용한 UTF-16 형식에 대한 인코딩을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+지정된 Encoding 객체가 현재 인스턴스와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | 현재 인스턴스와 비교할 Encoding 객체입니다. |
+
+**Returns:**
+boolean - 값이 현재 인스턴스와 같으면 true; 그렇지 않으면 false.
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+지정된 Object가 현재 인스턴스와 같은지 여부를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | 현재 인스턴스와 비교할 객체. |
+
+**Returns:**
+boolean - 값이 Encoding의 인스턴스이며 현재 인스턴스와 같으면 true; 그렇지 않으면 false.
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+ASCII (7비트) 문자 집합에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+빅 엔디안 바이트 순서를 사용한 UTF-16 형식에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+운영 체제의 현재 ANSI 코드 페이지에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+지정된 코드 페이지 식별자와 연결된 인코딩을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| codePage | int | 선호하는 인코딩의 코드 페이지 식별자. -or- 0은 기본 인코딩을 사용합니다. |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+지정된 문자 집합 이름과 연결된 인코딩을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| charsetName | java.lang.String | 지정된 문자 집합 이름 |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+지정된 문자 집합 객체와 연결된 인코딩을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | 지정된 문자 집합 객체 |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+UTF-7 형식에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+UTF-8 형식에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+UTF-8 식별자 없이 UTF-8 형식에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+리틀 엔디안 바이트 순서를 사용한 UTF-16 형식에 대한 인코딩을 가져옵니다.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/event/_index.md
+++ b/korean/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: 이벤트
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다.
+type: docs
+weight: 144
+url: /ko/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getEventDblClick()](#getEventDblClick--) | 도형을 더블 클릭할 때 평가되는 이벤트 요소입니다. |
+| [getEventDrop()](#getEventDrop--) | 도형이 인스턴스로 또는 복제·붙여넣기된 형태로 그리기 페이지에 놓일 때 평가되는 이벤트 요소입니다. |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop. |
+| [getEventXFMod()](#getEventXFMod--) | 도형의 페이지 상 위치 또는 방향이 변환될 때 평가되는 이벤트 요소입니다. |
+| [getTheData()](#getTheData--) | 향후 사용을 위해 예약되었습니다. |
+| [getTheText()](#getTheText--) | 도형의 텍스트 또는 텍스트 구성이 변경될 때 평가되는 이벤트 요소입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/event\#getDel--)을 참조하십시오. |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)을 참조하십시오. |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)을 참조하십시오. |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)을 참조하십시오. |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)을 참조하십시오. |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTheData()](../../com.aspose.diagram/event\#getTheData--)을 참조하십시오. |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTheText()](../../com.aspose.diagram/event\#getTheText--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+도형을 더블 클릭할 때 평가되는 이벤트 요소입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+도형이 인스턴스로 또는 복제·붙여넣기된 형태로 그리기 페이지에 놓일 때 평가되는 이벤트 요소입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+도형의 페이지 상 위치 또는 방향이 변환될 때 평가되는 이벤트 요소입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+향후 사용을 위해 예약되었습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+도형의 텍스트 또는 텍스트 구성이 변경될 때 평가되는 이벤트 요소입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/event\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTheData()](../../com.aspose.diagram/event\#getTheData--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTheText()](../../com.aspose.diagram/event\#getTheText--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/eventitem/_index.md
+++ b/korean/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Aspose.Diagram for Java API 참조
+description: 이벤트 코드를 캡슐화합니다.
+type: docs
+weight: 145
+url: /ko/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+이벤트 코드를 캡슐화합니다. EventItem 요소는 두 가지 종류의 동작을 트리거할 수 있습니다: 애드온을 실행하거나, 이벤트에 대한 알림을 호출 프로그램에 보낼 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [EventItem()](#EventItem--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | 상위 EventItem 요소의 동작 코드를 지정합니다. EventItem 요소가 DatadiagramML 파일에 저장되려면 지속 가능해야 합니다. |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | 이벤트가 활성화되었는지 비활성화되었는지를 나타내는 플래그를 나타냅니다. |
+| [getEventCode()](#getEventCode--) | 애드온을 트리거하는 이벤트를 나타내는 코드입니다. |
+| [getID()](#getID--) | 이벤트의 ID입니다. |
+| [getTarget()](#getTarget--) | 이벤트의 대상(target)을 지정합니다. |
+| [getTargetArgs()](#getTargetArgs--) | 이벤트 대상에 전달될 인수를 포함하는 문자열을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | 이 속성에 대한 설명은 [getAction()](../../com.aspose.diagram/eventitem\#getAction--)을(를) 참조하십시오. |
+| [setEnabled(int value)](#setEnabled-int-) | 이 속성에 대한 설명은 [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)을(를) 참조하십시오. |
+| [setEventCode(int value)](#setEventCode-int-) | 이 속성에 대한 설명은 [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/eventitem\#getID--)을(를) 참조하십시오. |
+| [setTarget(String value)](#setTarget-java.lang.String-) | 이 속성에 대한 설명은 [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)을(를) 참조하십시오. |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | 이 속성에 대한 설명은 [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+상위 EventItem 요소의 동작 코드를 지정합니다. EventItem 요소가 DatadiagramML 파일에 저장되려면 지속 가능해야 합니다. 현재, 지속 가능한 이벤트가 가질 수 있는 유효한 동작 코드는 1 (ONEVENT_ACT_RUNADDON) 하나뿐입니다.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+이벤트가 활성화되었는지 비활성화되었는지를 나타내는 플래그를 나타냅니다.
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+애드온을 트리거하는 이벤트를 나타내는 코드입니다. 이벤트 코드에 대한 자세한 내용은 Microsoft Visio 2007 Automation Reference의 Event Codes를 참조하십시오.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+이벤트의 ID입니다.
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+이벤트의 대상(target)을 지정합니다.
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+이벤트 대상에 전달될 인수를 포함하는 문자열을 지정합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+이 속성에 대한 설명은 [getAction()](../../com.aspose.diagram/eventitem\#getAction--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+이 속성에 대한 설명은 [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+이 속성에 대한 설명은 [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/eventitem\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+이 속성에 대한 설명은 [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+이 속성에 대한 설명은 [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/korean/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Aspose.Diagram for Java API 참조
+description: EventItem 컬렉션.
+type: docs
+weight: 146
+url: /ko/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+EventItem 컬렉션.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | 컬렉션에 eventItem을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | 컬렉션에서 eventItem을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+생성자.
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+컬렉션에 eventItem을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+컬렉션에서 eventItem을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/field/_index.md
+++ b/korean/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: 필드
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트에 삽입된 함수와 수식을 지정하는 요소를 포함합니다.
+type: docs
+weight: 147
+url: /ko/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+도형 텍스트에 삽입된 함수와 수식을 지정하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Field()](#Field--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDisplayValue()](#getDisplayValue--) | 이 필드의 서식이 지정된 문자열 값을 가져옵니다. |
+| [getEditMode()](#getEditMode--) | 향후 사용을 위해 예약되었습니다. |
+| [getFormat()](#getFormat--) | 서식 요소는 문자열, 숫자, 날짜 또는 시간, 기간, 통화인 텍스트 필드의 서식을 지정합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getObjectKind()](#getObjectKind--) | 텍스트 필드 유형을 나타냅니다. |
+| [getType()](#getType--) | Type은 텍스트 필드 값의 데이터 유형을 지정합니다. |
+| [getUICat()](#getUICat--) | Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 범주를 지정합니다. |
+| [getUICod()](#getUICod--) | Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 코드를 지정합니다. |
+| [getUIFmt()](#getUIFmt--) | Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 형식을 지정합니다. |
+| [getValue()](#getValue--) | 텍스트 필드의 값을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/field\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/field\#getIX--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+이 필드의 서식이 지정된 문자열 값을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+향후 사용을 위해 예약되었습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+Format 요소는 문자열, 숫자, 날짜 또는 시간, 기간, 통화인 텍스트 필드의 서식을 지정합니다. 텍스트 필드 유형은 해당 Type 요소에서 지정됩니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+텍스트 필드 유형을 나타냅니다.
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 범주를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 코드를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Visio 2000 이전 버전의 Microsoft Visio에서 삽입된 필드의 형식을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+텍스트 필드의 값을 포함합니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/field\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/field\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/korean/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 필드 컬렉션.
+type: docs
+weight: 148
+url: /ko/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+필드 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Add the Field object in the collection. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Remove the Field object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Add the Field object in the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Remove the Field object from the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/filefontsource/_index.md
+++ b/korean/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Aspose.Diagram for Java API 참조
+description: 파일 시스템에 저장된 단일 TrueType 글꼴 파일을 나타냅니다.
+type: docs
+weight: 149
+url: /ko/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+파일 시스템에 저장된 단일 TrueType 글꼴 파일을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | 폰트 파일 경로. |
+| [getType()](#getType--) | 폰트 소스의 유형을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 폰트 파일 경로 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+폰트 파일 경로.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+폰트 소스의 유형을 반환합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/korean/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Aspose.Diagram for Java API 참조
+description: 파일 형식 감지 메서드가 반환한 데이터를 포함합니다.
+type: docs
+weight: 150
+url: /ko/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+[FileFormatUtil](../../com.aspose.diagram/fileformatutil) 파일 형식 감지 메서드가 반환하는 데이터를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | 감지된 파일 형식을 가져옵니다. |
+| [getLoadFormat()](#getLoadFormat--) | 감지된 로드 형식을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+감지된 파일 형식을 가져옵니다.
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+감지된 로드 형식을 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fileformattype/_index.md
+++ b/korean/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Aspose.Diagram for Java API 참조
+description: 스프레드시트 파일 형식 유형을 열거합니다
+type: docs
+weight: 151
+url: /ko/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+스프레드시트 파일 형식 유형을 열거합니다
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CSV](#CSV) | CSV 파일을 나타냅니다. |
+| [DIF](#DIF) | 데이터 교환 형식. |
+| [DOC](#DOC) | DOC 파일을 나타냅니다. |
+| [DOCM](#DOCM) | DOCM 파일을 나타냅니다. |
+| [DOCX](#DOCX) | DOCX 파일을 나타냅니다. |
+| [DOTM](#DOTM) | dotm 파일을 나타냅니다. |
+| [DOTX](#DOTX) | dotx 파일을 나타냅니다. |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Excel 2003 xml 파일을 나타냅니다. |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Excel97-2003 xls 파일을 나타냅니다. |
+| [HTML](#HTML) | html 파일을 나타냅니다. |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | 이메일 파일을 나타냅니다. |
+| [MS_EQUATION](#MS-EQUATION) | MS Equation 3.0 개체를 나타냅니다. |
+| [ODS](#ODS) | ods 파일을 나타냅니다. |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | 내장된 네이티브 개체를 나타냅니다. |
+| [OOXML](#OOXML) | Office Open XML 파일(예: xlsx, docx, pptx 등)을 나타냅니다. |
+| [PDF](#PDF) | Pdf 파일을 나타냅니다. |
+| [POTM](#POTM) | Potm 파일을 나타냅니다. |
+| [POTX](#POTX) | Potx 파일을 나타냅니다. |
+| [PPSM](#PPSM) | ppsm 파일을 나타냅니다. |
+| [PPSX](#PPSX) | ppsx 파일을 나타냅니다. |
+| [PPT](#PPT) | ppt 파일을 나타냅니다. |
+| [PPTM](#PPTM) | pptm 파일을 나타냅니다. |
+| [PPTX](#PPTX) | pptx 파일을 나타냅니다. |
+| [SLDX](#SLDX) | sldx 파일을 나타냅니다. |
+| [SVG](#SVG) | svg 파일을 나타냅니다. |
+| [TAB_DELIMITED](#TAB-DELIMITED) | 탭 구분 텍스트 파일을 나타냅니다. |
+| [TIFF](#TIFF) | TIFF 파일을 나타냅니다. |
+| [UNKNOWN](#UNKNOWN) | 인식되지 않은 형식이며, 로드할 수 없습니다. |
+| [VDW](#VDW) | MS Visio VDW 웹 도면 형식입니다. |
+| [VDX](#VDX) | MS Visio VDX XML 형식. |
+| [VSD](#VSD) | MS Visio VSD 바이너리 형식입니다. |
+| [VSDM](#VSDM) | MS Visio 2013 VSDM 파일 형식. |
+| [VSDX](#VSDX) | MS Visio 2013 VSDX 파일 형식. |
+| [VSS](#VSS) | MS Visio VSS 바이너리 스텐실 형식. |
+| [VSSM](#VSSM) | MS Visio 2013 VSSM 파일 형식. |
+| [VSSX](#VSSX) | MS Visio 2013 VSSX 파일 형식. |
+| [VST](#VST) | MS Visio VST 바이너리 템플릿 형식. |
+| [VSTM](#VSTM) | MS Visio 2013 VSTM 파일 형식. |
+| [VSTX](#VSTX) | MS Visio 2013 VSTX 템플릿 파일 형식. |
+| [VSX](#VSX) | MS Visio VSX xml 스텐실 형식. |
+| [VTX](#VTX) | MS Visio VTX xml 템플릿 형식. |
+| [XLAM](#XLAM) | addinMacro-enabled 템플릿 xltm 파일을 나타냅니다. |
+| [XLSB](#XLSB) | xlsb 파일을 나타냅니다. |
+| [XLSM](#XLSM) | 매크로를 지원하는 xlsm 파일을 나타냅니다. |
+| [XLSX](#XLSX) | xlsx 파일을 나타냅니다. |
+| [XLTM](#XLTM) | 매크로 사용 가능 템플릿 xltm 파일을 나타냅니다. |
+| [XLTX](#XLTX) | 템플릿 xltx 파일을 나타냅니다. |
+| [XML](#XML) | 간단한 xml 파일을 나타냅니다. |
+| [XPS](#XPS) | XPS 파일을 나타냅니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+CSV 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+데이터 교환 형식.
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+doc 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+docm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+docx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+dotm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+dotx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Excel 2003 xml 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Excel97-2003 xls 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+html 파일을 나타냅니다.
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+이메일 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+MS Equation 3.0 객체를 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+ods 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+임베디드 네이티브 객체를 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+office open xml 파일(xlsx, docx, pptx 등)을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다. office open xml 파일이 암호화된 경우 xlsx, docx, pptx 등으로 감지되지 않을 수 있습니다.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf 파일을 나타냅니다.
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Potm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Potx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+ppsm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+ppsx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형를 감지하기 위해서만 사용됩니다.
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+ppt 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+pptm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+pptx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+sldx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+svg 파일을 나타냅니다.
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+탭 구분 텍스트 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF 파일을 나타냅니다.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+인식되지 않은 형식이며, 로드할 수 없습니다.
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio VDW 웹 도면 형식입니다.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML 형식.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio VSD 바이너리 형식입니다.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio 2013 VSDM 파일 형식.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 VSDX 파일 형식.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio VSS 바이너리 스텐실 형식.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio 2013 VSSM 파일 형식.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 VSSX 파일 형식.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio VST 바이너리 템플릿 형식.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio 2013 VSTM 파일 형식.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 VSTX 템플릿 파일 형식.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio VSX xml 스텐실 형식.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio VTX xml 템플릿 형식.
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+addinMacro-enabled 템플릿 xltm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+xlsb 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+매크로를 활성화하는 xlsm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+xlsx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+매크로 활성화 템플릿 xltm 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+템플릿 xltx 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+간단한 xml 파일을 나타냅니다. 파일 형식은 지원되지 않으며 파일 유형을 감지하기 위해서만 사용됩니다.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+XPS 파일을 나타냅니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/korean/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Aspose.Diagram for Java API 참조
+description: 파일 형식 열거형을 문자열이나 파일 확장자로 변환하고 다시 변환하는 유틸리티 메서드를 제공합니다.
+type: docs
+weight: 152
+url: /ko/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+파일 형식 열거형을 문자열이나 파일 확장자로 변환하고 다시 변환하는 유틸리티 메서드를 제공합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | 스트림에 저장된 Visio 형식에 대한 정보를 감지하고 반환합니다. |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | 파일에 저장된 Visio 형식에 대한 정보를 감지하고 반환합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+스트림에 저장된 Visio 형식에 대한 정보를 감지하고 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 스트림 |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+파일에 저장된 Visio 형식에 대한 정보를 감지하고 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| filePath | java.lang.String | 파일 경로. |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fill/_index.md
+++ b/korean/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: 채우기
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 및 도형 그림자에 대한 현재 채우기 서식 값을 포함하며, 패턴 전경색 및 배경색을 포함합니다.
+type: docs
+weight: 153
+url: /ko/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getFillBkgnd()](#getFillBkgnd--) | 도형 채우기 패턴 배경에 사용되는 색상을 지정합니다. |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | 도형 채우기 패턴 배경(채우기) 색상의 투명도 수준을 지정합니다. 0(완전히 불투명)에서 1(완전히 투명)까지. |
+| [getFillForegnd()](#getFillForegnd--) | 도형 채우기 패턴 전경(스트로크)에 사용되는 색상을 지정합니다. |
+| [getFillForegndTrans()](#getFillForegndTrans--) | 도형 채우기 패턴 전경(채우기) 색상의 투명도 수준을 지정합니다. 0(완전히 불투명)에서 1(완전히 투명)까지. |
+| [getFillPattern()](#getFillPattern--) | 도형의 채우기 패턴을 지정합니다. |
+| [getGradientFill()](#getGradientFill--) | 도형에 대한 현재 그라디언트 채우기 서식 값을 포함합니다. |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | 도형 그림자의 흐림 크기를 지정합니다. |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | 도형 그림자의 비스듬한 방향 각도를 지정합니다. |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | 도형 그림자가 도형으로부터 수평으로 오프셋되는 거리를 페이지 단위로 결정합니다. |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | 도형 그림자가 도형으로부터 수직으로 오프셋되는 거리를 페이지 단위로 결정합니다. |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | 도형 그림자를 확대하거나 축소할 수 있는 비율을 지정합니다. |
+| [getShapeShdwShow()](#getShapeShdwShow--) | 도형의 그림자 유형을 지정합니다. |
+| [getShapeShdwType()](#getShapeShdwType--) | 도형의 그림자 유형을 지정합니다. |
+| [getShdwBkgnd()](#getShdwBkgnd--) | 도형 그림자 채우기 패턴 배경(채우기)에 사용되는 색상을 지정합니다. |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | 도형 그림자 채우기 패턴 배경(채우기)의 투명도 수준을 지정합니다. 0.0(완전히 불투명)에서 1.0(완전히 투명)까지. |
+| [getShdwForegnd()](#getShdwForegnd--) | 도형 그림자 채우기 패턴 전경(스트로크)에 사용되는 색상을 지정합니다. |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | 도형 그림자 채우기 패턴 전경(스트로크)의 투명도 수준을 지정합니다. 0.0(완전히 불투명)에서 1.0(완전히 투명)까지. |
+| [getShdwPattern()](#getShdwPattern--) | 도형 그림자의 채우기 패턴을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/fill\#getDel--)을 참조하십시오. |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)을 참조하십시오. |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)을 참조하십시오. |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)을 참조하십시오. |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)을 참조하십시오. |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)을 참조하십시오. |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)을 참조하십시오. |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)을 참조하십시오. |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)을(를) 참조하십시오. |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)을(를) 참조하십시오. |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)을(를) 참조하십시오. |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | 이 속성에 대한 설명은 [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)을(를) 참조하십시오. |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | 이 속성에 대한 설명은 [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)을(를) 참조하십시오. |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)을(를) 참조하십시오. |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)을(를) 참조하십시오. |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)을(를) 참조하십시오. |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)을(를) 참조하십시오. |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+도형 채우기 패턴 배경에 사용되는 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+도형 채우기 패턴 배경(채우기) 색상의 투명도 수준을 지정합니다. 0(완전히 불투명)에서 1(완전히 투명)까지.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+도형 채우기 패턴 전경(스트로크)에 사용되는 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+도형 채우기 패턴 전경(채우기) 색상의 투명도 수준을 지정합니다. 0(완전히 불투명)에서 1(완전히 투명)까지.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+도형의 채우기 패턴을 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+도형에 대한 현재 그라디언트 채우기 서식 값을 포함합니다.
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+도형의 그림자 흐림 크기를 지정합니다. 현재 흐림을 그릴 수는 없지만, 이제 vsdx에서 파싱할 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+도형 그림자의 비스듬한 방향 각도를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+도형 그림자가 도형으로부터 수평으로 오프셋되는 거리를 페이지 단위로 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+도형 그림자가 도형으로부터 수직으로 오프셋되는 거리를 페이지 단위로 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+도형 그림자를 확대하거나 축소할 수 있는 비율을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+도형의 그림자 유형을 지정합니다.
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+도형의 그림자 유형을 지정합니다.
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+도형 그림자 채우기 패턴 배경(채우기)에 사용되는 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+도형 그림자 채우기 패턴 배경(채우기)의 투명도 수준을 지정합니다. 0.0(완전히 불투명)에서 1.0(완전히 투명)까지.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+도형 그림자 채우기 패턴 전경(스트로크)에 사용되는 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+도형 그림자 채우기 패턴 전경(스트로크)의 투명도 수준을 지정합니다. 0.0(완전히 불투명)에서 1.0(완전히 투명)까지.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+도형 그림자의 채우기 패턴을 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/fill\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+이 속성에 대한 설명은 [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/filltype/_index.md
+++ b/korean/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Aspose.Diagram for Java API 참조
+description: 채우기 형식 유형.
+type: docs
+weight: 154
+url: /ko/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+채우기 형식 유형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | 자동 서식 유형을 나타냅니다. |
+| [GRADIENT](#GRADIENT) | 그라디언트 채우기 형식. |
+| [NONE](#NONE) | 없음 서식 유형을 나타냅니다. |
+| [PATTERN](#PATTERN) | 패턴 채우기 형식. |
+| [SOLID](#SOLID) | 단색 채우기 형식. |
+| [TEXTURE](#TEXTURE) | 텍스처 채우기 형식. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+자동 서식 유형을 나타냅니다.
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+그라디언트 채우기 형식.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+없음 서식 유형을 나타냅니다.
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+패턴 채우기 형식.
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+단색 채우기 형식.
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+텍스처 채우기 형식.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fld/_index.md
+++ b/korean/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Aspose.Diagram for Java API 참조
+description: 해당 Field 요소에 대한 텍스트 필드 삽입 지점을 나타냅니다.
+type: docs
+weight: 155
+url: /ko/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+해당 Field 요소에 대한 텍스트 필드 삽입 지점을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int | 부모 요소 Shape 내에 있는 요소 Field의 0부터 시작하는 인덱스입니다. |
+| shape | [Shape](../../com.aspose.diagram/shape) | 도형. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/korean/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 두 배 포인트 숫자 컬렉션을 포함합니다
+type: docs
+weight: 156
+url: /ko/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+두 배 포인트 숫자 컬렉션을 포함합니다
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(double number)](#add-double-) | 컬렉션에 배수 포인트 번호를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | 컬렉션에서 배수 포인트 번호를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+생성자.
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+컬렉션에 배수 포인트 번호를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 숫자 | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+컬렉션에서 배수 포인트 번호를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 숫자 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/korean/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Aspose.Diagram for Java API 참조
+description: TrueType 글꼴 파일을 포함하는 폴더를 나타냅니다.
+type: docs
+weight: 157
+url: /ko/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+TrueType 글꼴 파일을 포함하는 폴더를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | 폰트 폴더 경로. |
+| [getScanSubFolders()](#getScanSubFolders--) | 하위 폴더를 스캔할지 여부를 결정합니다. |
+| [getType()](#getType--) | 폰트 소스의 유형을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| folderPath | java.lang.String | 폰트 폴더 경로 |
+| scanSubfolders | boolean | 하위 폴더를 스캔할지 여부를 결정합니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+폰트 폴더 경로.
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+하위 폴더를 스캔할지 여부를 결정합니다.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+폰트 소스의 유형을 반환합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/font/_index.md
+++ b/korean/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: 글꼴
+second_title: Aspose.Diagram for Java API 참조
+description: 글꼴에 대한 정보를 포함합니다.
+type: docs
+weight: 158
+url: /ko/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+글꼴에 대한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Font()](#Font--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | 글꼴이 지원하는 문자 집합. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | 다음 항목을 나타내는 플래그: 누락된 글꼴, 기본 글꼴, 아시아 글꼴, 복합 글꼴, 수직 글꼴 및 글꼴 유형. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 ID. |
+| [getName()](#getName--) | UTF-16 유니코드 문자열로 표시된 글꼴 이름. |
+| [getPanos()](#getPanos--) | 글꼴의 파노스 서명. |
+| [getUnicodeRanges()](#getUnicodeRanges--) | 글꼴이 지원하는 유니코드 범위. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | 이 속성에 대한 설명은 [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)를 참조하십시오. |
+| [setFlags(int value)](#setFlags-int-) | 이 속성에 대한 설명은 [getFlags()](../../com.aspose.diagram/font\#getFlags--)를 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/font\#getID--)를 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/font\#getName--)를 참조하십시오. |
+| [setPanos(String value)](#setPanos-java.lang.String-) | 이 속성에 대한 설명은 [getPanos()](../../com.aspose.diagram/font\#getPanos--)를 참조하십시오. |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | 이 속성에 대한 설명은 [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+글꼴이 지원하는 문자 집합.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+다음 항목을 나타내는 플래그: 누락된 글꼴, 기본 글꼴, 아시아 글꼴, 복합 글꼴, 수직 글꼴 및 글꼴 유형.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 ID.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+UTF-16 유니코드 문자열로 표시된 글꼴 이름.
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+글꼴의 파노스 서명. 파노스는 시각적 특성에 따라 서체를 분류하는 시스템입니다.
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+글꼴이 지원하는 유니코드 범위.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+이 속성에 대한 설명은 [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+이 속성에 대한 설명은 [getFlags()](../../com.aspose.diagram/font\#getFlags--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/font\#getID--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/font\#getName--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+이 속성에 대한 설명은 [getPanos()](../../com.aspose.diagram/font\#getPanos--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+이 속성에 대한 설명은 [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fontcollection/_index.md
+++ b/korean/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Font 요소의 컬렉션을 포함합니다.
+type: docs
+weight: 159
+url: /ko/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Font 요소의 컬렉션을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | 컬렉션에 Font 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getFont(int ID)](#getFont-int-) | Gets the element at the specified ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | 컬렉션에서 Font 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+생성자.
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+컬렉션에 Font 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int | int요소의 부모 요소 내에서 해당 요소의 ID. |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+컬렉션에서 Font 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/korean/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Aspose.Diagram for Java API 참조
+description: 글꼴 설정을 지정합니다
+type: docs
+weight: 160
+url: /ko/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+글꼴 설정을 지정합니다
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | 기본 글꼴 이름. |
+| [getFontSources()](#getFontSources--) | 소스 목록을 포함하는 배열의 복사본을 가져옵니다. |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | 원본 글꼴이 없을 경우 사용할 글꼴 대체 이름을 포함하는 배열을 반환합니다. |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | 글꼴이 없고 해당 글꼴의 대체가 설정되지 않은 경우 시스템 글꼴 대체를 먼저 사용할지 여부를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)을(를) 참조하십시오. |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | 글꼴 폴더를 설정합니다. |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | 글꼴 폴더들을 설정합니다. |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | 글꼴 소스를 설정합니다. |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | 주어진 원본 글꼴 이름에 대한 글꼴 대체 이름. |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | 이 속성에 대한 설명은 [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+기본 글꼴 이름.
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+소스 목록을 포함하는 배열의 복사본을 가져옵니다.
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+원본 글꼴이 없을 경우 사용할 글꼴 대체 이름을 포함하는 배열을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - 원본 글꼴이 제공되지 않을 경우 사용할 글꼴 대체 이름을 포함하는 배열입니다.
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+글꼴이 제공되지 않고 해당 글꼴의 대체가 설정되지 않은 경우 시스템 글꼴 대체를 먼저 사용할지 여부를 지정합니다. 예: Ubuntu에서는 "Arial" 글꼴이 일반적으로 "Liberation Sans"로 대체됩니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+글꼴 폴더를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fontFolder | java.lang.String | TrueType 글꼴을 포함하는 폴더입니다. |
+| recursive | boolean | 하위 폴더를 스캔할지 여부를 결정합니다. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+글꼴 폴더들을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | TrueType 글꼴을 포함하는 폴더들입니다. |
+| recursive | boolean | 하위 폴더를 스캔할지 여부를 결정합니다. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+글꼴 소스를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | TrueType 글꼴을 포함하는 소스 배열입니다. |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+주어진 원본 글꼴 이름에 대한 글꼴 대체 이름.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| originalFontName | java.lang.String | 원본 글꼴 이름입니다. |
+| substituteFontNames | java.lang.String[] | 원본 글꼴이 제공되지 않을 경우 사용할 글꼴 대체 이름 목록입니다. |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/korean/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Aspose.Diagram for Java API 참조
+description: 다양한 글꼴 소스를 지정할 수 있게 하는 클래스들을 위한 추상 기본 클래스입니다.
+type: docs
+weight: 161
+url: /ko/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+다양한 글꼴 소스를 지정할 수 있게 하는 클래스들을 위한 추상 기본 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | 폰트 소스의 유형을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+폰트 소스의 유형을 반환합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/korean/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Aspose.Diagram for Java API 참조
+description: 글꼴 소스 유형을 지정합니다.
+type: docs
+weight: 162
+url: /ko/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+글꼴 소스 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | 폰트 파일이 포함된 폴더를 나타냅니다. |
+| [FONT_FILE](#FONT-FILE) | 단일 폰트 파일을 나타냅니다. |
+| [MEMORY_FONT](#MEMORY-FONT) | 메모리 내 단일 폰트를 나타냅니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+폰트 파일이 포함된 폴더를 나타냅니다.
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+단일 폰트 파일을 나타냅니다.
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+메모리 내 단일 폰트를 나타냅니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/foreign/_index.md
+++ b/korean/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: 외부
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다.
+type: docs
+weight: 163
+url: /ko/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체의 너비와 높이를 지정하는 요소를 포함합니다. 또한 객체 이미지가 경계 내에서 오프셋되는 거리를 지정하는 요소도 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getImgHeight()](#getImgHeight--) | 객체 경계 내에서 객체 이미지의 높이를 결정합니다. |
+| [getImgOffsetX()](#getImgOffsetX--) | 객체 경계 원점으로부터 객체가 수평으로 오프셋되는 거리를 결정합니다. |
+| [getImgOffsetY()](#getImgOffsetY--) | 객체 경계 원점으로부터 객체가 수직으로 오프셋되는 거리를 결정합니다. |
+| [getImgWidth()](#getImgWidth--) | 객체 경계 내에서 객체 이미지의 너비를 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/foreign\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+객체 경계 내 이미지의 높이를 결정합니다. 기본 수식은: F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+객체 경계 원점으로부터 객체가 수평으로 오프셋되는 거리를 결정합니다. 기본값은 0이며, 기본 수식은 F="ImgWidth\*0"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+객체 경계 원점으로부터 객체가 수직으로 오프셋되는 거리를 결정합니다. 기본값은 0이며, 기본 수식은 F="ImgHeight\*0"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+객체 경계 내 이미지의 너비를 결정합니다. 기본 수식은: F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/foreign\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/foreigndata/_index.md
+++ b/korean/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Aspose.Diagram for Java API 참조
+description: Windows 메타파일 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME Multipurpose Internet Mail Extensions 인코딩 BLOB을 포함합니다.
+type: docs
+weight: 164
+url: /ko/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | 이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. |
+| [getCompressionType()](#getCompressionType--) | 이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. |
+| [getExtentX()](#getExtentX--) | 이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. |
+| [getExtentY()](#getExtentY--) | 이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. |
+| [getForeignType()](#getForeignType--) | 데이터 유형. |
+| [getImageData()](#getImageData--) | OLE 객체의 이미지를 바이트 배열로 나타냅니다. |
+| [getMappingMode()](#getMappingMode--) | 이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. |
+| [getObjectData()](#getObjectData--) | 임베드된 OLE 객체 데이터를 바이트 배열로 나타냅니다. |
+| [getObjectHeight()](#getObjectHeight--) | 이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다. |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | 연결된 OLE 객체에 대한 원본 파일의 전체 이름을 반환합니다. |
+| [getObjectType()](#getObjectType--) | ForeignType 속성이 "Object"인 경우, ForeignData 요소에도 ObjectType 속성이 있어야 합니다. |
+| [getObjectWidth()](#getObjectWidth--) | 이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다. |
+| [getShowAsIcon()](#getShowAsIcon--) | 이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다. |
+| [getValue()](#getValue--) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | 이 속성에 대한 설명은 [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)을(를) 참조하십시오. |
+| [setCompressionType(int value)](#setCompressionType-int-) | 이 속성에 대한 설명은 [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)을(를) 참조하십시오. |
+| [setExtentX(double value)](#setExtentX-double-) | 이 속성에 대한 설명은 [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)을(를) 참조하십시오. |
+| [setExtentY(double value)](#setExtentY-double-) | 이 속성에 대한 설명은 [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)을(를) 참조하십시오. |
+| [setForeignType(int value)](#setForeignType-int-) | 이 속성에 대한 설명은 [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)을(를) 참조하십시오. |
+| [setImageData(byte[] value)](#setImageData-byte---) | 이 속성에 대한 설명은 [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)을(를) 참조하십시오. |
+| [setMappingMode(int value)](#setMappingMode-int-) | 이 속성에 대한 설명은 [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)을(를) 참조하십시오. |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | 이 속성에 대한 설명은 [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)을(를) 참조하십시오. |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | 이 속성에 대한 설명은 [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)을(를) 참조하십시오. |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | 이 속성에 대한 설명은 [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)을(를) 참조하십시오. |
+| [setObjectType(int value)](#setObjectType-int-) | 이 속성에 대한 설명은 [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)을(를) 참조하십시오. |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | 이 속성에 대한 설명은 [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)을(를) 참조하십시오. |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | 이 속성에 대한 설명은 [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)을(를) 참조하십시오. |
+| [setValue(byte[] value)](#setValue-byte---) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. 값은 파일에 적용된 압축 수준을 나타냅니다. 압축 수준은 백분율의 백분의 일 단위로 측정됩니다.
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+이 속성은 외부 데이터가 DIB, JPG, PNG, TIFF 또는 GIF 파일과 같은 래스터 기반 외부 객체인 경우에만 의미가 있습니다. 값은 파일에 적용된 압축 유형을 나타냅니다.
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. 값은 메타파일의 가로 범위를 나타냅니다.
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. 값은 메타파일의 세로 범위를 나타냅니다.
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+데이터 유형.
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+OLE 객체의 이미지를 바이트 배열로 나타냅니다.
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+이 속성은 외부 데이터가 메타파일인 경우에만 의미가 있습니다. 값은 메타파일의 매핑 모드를 나타냅니다.
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+임베드된 OLE 객체 데이터를 바이트 배열로 나타냅니다.
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다. 값은 페이지 단위로 객체의 높이를 나타냅니다.
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+연결된 OLE 객체에 대한 원본 파일의 전체 이름을 반환합니다. 파일 유형이 OleFileType.Unknown인 경우에만 전체 이름 설정을 지원합니다. 예: wav 파일, avi 파일 등.
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+ForeignType 속성이 "Object"인 경우, ForeignData 요소에도 ObjectType 속성이 있어야 합니다.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다. 값은 페이지 단위로 객체의 너비를 나타냅니다.
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+이 속성은 외부 데이터가 OLE2 임베디드 객체인 경우에만 의미가 있습니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+이 속성에 대한 설명은 [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+이 속성에 대한 설명은 [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+이 속성에 대한 설명은 [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+이 속성에 대한 설명은 [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+이 속성에 대한 설명은 [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+이 속성에 대한 설명은 [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/foreigntype/_index.md
+++ b/korean/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Aspose.Diagram for Java API 참조
+description: 데이터 유형.
+type: docs
+weight: 165
+url: /ko/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+데이터 유형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | 향상된 메타파일. |
+| [INK](#INK) | 잉크. |
+| [METAFILE](#METAFILE) | 메타파일. |
+| [OBJECT](#OBJECT) | 객체. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+향상된 메타파일.
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+잉크.
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+메타파일.
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+객체.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/formattxt/_index.md
+++ b/korean/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 서식을 위한 추상 클래스
+type: docs
+weight: 166
+url: /ko/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+텍스트 서식을 위한 추상 클래스
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/korean/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 텍스트를 포함하는 FormatTxt 컬렉션.
+type: docs
+weight: 167
+url: /ko/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+도형의 텍스트를 포함하는 FormatTxt 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | 컬렉션에 FormatTxt 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getText()](#getText--) | 형식이 적용된 도형의 텍스트를 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | 컬렉션에서 FormatTxt 객체를 제거합니다. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | 형식 없이 도형의 텍스트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+컬렉션에 FormatTxt 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+형식이 적용된 도형의 텍스트를 포함합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+컬렉션에서 FormatTxt 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+형식 없이 도형의 텍스트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/korean/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Aspose.Diagram for Java API 참조
+description: 연결이 시작되는 도형의 부분.
+type: docs
+weight: 168
+url: /ko/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+연결이 시작되는 도형의 부분.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | BeginX 셀. |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | BeginX/BeginY 점. |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | BeginY 셀. |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | 하단 가장자리. |
+| [CENTER_EDGE](#CENTER-EDGE) | 중심 가장자리. |
+| [CONTROL_POINT](#CONTROL-POINT) | 제어점. |
+| [END_X_CELL](#END-X-CELL) | EndX 셀. |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | EndX/EndY 점. |
+| [END_Y_CELL](#END-Y-CELL) | EndY 셀. |
+| [LEFT_EDGE](#LEFT-EDGE) | 왼쪽 가장자리. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | 중간 가장자리. |
+| [NONE](#NONE) | 없음. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | 오른쪽 가장자리. |
+| [TOP_EDGE](#TOP-EDGE) | 위쪽 가장자리. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+BeginX 셀.
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+BeginX/BeginY 점.
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+BeginY 셀.
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+하단 가장자리.
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+중심 가장자리.
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+제어점.
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+EndX 셀.
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+EndX/EndY 점.
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+EndY 셀.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+왼쪽 가장자리.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+중간 가장자리.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+없음.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+오른쪽 가장자리.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+위쪽 가장자리.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/geom/_index.md
+++ b/korean/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Aspose.Diagram for Java API 참조
+description: 도형을 구성하는 선과 호의 정점 좌표를 지정하는 요소를 포함합니다.
+type: docs
+weight: 169
+url: /ko/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+도형을 구성하는 선과 호의 정점 좌표를 지정하는 요소를 포함합니다. 도형에 경로가 여러 개 있는 경우 각 경로마다 Geom 요소가 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Geom()](#Geom--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | 좌표 컬렉션입니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | 다음 도형의 좌표 컬렉션 멤버에 대한 IX 값을 반환합니다. |
+| [getNoFill()](#getNoFill--) | 경로를 채울 수 있는지 여부를 지정합니다. |
+| [getNoLine()](#getNoLine--) | 경로 경계 주변에 선이 그려지는지 여부를 지정합니다. |
+| [getNoQuickDrag()](#getNoQuickDrag--) | 사용자가 Geometry 섹션에 정의된 채워진 영역을 클릭할 때 도형을 선택하거나 끌 수 있는지를 결정합니다. |
+| [getNoShow()](#getNoShow--) | 경로가 도면 페이지에 표시되는지 여부를 지정합니다. |
+| [getNoSnap()](#getNoSnap--) | 다른 도형이 경로에 스냅되는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/geom\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/geom\#getIX--)을(를) 참조하십시오. |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)을(를) 참조하십시오. |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)을(를) 참조하십시오. |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)을(를) 참조하십시오. |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)을(를) 참조하십시오. |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+좌표 컬렉션. 좌표 순서를 표시합니다.
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+다음 도형의 좌표 컬렉션 멤버에 대한 IX 값을 반환합니다.
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+경로를 채울 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+경로 경계 주변에 선이 그려지는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+사용자가 Geometry 섹션에 정의된 채워진 영역을 클릭할 때 도형을 선택하거나 끌 수 있는지를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+경로가 도면 페이지에 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+다른 도형이 경로에 스냅되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/geom\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/geom\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/geomcollection/_index.md
+++ b/korean/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Geom 컬렉션.
+type: docs
+weight: 170
+url: /ko/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Geom 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | 컬렉션에 Geom 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | 컬렉션에서 Geom 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+컬렉션에 Geom 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+컬렉션에서 Geom 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gloweffect/_index.md
+++ b/korean/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Aspose.Diagram for Java API 참조
+description: 이 클래스는 객체 가장자리 바깥에 색상 흐림 윤곽선이 추가되는 글로우 효과를 지정합니다.
+type: docs
+weight: 171
+url: /ko/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+이 클래스는 객체 가장자리 외부에 색상 흐림 윤곽선을 추가하는 글로우 효과를 지정합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | 포인트 단위의 글로우 반경입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | 이 속성에 대한 설명은 [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+포인트 단위의 글로우 반경입니다.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+이 속성에 대한 설명은 [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/korean/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Aspose.Diagram for Java API 참조
+description: Specifies constants that identify which shapes to return based on the dimensionality and directionality of the connection points that are glued to a particular shape passed to the Shape.GluedShapes method.
+type: docs
+weight: 176
+url: /ko/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+특정 도형에 접착된 연결 지점의 차원 및 방향성을 기반으로 반환할 도형을 식별하는 상수를 지정합니다; Shape.GluedShapes 메서드에 전달됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Return IDs of all 1-D shapes that are glued to this shape. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Return all 2-D shapes that are glued to this shape and all 2-D shapes to which this shape is glued. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Return IDs of 1-D shapes whose end points are glued to this shape. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | If the source object is a 1-D shape, return IDs of 2-D shape to which the begin point is glued. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | 이 도형에 시작점이 붙어 있는 1-D 도형들의 ID를 반환합니다. |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | 소스 객체가 1-D 도형인 경우, 끝점이 붙어 있는 2-D 도형의 ID를 반환합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Return IDs of all 1-D shapes that are glued to this shape.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Return all 2-D shapes that are glued to this shape and all 2-D shapes to which this shape is glued.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Return IDs of 1-D shapes whose end points are glued to this shape.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+소스 객체가 1-D 도형인 경우, 시작점이 붙어 있는 2-D 도형의 ID를 반환합니다. 소스 객체가 2-D 도형인 경우, 이 도형에 붙어 있는 2-D 도형들의 ID를 반환합니다.
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+이 도형에 시작점이 붙어 있는 1-D 도형들의 ID를 반환합니다.
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+소스 객체가 1-D 도형인 경우, 끝점이 붙어 있는 2-D 도형의 ID를 반환합니다. 소스 객체가 2-D 도형인 경우, 이 도형에 붙어 있는 2-D 도형들의 ID를 반환합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gluesettings/_index.md
+++ b/korean/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Aspose.Diagram for Java API 참조
+description: 비트 값은 특정 접착 설정이 켜져 있는지 꺼져 있는지를 나타냅니다.
+type: docs
+weight: 172
+url: /ko/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+비트 값은 특정 접착 설정이 켜져 있거나 꺼져 있음을 나타냅니다. 값은 여러 값의 합일 수 있습니다:
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | 연결 지점에 Glue를 적용합니다. |
+| [DISABLED](#DISABLED) | 접착이 비활성화되었습니다 |
+| [GEOMETRY](#GEOMETRY) | 기하학에 Glue를 적용합니다. |
+| [GUIDES](#GUIDES) | 가이드에 Glue를 적용합니다. |
+| [HANDLES](#HANDLES) | 핸들에 Glue를 적용합니다. |
+| [NONE](#NONE) | Glue가 활성화되었지만, 다른 Glue 설정은 활성화되지 않았습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VERTICES](#VERTICES) | 정점에 Glue를 적용합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+연결 지점에 Glue를 적용합니다.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+접착이 비활성화되었습니다
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+기하학에 Glue를 적용합니다.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+가이드에 Glue를 적용합니다.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+핸들에 Glue를 적용합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Glue가 활성화되었지만, 다른 Glue 설정은 활성화되지 않았습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+정점에 Glue를 적용합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다.
+type: docs
+weight: 173
+url: /ko/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | Glue가 비활성화되었습니다. |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | Glue가 활성화되었지만, 다른 Glue 설정은 활성화되지 않았습니다. |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | 연결 지점에 Glue를 적용합니다. |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | 기하학에 Glue를 적용합니다. |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | 가이드에 Glue를 적용합니다. |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | 핸들에 Glue를 적용합니다. |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | 정점에 Glue를 적용합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+Glue가 비활성화되었습니다.
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+Glue가 활성화되었지만, 다른 Glue 설정은 활성화되지 않았습니다.
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+연결 지점에 Glue를 적용합니다.
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+기하학에 Glue를 적용합니다.
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+가이드에 Glue를 적용합니다.
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+핸들에 Glue를 적용합니다.
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+정점에 Glue를 적용합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gluetype/_index.md
+++ b/korean/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 연결할 때 동적 도형 간 접착이 허용되는지 지정합니다.
+type: docs
+weight: 174
+url: /ko/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/gluetype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/gluetype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 연결할 때 동적 도형 간 접착이 허용되는지 지정합니다.
+type: docs
+weight: 175
+url: /ko/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | 동적 접착을 허용합니다. |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | 동적 접착을 허용합니다 (Microsoft Visio 2002에서 사용되지 않음). |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | 기본값. |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | 이 2D 도형이 동적 접착을 사용하여 연결되는 것을 허용하지 않습니다. |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | 동적 접착을 허용하지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+동적 접착을 허용합니다.
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+동적 접착을 허용합니다 (Microsoft Visio 2002에서 사용되지 않음).
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+기본값. 동적 커넥터에만 동적 접착을 허용하고, 그렇지 않으면 정적 접착을 사용합니다.
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+이 2D 도형이 동적 접착을 사용하여 연결되는 것을 허용하지 않습니다.
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+동적 접착을 허용하지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/korean/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Aspose.Diagram for Java API 참조
+description: 그라디언트의 모든 방향 유형을 나타냅니다.
+type: docs
+weight: 177
+url: /ko/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+그라디언트의 모든 방향 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | 알 수 없음 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+알 수 없음
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientfill/_index.md
+++ b/korean/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Aspose.Diagram for Java API 참조
+description: 그라디언트 채우기를 나타냅니다.
+type: docs
+weight: 178
+url: /ko/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+그라디언트 채우기를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | 채우기 색상 그라데이션의 방향을 지정합니다. |
+| [getGradientDir()](#getGradientDir--) | 채우기 색상 그라데이션의 유형을 지정합니다. |
+| [getGradientEnabled()](#getGradientEnabled--) | 채우기 색상 그라데이션이 표시되는지 여부를 지정합니다. |
+| [getGradientStops()](#getGradientStops--) | 그라디언트 스톱 컬렉션을 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)을 참조하십시오. |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)을 참조하십시오. |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+채우기 색상 그라데이션의 방향을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+채우기 색상 그라데이션의 유형을 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+채우기 색상 그라데이션이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+그라디언트 스톱 컬렉션을 나타냅니다.
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/korean/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 채우기 색상 그라디언트 유형을 지정합니다.
+type: docs
+weight: 179
+url: /ko/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+도형의 채우기 색상 그라디언트 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LINEAR](#LINEAR) | 선형 채우기 색상 그라디언트를 지정합니다. |
+| [PATH](#PATH) | 모양의 채우기 색상 그라디언트가 경로 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | 모양의 채우기 색상 그라디언트가 모양의 왼쪽 아래 모서리에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | 모양의 채우기 색상 그라디언트가 모양의 오른쪽 아래 모서리에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | 모양의 채우기 색상 그라디언트가 모양의 중심에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | 모양의 채우기 색상 그라디언트가 모양의 아래쪽 가장자리 중앙에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | 모양의 채우기 색상 그라디언트가 모양의 위쪽 가장자리 중앙에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | 모양의 채우기 색상 그라디언트가 모양의 왼쪽 위 모서리에서 방사형 모드에 있음을 지정합니다. |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | 모양의 채우기 색상 그라디언트가 모양의 오른쪽 위 모서리에서 방사형 모드에 있음을 지정합니다. |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | 모양의 채우기 색상 그라디언트가 모양의 왼쪽 아래 모서리에서 사각형 모드에 있음을 지정합니다. |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | 모양의 채우기 색상 그라디언트가 모양의 오른쪽 아래 모서리에서 사각형 모드에 있음을 지정합니다. |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | 모양의 채우기 색상 그라디언트가 모양의 중심에서 사각형 모드에 있음을 지정합니다. |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | 모양의 채우기 색상 그라디언트가 모양의 왼쪽 위 모서리에서 사각형 모드에 있음을 지정합니다. |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | 모양의 채우기 색상 그라디언트가 모양의 오른쪽 위 모서리에서 사각형 모드에 있음을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+선형 채우기 색상 그라디언트를 지정합니다.
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+모양의 채우기 색상 그라디언트가 경로 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 왼쪽 아래 모서리에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 오른쪽 아래 모서리에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 중심에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 아래쪽 가장자리 중앙에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 위쪽 가장자리 중앙에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 왼쪽 위 모서리에서 방사형 모드에 있음을 지정합니다.
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 오른쪽 위 모서리에서 방사형 모드에 있음을 지정합니다.
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 왼쪽 아래 모서리에서 사각형 모드에 있음을 지정합니다.
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 오른쪽 아래 모서리에서 사각형 모드에 있음을 지정합니다.
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 중심에서 사각형 모드에 있음을 지정합니다.
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 왼쪽 위 모서리에서 사각형 모드에 있음을 지정합니다.
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+모양의 채우기 색상 그라디언트가 모양의 오른쪽 위 모서리에서 사각형 모드에 있음을 지정합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/korean/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Aspose.Diagram for Java API 참조
+description: 모든 그라디언트 채우기 유형을 나타냅니다.
+type: docs
+weight: 180
+url: /ko/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+모든 그라디언트 채우기 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LINEAR](#LINEAR) | Linear |
+| [PATH](#PATH) | Path |
+| [RADIAL](#RADIAL) | Radial |
+| [RECTANGLE](#RECTANGLE) | Rectangle |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Path
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+Rectangle
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientstop/_index.md
+++ b/korean/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Aspose.Diagram for Java API 참조
+description: 그라디언트 스톱을 나타냅니다.
+type: docs
+weight: 181
+url: /ko/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+그라디언트 스톱을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | 이 그라디언트 스톱의 색상을 가져옵니다. |
+| [getPosition()](#getPosition--) | 스톱의 위치입니다. |
+| [getTransparency()](#getTransparency--) | 0.0(불투명)에서 1.0(투명)까지의 값으로 영역의 투명도 정도를 반환하거나 설정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)을(를) 참조하십시오. |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)을(를) 참조하십시오. |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+이 그라디언트 스톱의 색상을 가져옵니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+스톱의 위치입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+0.0(불투명)에서 1.0(투명)까지의 값으로 영역의 투명도 정도를 반환하거나 설정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/korean/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 그라디언트 스톱 컬렉션을 나타냅니다.
+type: docs
+weight: 182
+url: /ko/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+그라디언트 스톱 컬렉션을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | 그라디언트 스톱 추가. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 인덱스로 그라디언트 스톱을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+그라디언트 스톱 추가.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | 스톱의 위치, 백분율 단위. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | 스톱의 색상. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+인덱스로 그라디언트 스톱을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 인덱스. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/korean/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Aspose.Diagram for Java API 참조
+description: 그라디언트 셰이딩 스타일을 나타냅니다.
+type: docs
+weight: 183
+url: /ko/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+그라디언트 셰이딩 스타일을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | 대각선 아래쪽 음영 스타일 |
+| [DIAGONAL_UP](#DIAGONAL-UP) | 대각선 위쪽 음영 스타일 |
+| [FROM_CENTER](#FROM-CENTER) | 중심에서 시작하는 음영 스타일 |
+| [FROM_CORNER](#FROM-CORNER) | 코너에서 시작하는 음영 스타일 |
+| [HORIZONTAL](#HORIZONTAL) | 수평 음영 스타일 |
+| [UNKNOWN](#UNKNOWN) | 알 수 없는 음영 스타일. 템플릿 파일의 음영 스타일(GradientStyleType의 어떤 멤버에도 해당되지 않음) 전용입니다. |
+| [VERTICAL](#VERTICAL) | 수직 음영 스타일 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+대각선 아래쪽 음영 스타일
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+대각선 위쪽 음영 스타일
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+중심에서 시작하는 음영 스타일
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+코너에서 시작하는 음영 스타일
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+수평 음영 스타일
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+알 수 없는 음영 스타일. 템플릿 파일의 음영 스타일(GradientStyleType의 어떤 멤버에도 해당되지 않음) 전용입니다.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+수직 음영 스타일
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/griddensity/_index.md
+++ b/korean/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 사용할 가로/세로 그리드 유형을 지정합니다.
+type: docs
+weight: 184
+url: /ko/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+페이지에 사용할 가로/세로 그리드 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지에 사용할 가로/세로 그리드 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/griddensity\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지에 사용할 가로/세로 그리드 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/griddensity\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/korean/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 사용할 가로/세로 그리드 유형을 지정합니다.
+type: docs
+weight: 185
+url: /ko/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+페이지에 사용할 가로/세로 그리드 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [COARSE](#COARSE) | 거침. |
+| [FINE](#FINE) | 정밀 |
+| [FIXED](#FIXED) | 고정됨. |
+| [NORMAL](#NORMAL) | 보통. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+거침.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+정밀
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+고정됨.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+보통. 기본.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/group/_index.md
+++ b/korean/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Group
+second_title: Aspose.Diagram for Java API 참조
+description: 그룹에 도형을 추가하고 그룹의 구성원을 이동하며 그룹을 선택하는 방법을 제어하는 요소를 포함합니다.
+type: docs
+weight: 186
+url: /ko/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDisplayMode()](#getDisplayMode--) | Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원이 어떻게 표시되는지를 지정합니다. |
+| [getDontMoveChildren()](#getDontMoveChildren--) | 마우스를 사용하여 그룹 내 도형을 끌 수 있는지 여부를 지정합니다. |
+| [getSelectMode()](#getSelectMode--) | 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | 도형을 그룹에 놓을 때 그룹에 도형을 추가하도록 허용하는지 여부를 지정합니다. |
+| [isSnapTarget()](#isSnapTarget--) | 그룹 또는 그룹 내 도형에 스냅이 활성화되는지 여부를 지정합니다. |
+| [isTextEditTarget()](#isTextEditTarget--) | 그룹에 텍스트를 할당하는 방법을 지정합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/group\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+Group 요소에 포함될 경우, DisplayMode 요소는 그룹 도형 및 그 구성원이 어떻게 표시되는지를 지정합니다.
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+마우스를 사용하여 그룹 내 도형을 끌 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+도형을 그룹에 놓을 때 그룹에 도형을 추가하도록 허용하는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+그룹 또는 그룹 내 도형에 스냅이 활성화되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+그룹에 텍스트를 할당하는 방법을 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/group\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/headerfooter/_index.md
+++ b/korean/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 머리글 및 바닥글에 대한 요소를 포함합니다.
+type: docs
+weight: 188
+url: /ko/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+문서의 머리글 및 바닥글 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | 문서 바닥글 중앙 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [getFooterLeft()](#getFooterLeft--) | 문서 바닥글 왼쪽 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [getFooterMargin()](#getFooterMargin--) | 문서 바닥글의 여백을 지정합니다. |
+| [getFooterRight()](#getFooterRight--) | 문서 바닥글 오른쪽 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [getHeaderCenter()](#getHeaderCenter--) | 문서 머리글 중앙 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | 머리글 및 바닥글 텍스트 색상의 RGB 값입니다. |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | 머리글 및 바닥글 텍스트에 사용되는 글꼴을 지정합니다. |
+| [getHeaderLeft()](#getHeaderLeft--) | 문서 머리글 왼쪽 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [getHeaderMargin()](#getHeaderMargin--) | 문서 바닥글의 여백을 지정합니다. |
+| [getHeaderRight()](#getHeaderRight--) | 문서 머리글 오른쪽 부분에 표시되는 텍스트 문자열을 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | 이 속성에 대한 설명은 [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)을(를) 참조하십시오. |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | 이 속성에 대한 설명은 [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)을(를) 참조하십시오. |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | 이 속성에 대한 설명은 [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)을(를) 참조하십시오. |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | 이 속성에 대한 설명은 [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)을(를) 참조하십시오. |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | 이 속성에 대한 설명은 [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)을(를) 참조하십시오. |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | 이 속성에 대한 설명은 [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)을(를) 참조하십시오. |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | 이 속성에 대한 설명은 [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)을(를) 참조하십시오. |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | 이 속성에 대한 설명은 [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)을(를) 참조하십시오. |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | 이 속성에 대한 설명은 [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+문서 바닥글 중앙 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+문서 바닥글 왼쪽 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+문서 바닥글의 여백을 지정합니다.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+문서 바닥글 오른쪽 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+문서 머리글 중앙 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+머리글 및 바닥글 텍스트 색상의 RGB 값입니다.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+머리글 및 바닥글 텍스트에 사용되는 글꼴을 지정합니다.
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+문서 머리글 왼쪽 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+문서 바닥글의 여백을 지정합니다.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+문서 머리글 오른쪽 부분에 표시되는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+이 속성에 대한 설명은 [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+이 속성에 대한 설명은 [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+이 속성에 대한 설명은 [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+이 속성에 대한 설명은 [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+이 속성에 대한 설명은 [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+이 속성에 대한 설명은 [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+이 속성에 대한 설명은 [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+이 속성에 대한 설명은 [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+이 속성에 대한 설명은 [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/korean/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Aspose.Diagram for Java API 참조
+description: 머리글 및 바닥글 텍스트에 사용되는 글꼴을 지정합니다.
+type: docs
+weight: 189
+url: /ko/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+머리글 및 바닥글 텍스트에 사용되는 글꼴을 지정합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Specifies the character set of the font. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Specifies the clipping precision of the font. |
+| [getEscapement()](#getEscapement--) | Specifies the escapement attribute of the font. |
+| [getFaceName()](#getFaceName--) | Specifies the type face name attribute of the font. |
+| [getHeight()](#getHeight--) | Specifies the height of the font. |
+| [getItalic()](#getItalic--) | Specifies the weight of the font. |
+| [getOrientation()](#getOrientation--) | Specifies the orientation of the font. |
+| [getOutPrecision()](#getOutPrecision--) | Specifies the output precision attribute of the font. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Specifies the pitch and family of the font. |
+| [getQuality()](#getQuality--) | Specifies the output quality of the font. |
+| [getStrikeOut()](#getStrikeOut--) | Specifies whether the font is a strikeout font. |
+| [getUnderline()](#getUnderline--) | Specifies whether the font is underlined. |
+| [getWeight()](#getWeight--) | Specifies the weight of the font. |
+| [getWidth()](#getWidth--) | Specifies the width of the font. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | For the description of this property, please see \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | For the description of this property, please see \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | For the description of this property, please see [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | For the description of this property, please see [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | For the description of this property, please see [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | 이 속성에 대한 설명은 [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)을(를) 참조하십시오. |
+| [setOrientation(int value)](#setOrientation-int-) | 이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)을(를) 참조하십시오. |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | 이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | 이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setQuality(long value)](#setQuality-long-) | 이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}을(를) 참조하십시오. |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | 이 속성에 대한 설명은 [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)을(를) 참조하십시오. |
+| [setUnderline(int value)](#setUnderline-int-) | 이 속성에 대한 설명은 [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)을(를) 참조하십시오. |
+| [setWeight(int value)](#setWeight-int-) | 이 속성에 대한 설명은 [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)을(를) 참조하십시오. |
+| [setWidth(int value)](#setWidth-int-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+글꼴의 문자 집합을 지정합니다. GDI LOGFONT lfCharSet 필드와 동일합니다.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+글꼴의 클리핑 정밀도를 지정합니다. GDI LOGFONT lfClipPrecision 필드와 동일합니다.
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+글꼴의 이스케이프 속성을 지정합니다. GDI LOGFONT lfEscapement 필드와 동일합니다.
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+글꼴의 서체 이름 속성을 지정합니다. GDI LOGFONT lfFaceName 필드와 동일합니다.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+글꼴의 높이를 지정합니다. GDI LOGFONT lfHeight 필드와 동일합니다.
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+글꼴의 굵기를 지정합니다. GDI LOGFONT lfWeight 필드와 동일합니다.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+글꼴의 방향을 지정합니다. GDI LOGFONT lfOrientation 필드와 동일합니다.
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+글꼴의 출력 정밀도 속성을 지정합니다. GDI LOGFONT lfOutPrecision 필드와 동일합니다.
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+글꼴의 피치와 패밀리를 지정합니다. GDI LOGFONT lfPitchAndFamily 필드와 동일합니다.
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+글꼴의 출력 품질을 지정합니다. GDI LOGFONT lfQuality 필드와 동일합니다.
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+글꼴이 취소선인지 여부를 지정합니다. GDI LOGFONT lfStrikeOut 필드와 동일합니다.
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+글꼴에 밑줄이 있는지 여부를 지정합니다. GDI LOGFONT lfUnderline 필드와 동일합니다.
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+글꼴의 굵기를 지정합니다. GDI LOGFONT lfWeight 필드와 동일합니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+글꼴의 너비를 지정합니다. GDI LOGFONT lfWidth 필드와 동일합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+For the description of this property, please see \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+For the description of this property, please see \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+For the description of this property, please see [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+For the description of this property, please see [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+For the description of this property, please see [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+이 속성에 대한 설명은 [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+이 속성에 대한 설명은 \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+이 속성에 대한 설명은 [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+이 속성에 대한 설명은 [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+이 속성에 대한 설명은 [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/help/_index.md
+++ b/korean/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: 도움말
+second_title: Aspose.Diagram for Java API 참조
+description: Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+type: docs
+weight: 190
+url: /ko/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | 인간이 읽을 수 있는 저작권 문구를 나타내는 문자열을 포함합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getHelpTopic()](#getHelpTopic--) | Shape 요소의 도움말 주제 ID를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/help\#getDel--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+인간이 읽을 수 있는 저작권 문구를 나타내는 문자열을 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Shape 요소의 도움말 주제 ID를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/help\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/horzalign/_index.md
+++ b/korean/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트 블록에서 텍스트의 수평 정렬을 지정합니다.
+type: docs
+weight: 191
+url: /ko/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/horzalign\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/horzalign\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/korean/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트 블록에서 텍스트의 수평 정렬을 지정합니다.
+type: docs
+weight: 192
+url: /ko/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CENTER](#CENTER) | Center. |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | 강제 양쪽 맞춤. |
+| [JUSTIFY](#JUSTIFY) | 양쪽 맞춤. |
+| [LEFT_ALIGN](#LEFT-ALIGN) | 왼쪽 정렬. |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | 오른쪽 정렬. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center.
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+강제 양쪽 맞춤.
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+양쪽 맞춤.
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+왼쪽 정렬.
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+오른쪽 정렬.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 HTML로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다.
+type: docs
+weight: 187
+url: /ko/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+다이어그램 페이지를 HTML로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | 이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 숨겨진 페이지를 내보낼지 여부를 정의합니다. |
+| [getPageCount()](#getPageCount--) | HTML에서 렌더링할 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 첫 번째 페이지의 0 기반 인덱스. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getResolution()](#getResolution--) | 생성된 HTML의 해상도(인치당 도트 수). |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | HTML을 단일 파일로 저장할지 여부를 나타냅니다. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 모든 페이지를 이미지로 저장할지, 전경만 저장할지 여부를 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. |
+| [getSaveTitle()](#getSaveTitle--) | 제목을 내보낼지 여부를 정의합니다. |
+| [getSaveToolBar()](#getSaveToolBar--) | 툴바 저장 여부를 지정합니다. 기본값은 true입니다. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getStreamProvider()](#getStreamProvider--) | 객체를 내보내기 위한 IStreamProvider. |
+| [getTitle()](#getTitle--) | HTML에서 렌더링할 다이어그램의 제목. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | 이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--)을(를) 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--)을(를) 참조하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setResolution(int value)](#setResolution-int-) | 이 속성에 대한 설명은 [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--)을(를) 참조하십시오. |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | 이 속성에 대한 설명은 [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--)을(를) 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | 이 속성에 대한 설명은 [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--)을(를) 참조하십시오. |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | 이 속성에 대한 설명은 [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | 이 속성에 대한 설명은 [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--)을(를) 참조하십시오. |
+| [setTitle(String value)](#setTitle-java.lang.String-) | 이 속성에 대한 설명은 [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+숨겨진 페이지를 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+HTML에서 렌더링할 페이지 수입니다. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 첫 번째 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+생성된 HTML의 해상도(인치당 도트 수)입니다. 이 속성은 HTML로 저장할 때만 영향을 미칩니다. 기본값은 96입니다.
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+HTML을 단일 파일로 저장할지 여부를 나타냅니다. 기본값은 false입니다. 페이지가 여러 개 있는 경우 해당 페이지와 기타 리소스를 별도의 파일로 저장해야 합니다. 일부 시나리오에서는 전송 편의를 위해 하나의 결과 파일만 필요할 수 있습니다. 이 경우 사용자는 이 속성을 true로 설정할 수 있습니다.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+이미지에 모든 페이지를 저장할지 아니면 전경만 저장할지 지정합니다. true인 경우 전경 페이지만 렌더링됩니다(배경이 있으면 포함). false인 경우 전경 페이지가 렌더링된 뒤 빈 배경 페이지가 렌더링됩니다. PageCount가 1보다 클 때만 true를 반환할 수 있습니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat만 사용할 수 있습니다.
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+제목을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+툴바 저장 여부를 지정합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+객체를 내보내기 위한 IStreamProvider.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+HTML로 렌더링할 다이어그램의 제목입니다. Title이 null이면 Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties)가 제목으로 사용됩니다. Diagram.DocumentProperties.Title이 null이거나 비어 있으면 다이어그램 파일 이름이 제목으로 사용됩니다.
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+이 속성에 대한 설명은 [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+이 속성에 대한 설명은 [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+이 속성에 대한 설명은 [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/hyperlink/_index.md
+++ b/korean/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hyperlink
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 또는 도면 페이지와 다른 도면 페이지, 다른 파일 또는 웹 사이트 간에 여러 번 점프를 만들기 위한 요소를 포함합니다.
+type: docs
+weight: 193
+url: /ko/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+도형 또는 그리기 페이지와 다른 그리기 페이지, 다른 파일, 또는 웹 사이트 간에 여러 번 점프를 생성하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | 점프할 URL 주소, DOS 파일 이름 또는 UNC 경로를 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | 도형 또는 페이지에 대한 기본 하이퍼링크를 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDescription()](#getDescription--) | Description 요소는 하이퍼링크를 설명하는 텍스트 문자열을 포함합니다. |
+| [getExtraInfo()](#getExtraInfo--) | 이미지 맵의 좌표와 같은 URL을 해석하는 데 사용할 정보를 포함합니다. |
+| [getFrame()](#getFrame--) | Microsoft Visio가 컨테이너 애플리케이션에서 활성 문서로 열릴 때 대상이 되는 프레임 이름을 포함합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getInvisible()](#getInvisible--) | Invisible 요소는 도형 또는 페이지의 바로 가기 메뉴에 하이퍼링크가 표시되는지 여부를 나타냅니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getNewWindow()](#getNewWindow--) | Microsoft Visio가 하이퍼링크를 따라 웹 페이지 또는 다른 Visio 문서를 열 때 새 위치에 창을 열지 여부를 지정합니다. |
+| [getSortKey()](#getSortKey--) | Invisible 요소는 도형 또는 페이지의 바로 가기 메뉴에 하이퍼링크가 표시되는지 여부를 나타냅니다. |
+| [getSubAddress()](#getSubAddress--) | 대상 문서 내에서 연결할 위치를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/hyperlink\#getID--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/hyperlink\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+점프할 URL 주소, DOS 파일 이름 또는 UNC 경로를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+도형 또는 페이지에 대한 기본 하이퍼링크를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Description 요소는 하이퍼링크를 설명하는 텍스트 문자열을 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+이미지 맵의 좌표와 같은 URL을 해석하는 데 사용할 정보를 포함합니다. 예를 들어, x=41 y=7은 이미지 맵의 좌표를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Microsoft Visio가 컨테이너 애플리케이션에서 활성 문서로 열릴 때 대상이 되는 프레임 이름을 포함합니다. 기본값은 빈 문자열입니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Invisible 요소는 도형 또는 페이지의 바로 가기 메뉴에 하이퍼링크가 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+Microsoft Visio가 하이퍼링크를 따라 웹 페이지 또는 다른 Visio 문서를 열 때 새 위치에 창을 열지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Invisible 요소는 도형 또는 페이지의 바로 가기 메뉴에 하이퍼링크가 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+대상 문서 내에서 연결할 위치를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/hyperlink\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/hyperlink\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/korean/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 하이퍼링크 컬렉션.
+type: docs
+weight: 194
+url: /ko/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+하이퍼링크 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | 컬렉션에 Hyperlink 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | 컬렉션에서 Hyperlink 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+컬렉션에 Hyperlink 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+컬렉션에서 Hyperlink 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/korean/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 선택적 int.
+type: docs
+weight: 195
+url: /ko/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+Optional int. The size of the element's icon.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double. |
+| [NORMAL](#NORMAL) | 보통. |
+| [TALL](#TALL) | Tall. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [WIDE](#WIDE) | Wide. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+보통.
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+Tall.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+Wide.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/image/_index.md
+++ b/korean/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: 이미지
+second_title: Aspose.Diagram for Java API 참조
+description: 비트맵에 대한 감마, 밝기, 대비, 흐림, 선명도, 노이즈 제거 및 투명도 값을 포함합니다.
+type: docs
+weight: 196
+url: /ko/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | 비트맵 이미지를 흐리게 하거나 부드럽게 합니다. |
+| [getBrightness()](#getBrightness--) | 비트맵 이미지의 밝기를 조정합니다. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | 비트맵 이미지의 대비를 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDenoise()](#getDenoise--) | 비트맵 이미지에서 노이즈(무작위로 분포된 색상 레벨을 가진 픽셀)를 제거합니다. |
+| [getGamma()](#getGamma--) | 모니터나 스캐너와 같은 특정 출력 장치에 맞게 이미지의 강도를 조정하거나 보정합니다. |
+| [getSharpen()](#getSharpen--) | 비트맵 이미지를 선명하게 할 정도를 지정합니다. |
+| [getTransparency()](#getTransparency--) | 레이어 색상의 투명도 수준을 0(불투명)에서 1(완전 투명)까지 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/image\#getDel--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+비트맵 이미지를 흐리게 하거나 부드럽게 합니다. Blur 요소는 0에서 1 사이의 값을 포함하며, 기본값은 0입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+비트맵 이미지의 밝기를 조정합니다. Brightness 요소는 0에서 1 사이의 값을 포함하며, 기본값은 0.5입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+비트맵 이미지의 대비를 지정합니다. Contrast 요소는 0에서 1 사이의 값을 포함합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+비트맵 이미지에서 노이즈(무작위로 분포된 색상 레벨을 가진 픽셀)를 제거합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+모니터나 스캐너와 같은 특정 출력 장치에 맞게 이미지의 강도를 조정하거나 보정합니다. 기본값은 1(보정 없음)입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+비트맵 이미지를 선명하게 할 정도를 지정합니다. 이미지를 선명하게 하면 인접 픽셀의 대비를 높여 초점을 맞춥니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+레이어 색상의 투명도 수준을 0(불투명)에서 1(완전 투명)까지 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/image\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: 이미지 컨트롤을 나타냅니다.
+type: docs
+weight: 197
+url: /ko/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+이미지 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getBorderOleColor()](#getBorderOleColor--) | the ole color of the background. |
+| [getBorderStyle()](#getBorderStyle--) | the type of border used by the control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPictureAlignment()](#getPictureAlignment--) | 폼 또는 이미지 내부에서 그림의 정렬. |
+| [getPictureSizeMode()](#getPictureSizeMode--) | 그림을 표시하는 방법. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTiled()](#isTiled--) | 그림이 배경 전체에 타일 형식으로 표시되는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--)을(를) 참조하십시오. |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | 이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오. |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | 이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--)을(를) 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--)을(를) 참조하십시오. |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | 이 속성에 대한 설명은 [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)을(를) 참조하십시오. |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | 이 속성에 대한 설명은 [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)을(를) 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오. |
+| [setTiled(boolean value)](#setTiled-boolean-) | 이 속성에 대한 설명은 [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+the type of border used by the control.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+폼 또는 이미지 내부에서 그림의 정렬.
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+그림을 표시하는 방법.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+그림이 배경 전체에 타일 형식으로 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+이 속성에 대한 설명은 [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/korean/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 페이지의 생성된 이미지에 대한 색상 모드를 지정합니다.
+type: docs
+weight: 198
+url: /ko/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+문서 페이지의 생성된 이미지에 대한 색상 모드를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | 문서의 페이지가 흑백 이미지로 렌더링됩니다. |
+| [GRAYSCALE](#GRAYSCALE) | 문서의 페이지가 그레이스케일 이미지로 렌더링됩니다. |
+| [NONE](#NONE) | 문서의 페이지가 컬러 이미지로 렌더링됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+문서의 페이지가 흑백 이미지로 렌더링됩니다.
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+문서의 페이지가 그레이스케일 이미지로 렌더링됩니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+문서의 페이지가 컬러 이미지로 렌더링됩니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/imageformat/_index.md
+++ b/korean/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 이미지의 파일 형식을 지정합니다.
+type: docs
+weight: 199
+url: /ko/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+이미지의 파일 형식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 이 ImageFormat 객체와 동등한 ImageFormat 객체인지 여부를 나타내는 값을 반환합니다. |
+| [getBmp()](#getBmp--) | 비트맵(BMP) 이미지 형식을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | 향상된 메타파일(EMF) 이미지 형식을 가져옵니다. |
+| [getExif()](#getExif--) | 교환 이미지 파일(Exif) 형식을 가져옵니다. |
+| [getGif()](#getGif--) | 그래픽 교환 형식(GIF) 이미지 형식을 가져옵니다. |
+| [getIcon()](#getIcon--) | Windows 아이콘 이미지 형식을 가져옵니다. |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | 접미사 이름에 따라 이미지 형식을 가져옵니다. |
+| [getJpeg()](#getJpeg--) | Joint Photographic Experts Group(JPEG) 이미지 형식을 가져옵니다. |
+| [getMemoryBmp()](#getMemoryBmp--) | 메모리 비트맵 이미지 형식을 가져옵니다. |
+| [getName()](#getName--) | 이 ImageFormat 인스턴스의 문자열 이름을 가져옵니다. |
+| [getPng()](#getPng--) | W3C Portable Network Graphics(PNG) 이미지 형식을 가져옵니다. |
+| [getTiff()](#getTiff--) | TIFF(Tagged Image File Format) 이미지 형식을 가져옵니다. |
+| [getWmf()](#getWmf--) | Windows 메타파일(WMF) 이미지 형식을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 이 ImageFormat 객체와 동등한 ImageFormat 객체인지 여부를 나타내는 값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 테스트할 객체. |
+
+**Returns:**
+boolean - o가 이 ImageFormat 객체와 동등한 ImageFormat 객체인 경우 true; 그렇지 않으면 false.
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+비트맵(BMP) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+향상된 메타파일(EMF) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+교환 이미지 파일(Exif) 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+그래픽 교환 형식(GIF) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Windows 아이콘 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+접미사 이름에 따라 이미지 형식을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String | 접미사 이름 |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Joint Photographic Experts Group(JPEG) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+메모리 비트맵 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+이 ImageFormat 인스턴스의 문자열 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String - 이 ImageFormat 인스턴스의 문자열 이름
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+W3C Portable Network Graphics(PNG) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+TIFF(Tagged Image File Format) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Windows 메타파일(WMF) 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다.
+type: docs
+weight: 200
+url: /ko/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+다이어그램 페이지를 이미지로 렌더링할 때 추가 옵션을 지정할 수 있게 합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | 이 클래스를 새 인스턴스로 초기화하며, 이 인스턴스를 사용하여 Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat 또는 Aspose.Diagram.SaveFileFormat 형식으로 렌더링된 이미지를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | 합성 중에 사용할 품질 수준을 지정합니다. |
+| [getContentZoom()](#getContentZoom--) | 이 매개변수는 스케일과 유사하지만 생성된 이미지 크기에 영향을 주지는 않습니다. |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 숨겨진 페이지를 내보낼지 여부를 정의합니다. |
+| [getImageBrightness()](#getImageBrightness--) | 생성된 이미지의 밝기. |
+| [getImageColorMode()](#getImageColorMode--) | 생성된 이미지의 색상 모드. |
+| [getImageContrast()](#getImageContrast--) | 생성된 이미지의 대비. |
+| [getInterpolationMode()](#getInterpolationMode--) | 이미지를 스케일링하거나 회전할 때 사용되는 알고리즘을 지정합니다. |
+| [getJpegQuality()](#getJpegQuality--) | 생성된 JPEG 이미지의 품질을 결정하는 값. |
+| [getPageCount()](#getPageCount--) | 멀티 페이지 TIFF 파일로 저장할 때 렌더링할 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 첫 번째 페이지의 0 기반 인덱스. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | 렌더링 중 픽셀이 어떻게 오프셋되는지를 지정하는 값. |
+| [getResolution()](#getResolution--) | 생성된 이미지의 해상도(인치당 도트 수). |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | 저장 영역이 PDF와 동일한지 여부를 지정합니다. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 모든 페이지를 이미지로 저장할지, 전경만 저장할지 여부를 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. |
+| [getScale()](#getScale--) | 생성된 이미지의 확대 배율. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getSmoothingMode()](#getSmoothingMode--) | 선과 곡선 및 채워진 영역의 가장자리에 스무딩(안티앨리어싱)이 적용되는지 여부를 지정합니다. |
+| [getTiffCompression()](#getTiffCompression--) | 생성된 이미지를 TIFF 형식으로 저장할 때 적용할 압축 유형. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | 이 속성에 대한 설명은 [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)을(를) 참조하십시오. |
+| [setContentZoom(float value)](#setContentZoom-float-) | 이 속성에 대한 설명은 [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)을(를) 참조하십시오. |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | 이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)을(를) 참조하십시오. |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | 이 속성에 대한 설명은 [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)을(를) 참조하십시오. |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | 이 속성에 대한 설명은 [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)을(를) 참조하십시오. |
+| [setImageContrast(float value)](#setImageContrast-float-) | 이 속성에 대한 설명은 [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)을(를) 참조하십시오. |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | 이 속성에 대한 설명은 [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)을(를) 참조하십시오. |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | 이 속성에 대한 설명은 [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)을(를) 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)을(를) 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)을(를) 참조하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | 이 속성에 대한 설명은 [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)을(를) 참조하십시오. |
+| [setResolution(float value)](#setResolution-float-) | 이 속성에 대한 설명은 [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)을(를) 참조하십시오. |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | 이 속성에 대한 설명은 [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)을(를) 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setScale(float value)](#setScale-float-) | 이 속성에 대한 설명은 [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | 이 속성에 대한 설명은 [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)을(를) 참조하십시오. |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | 이 속성에 대한 설명은 [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+이 클래스를 새 인스턴스로 초기화하며, 이 인스턴스를 사용하여 Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat 또는 Aspose.Diagram.SaveFileFormat 형식으로 렌더링된 이미지를 저장할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat 또는 Aspose.Diagram.SaveFileFormat일 수 있습니다. |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+합성 중에 사용할 품질 수준을 지정합니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.CompositingQuality입니다.
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+이 매개변수는 scale과 유사하지만 생성된 이미지 크기에 영향을 주지는 않습니다. 기본값은 1.0입니다. 값은 0보다 커야 합니다.
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+숨겨진 페이지를 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+생성된 이미지의 밝기입니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 0.5입니다. 값은 0과 1 사이여야 합니다.
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+생성된 이미지의 색상 모드입니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.ImageColorMode입니다.
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+생성된 이미지의 대비입니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 0.5입니다. 값은 0과 1 사이여야 합니다.
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+이미지를 확대/축소하거나 회전할 때 사용되는 알고리즘을 지정합니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.InterpolationMode입니다.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+생성된 JPEG 이미지의 품질을 결정하는 값입니다. JPEG로 저장할 때만 영향을 미칩니다. 이 속성을 사용하여 JPEG 형식으로 저장할 때 생성된 이미지의 품질을 가져오거나 설정할 수 있습니다. 값은 0에서 100 사이이며, 0은 최저 품질이지만 최대 압축, 100은 최고 품질이지만 최소 압축을 의미합니다. 기본값은 95입니다.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+다중 페이지 TIFF 파일로 저장할 때 렌더링할 페이지 수입니다. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 첫 번째 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+렌더링 중 픽셀 오프셋 방식을 지정하는 값입니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.PixelOffsetMode입니다.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+생성된 이미지의 해상도(인치당 도트 수)입니다. 이 속성는 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 96입니다.
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+저장 영역이 PDF와 동일한지 여부를 지정합니다. true이면 렌더링 영역이 PDF와 동일합니다. false이면 렌더링 영역이 기본값입니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+이미지에 모든 페이지를 저장할지 아니면 전경만 저장할지 지정합니다. true인 경우 전경 페이지만 렌더링됩니다(배경이 있으면 포함). false인 경우 전경 페이지가 렌더링된 뒤 빈 배경 페이지가 렌더링됩니다. PageCount가 1보다 클 때만 true를 반환할 수 있습니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat 또는 Aspose.Diagram.SaveFileFormat 중 하나일 수 있습니다.
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+생성된 이미지의 확대 배율입니다. 기본값은 1.0입니다. 값은 0보다 커야 합니다.
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+선과 곡선 및 채워진 영역의 가장자리에 스무딩(안티앨리어싱)이 적용되는지 여부를 지정합니다. 이 속성은 래스터 이미지 형식으로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.SmoothingMode입니다.
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+생성된 이미지를 TIFF 형식으로 저장할 때 적용할 압축 유형입니다. TIFF로 저장할 때만 영향을 미칩니다. 기본값은 Aspose.Diagram.Saving.TiffCompression입니다.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+이 속성에 대한 설명은 [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+이 속성에 대한 설명은 [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+이 속성에 대한 설명은 [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+이 속성에 대한 설명은 [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+이 속성에 대한 설명은 [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이 속성에 대한 설명은 [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+이 속성에 대한 설명은 [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+이 속성에 대한 설명은 [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/korean/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Aspose.Diagram for Java API 참조
+description: 각 객체에 대한 글꼴 구성.
+type: docs
+weight: 201
+url: /ko/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+각 [Diagram](../../com.aspose.diagram/diagram) 객체에 대한 글꼴 구성.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | 소스 목록을 포함하는 배열의 복사본을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | 글꼴 폴더를 설정합니다. |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | 글꼴 폴더들을 설정합니다. |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | 글꼴 소스를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+소스 목록을 포함하는 배열의 복사본을 가져옵니다.
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+글꼴 폴더를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fontFolder | java.lang.String | TrueType 글꼴을 포함하는 폴더입니다. |
+| recursive | boolean | 하위 폴더를 스캔할지 여부를 결정합니다. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+글꼴 폴더들을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | TrueType 글꼴을 포함하는 폴더들입니다. |
+| recursive | boolean | 하위 폴더를 스캔할지 여부를 결정합니다. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+글꼴 소스를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | TrueType 글꼴을 포함하는 소스 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/infiniteline/_index.md
+++ b/korean/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Aspose.Diagram for Java API 참조
+description: 무한선상의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다.
+type: docs
+weight: 202
+url: /ko/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+무한선상의 두 점에 대한 x 및 y 좌표를 지정하는 요소를 포함합니다. X와 Y 요소는 첫 번째 점의 x 및 y 좌표를 지정하고, A와 B 요소는 두 번째 점의 x 및 y 좌표를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | [InfiniteLine](../../com.aspose.diagram/infiniteline) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 무한선상의 점에 대한 x 좌표이며, y 좌표는 B 요소로 표시됩니다. |
+| [getB()](#getB--) | 무한선상의 점에 대한 y 좌표이며, x 좌표는 A 요소로 표시됩니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 무한선상의 점에 대한 x 좌표입니다. |
+| [getY()](#getY--) | 무한선상의 점에 대한 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/infiniteline\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/infiniteline\#getB--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/infiniteline\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/infiniteline\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+[InfiniteLine](../../com.aspose.diagram/infiniteline) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+무한선상의 점에 대한 x 좌표이며, y 좌표는 B 요소로 표시됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+무한선상의 점에 대한 y 좌표이며, x 좌표는 A 요소로 표시됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+무한선상의 점에 대한 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+무한선상의 점에 대한 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/infiniteline\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/infiniteline\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/infiniteline\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/infiniteline\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/korean/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Aspose.Diagram for Java API 참조
+description: InfiniteLine 컬렉션.
+type: docs
+weight: 203
+url: /ko/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+InfiniteLine 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/korean/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Aspose.Diagram for Java API 참조
+description: 입력기(Input Method Editor)의 기본 실행 시간 모드를 나타냅니다.
+type: docs
+weight: 204
+url: /ko/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+입력기(Input Method Editor)의 기본 실행 시간 모드를 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALPHA](#ALPHA) | 반각 영숫자 모드로 IME가 켜져 있습니다. |
+| [ALPHA_FULL](#ALPHA-FULL) | 전각 영숫자 모드로 IME가 켜져 있습니다. |
+| [DISABLE](#DISABLE) | IME가 꺼져 있습니다. 사용자는 키보드로 IME를 켤 수 없습니다. |
+| [HANGUL](#HANGUL) | 반각 한글 모드로 IME가 켜져 있습니다. |
+| [HANGUL_FULL](#HANGUL-FULL) | 전각 한글 모드로 IME가 켜져 있습니다. |
+| [HANZI](#HANZI) | 반각 한자 모드로 IME가 켜져 있습니다. |
+| [HANZI_FULL](#HANZI-FULL) | 전각 한자 모드로 IME가 켜져 있습니다. |
+| [HIRAGANA](#HIRAGANA) | 전각 히라가나 모드로 IME가 켜져 있습니다. |
+| [KATAKANA](#KATAKANA) | 전각 가타카나 모드로 IME가 켜져 있습니다. |
+| [KATAKANA_HALF](#KATAKANA-HALF) | 반각 가타카나 모드로 IME가 켜져 있습니다. |
+| [NO_CONTROL](#NO-CONTROL) | IME를 제어하지 않습니다. |
+| [OFF](#OFF) | IME가 꺼져 있습니다. |
+| [ON](#ON) | IME가 켜져 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+반각 영숫자 모드로 IME가 켜져 있습니다.
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+전각 영숫자 모드로 IME가 켜져 있습니다.
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IME가 꺼져 있습니다. 사용자는 키보드로 IME를 켤 수 없습니다.
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+반각 한글 모드로 IME가 켜져 있습니다.
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+전각 한글 모드로 IME가 켜져 있습니다.
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+반각 한자 모드로 IME가 켜져 있습니다.
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+전각 한자 모드로 IME가 켜져 있습니다.
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+전각 히라가나 모드로 IME가 켜져 있습니다.
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+전각 가타카나 모드로 IME가 켜져 있습니다.
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+반각 가타카나 모드로 IME가 켜져 있습니다.
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+IME를 제어하지 않습니다.
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IME가 꺼져 있습니다. 영어 모드.
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IME가 켜져 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/korean/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Aspose.Diagram for Java API 참조
+description: InterpolationMode 열거형은 이미지가 확대되거나 회전될 때 사용되는 알고리즘을 지정합니다.
+type: docs
+weight: 206
+url: /ko/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+InterpolationMode 열거형은 이미지가 확대되거나 회전될 때 사용되는 알고리즘을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | 양입방 보간을 지정합니다. |
+| [BILINEAR](#BILINEAR) | 양선형 보간을 지정합니다. |
+| [DEFAULT](#DEFAULT) | 기본 모드를 지정합니다. |
+| [HIGH](#HIGH) | 고품질 보간을 지정합니다. |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | 고품질 양입방 보간을 지정합니다. |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | 고품질 양선형 보간을 지정합니다. |
+| [INVALID](#INVALID) | QualityMode 열거형의 Invalid 요소와 동일합니다. |
+| [LOW](#LOW) | 저품질 보간을 지정합니다. |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | 최근접 이웃 보간을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+양입방 보간을 지정합니다. 사전 필터링이 수행되지 않습니다. 이 모드는 이미지 크기를 원본 크기의 25% 이하로 축소하는 데 적합하지 않습니다.
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+양선형 보간을 지정합니다. 사전 필터링이 수행되지 않습니다. 이 모드는 이미지 크기를 원본 크기의 50% 이하로 축소하는 데 적합하지 않습니다.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+기본 모드를 지정합니다.
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+고품질 보간을 지정합니다.
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+고품질 양입방 보간을 지정합니다. 고품질 축소를 보장하기 위해 사전 필터링이 수행됩니다. 이 모드는 가장 높은 품질의 변환된 이미지를 생성합니다.
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+고품질 양선형 보간을 지정합니다. 고품질 축소를 보장하기 위해 사전 필터링이 수행됩니다.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+QualityMode 열거형의 Invalid 요소와 동일합니다.
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+저품질 보간을 지정합니다.
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+최근접 이웃 보간을 지정합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/korean/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Aspose.Diagram for Java API 참조
+description: 인터럽트와 관련된 모든 연산자를 나타냅니다.
+type: docs
+weight: 207
+url: /ko/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+인터럽트와 관련된 모든 연산자를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | 현재 연산자를 중단합니다. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | 모니터가 중단을 요청하도록 표시합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+현재 연산자를 중단합니다.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+모니터가 중단을 요청하도록 표시합니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/intvalue/_index.md
+++ b/korean/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Aspose.Diagram for Java API 참조
+description: 정수 값
+type: docs
+weight: 205
+url: /ko/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+정수 값
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 정수 값. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | 이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)을(를) 참조하십시오. |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/intvalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+| 단위 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+정수 값.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/intvalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/korean/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 저장 프로세스의 진행 상황을 제어/표시합니다.
+type: docs
+weight: 456
+url: /ko/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+페이지 저장 프로세스의 진행 상황을 제어/표시합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Control/페이지가 출력될 끝을 나타냅니다. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Control/페이지가 출력되기 시작함을 나타냅니다. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Control/페이지가 출력될 끝을 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | 페이지 저장 프로세스 종료에 대한 정보. |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Control/페이지가 출력되기 시작함을 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | 페이지 저장 프로세스 시작에 대한 정보. |
+

--- a/korean/java/com.aspose.diagram/issue/_index.md
+++ b/korean/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 단일 검증 문제를 나타냅니다.
+type: docs
+weight: 208
+url: /ko/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+문서의 단일 검증 문제를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Issue()](#Issue--) | 생성자 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | 검증 문제의 고유 식별자를 지정합니다. |
+| [getIgnored()](#getIgnored--) | 검증 문제가 현재 무시되는지 여부를 지정합니다. |
+| [getIssueTarget()](#getIssueTarget--) | 상위 검증 문제의 대상에 따라, 상위 검증 문제가 연결된 페이지 또는 페이지와 도형을 모두 지정합니다. |
+| [getRuleInfo()](#getRuleInfo--) | 상위 검증 이슈와 관련된 검증 규칙에 대한 정보를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/issue\#getID--)을(를) 참조하십시오. |
+| [setIgnored(int value)](#setIgnored-int-) | 이 속성에 대한 설명은 [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+생성자
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+검증 문제의 고유 식별자를 지정합니다.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+검증 문제가 현재 무시되는지 여부를 지정합니다. 기본값은 False입니다.
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+부모 검증 문제의 대상에 따라 해당 문제와 연관된 페이지 또는 페이지와 도형 모두를 지정합니다. 부모 검증 문제의 대상이 문서인 경우, IssueTarget은 페이지도 도형도 지정하지 않습니다.
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+상위 검증 이슈와 관련된 검증 규칙에 대한 정보를 지정합니다.
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/issue\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+이 속성에 대한 설명은 [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/issuecollection/_index.md
+++ b/korean/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Issue 컬렉션.
+type: docs
+weight: 209
+url: /ko/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Issue 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | 컬렉션에 이슈를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | 컬렉션에서 이슈를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+컬렉션에 이슈를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+컬렉션에서 이슈를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/issuetarget/_index.md
+++ b/korean/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Aspose.Diagram for Java API 참조
+description: 부모 검증 문제의 대상에 따라 해당 문제와 연관된 페이지 또는 페이지와 도형 모두를 지정합니다.
+type: docs
+weight: 210
+url: /ko/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+부모 검증 문제의 대상에 따라 해당 문제와 연관된 페이지 또는 페이지와 도형 모두를 지정합니다. 부모 검증 문제의 대상이 문서인 경우, IssueTarget은 페이지도 도형도 지정하지 않습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | 부모 검증 문제와 연관된 페이지의 고유 식별자를 지정합니다. |
+| [getShapeId()](#getShapeId--) | 부모 검증 문제와 연관된 도형의 고유 식별자를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | 이 속성에 대한 설명은 [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)을(를) 참조하십시오. |
+| [setShapeId(long value)](#setShapeId-long-) | 이 속성에 대한 설명은 [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+부모 검증 문제와 연관된 페이지의 고유 식별자를 지정합니다. 대상이 문서인 경우, PageID 값은 0xFFFFFFFF가 될 수 있습니다.
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+부모 검증 문제와 연관된 도형의 고유 식별자를 지정합니다. 대상이 문서이거나 페이지인 경우, ShapeID 값은 0xFFFFFFFF가 될 수 있습니다.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+이 속성에 대한 설명은 [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+이 속성에 대한 설명은 [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/korean/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Aspose.Diagram for Java API 참조
+description: 내보낸 스트림 제공자를 나타냅니다.
+type: docs
+weight: 457
+url: /ko/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+내보낸 스트림 제공자를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | 스트림을 닫습니다. |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | 스트림을 가져옵니다. |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+스트림을 닫습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+스트림을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/korean/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/korean/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Aspose.Diagram for Java API 참조
+description: 경고에 대한 콜백 인터페이스입니다.
+type: docs
+weight: 458
+url: /ko/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+경고에 대한 콜백 인터페이스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | 우리 콜백은 "Warning" 메서드만 구현하면 됩니다. |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+우리 콜백은 "Warning" 메서드만 구현하면 됩니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | 경고 정보 |
+

--- a/korean/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: 레이블 ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 211
+url: /ko/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+레이블 ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | 컨트롤의 단축키입니다. |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getBorderOleColor()](#getBorderOleColor--) | the ole color of the background. |
+| [getBorderStyle()](#getBorderStyle--) | the type of border used by the control. |
+| [getCaption()](#getCaption--) | 컨트롤에 표시되는 설명 텍스트입니다. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPicturePosition()](#getPicturePosition--) | 컨트롤 캡션에 상대적인 그림의 위치. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isWordWrapped()](#isWordWrapped--) | 컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | 이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)을(를) 참조하십시오. |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | 이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오. |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | 이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)을(를) 참조하십시오. |
+| [setCaption(String value)](#setCaption-java.lang.String-) | 이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)을(를) 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)을(를) 참조하십시오. |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | 이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)을(를) 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | 이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+컨트롤의 단축키입니다.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+the type of border used by the control.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+컨트롤에 표시되는 설명 텍스트입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+컨트롤 캡션에 상대적인 그림의 위치.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layer/_index.md
+++ b/korean/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Layer
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 대한 단일 레이어와 그 속성을 정의하는 요소를 포함합니다.
+type: docs
+weight: 212
+url: /ko/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+페이지에 대한 단일 레이어와 그 속성을 정의하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Layer()](#Layer--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | 레이어가 활성 상태인지 여부를 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | 레이어를 표시하는 데 사용되는 색상표의 색상 인덱스 또는 색상표에 없는 사용자 정의 색상을 지정하는 RGB 값(예: \#ff9900). |
+| [getColorTrans()](#getColorTrans--) | 레이어 또는 도형 텍스트 색상의 투명도 정도를 0(완전히 불투명)에서 1(완전히 투명)까지 결정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getGlue()](#getGlue--) | 레이어에 속한 도형을 접착할 수 있는지 여부를 지정합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getLock()](#getLock--) | 레이어에 속한 도형이 선택되거나 편집되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다. |
+| [getName()](#getName--) | Name 요소는 레이어의 이름을 지정합니다. |
+| [getNameUniv()](#getNameUniv--) | 레이어의 전역 이름을 지정합니다. |
+| [getPrint()](#getPrint--) | 도면을 인쇄할 때 레이어에 속한 도형이 인쇄되는지 여부를 지정합니다. |
+| [getSnap()](#getSnap--) | 다른 도형이 레이어에 할당된 도형에 스냅될 수 있는지 여부를 지정합니다. |
+| [getStatus()](#getStatus--) | 레이어가 문서에 대한 유효한 레이어인지 여부를 지정합니다. |
+| [getVisible()](#getVisible--) | 레이어에 속한 도형이 도면 페이지에 표시되는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | 요소가 로컬에서 확인되었는지 여부를 나타내는 플래그입니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | 이 속성에 대한 설명은 [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layer\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/layer\#getIX--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+레이어가 활성 상태인지 여부를 지정합니다. 레이어에 미리 할당되지 않은 도형은 도면 페이지에 놓일 때 활성 레이어에 할당됩니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+레이어를 표시하는 데 사용되는 색상표의 색상 인덱스 또는 색상표에 없는 사용자 정의 색상을 지정하는 RGB 값(예: \#ff9900).
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+레이어 또는 도형 텍스트 색상의 투명도 정도를 0(완전히 불투명)에서 1(완전히 투명)까지 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+레이어에 속한 도형을 접착할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+레이어에 속한 도형이 선택되거나 편집되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name 요소는 레이어의 이름을 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+레이어의 전역 이름을 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+도면을 인쇄할 때 레이어에 속한 도형이 인쇄되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+다른 도형이 레이어에 할당된 도형에 스냅될 수 있는지 여부를 지정합니다. 레이어에 할당된 도형은 다른 도형에 스냅될 수 있지만, 다른 도형은 해당 도형에 스냅될 수 없습니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+레이어가 문서에 대한 유효한 레이어인지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+레이어에 속한 도형이 도면 페이지에 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+요소가 로컬에서 확인되었는지 여부를 나타내는 플래그입니다. 값이 1이면 요소가 로컬에서 확인된 것을 의미합니다.
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+이 속성에 대한 설명은 [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layer\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/layer\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layercollection/_index.md
+++ b/korean/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Layer 컬렉션.
+type: docs
+weight: 213
+url: /ko/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Layer 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | 컬렉션에 Layer 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | 컬렉션에서 Layer 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+컬렉션에 Layer 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+컬렉션에서 Layer 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layermem/_index.md
+++ b/korean/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Aspose.Diagram for Java API 참조
+description: 각 레이어에 할당된 도형을 지정하는 LayerMember 요소를 포함합니다.
+type: docs
+weight: 214
+url: /ko/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+도형이 할당된 각 레이어를 지정하는 LayerMember 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getLayerMember()](#getLayerMember--) | 도형이 할당된 레이어 또는 레이어들을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layermem\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+도형이 할당된 레이어 또는 레이어들을 지정합니다. 레이어 할당은 페이지의 레이어에 대한 0부터 시작하는 인덱스를 기준으로 지정됩니다. 도형이 둘 이상의 레이어에 할당된 경우 각 레이어 인덱스는 세미콜론으로 구분됩니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layermem\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layout/_index.md
+++ b/korean/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: 레이아웃
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다.
+type: docs
+weight: 215
+url: /ko/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | 커넥터가 재경로 지정되는 시점을 결정합니다. |
+| [getConLineJumpCode()](#getConLineJumpCode--) | 두 연결기가 교차할 때 연결기가 점프하는지 여부를 결정합니다, |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | 동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | 동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다. |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | 동적 커넥터의 라인 점프 스타일을 결정합니다. |
+| [getConLineRouteExt()](#getConLineRouteExt--) | 커넥터의 외관을 결정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDisplayLevel()](#getDisplayLevel--) | 도형에 대한 표시 레벨 밴드( Z-순서 그룹화의 상대 범위)를 결정합니다. |
+| [getRelationships()](#getRelationships--) | 컨테이너, 목록, 호출선 및 도형 간의 관계를 저장합니다. |
+| [getShapeFixedCode()](#getShapeFixedCode--) | 배치 가능한 도형에 대한 배치 동작을 지정합니다. |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | 사용자가 '도형 배치'(도형 메뉴)를 선택할 때 배치 가능한 도형을 기존 도형 위에 배치할 수 있는지 여부를 지정합니다. |
+| [getShapePermeableX()](#getShapePermeableX--) | 연결기가 도형을 가로로 통과하도록 라우팅할 수 있는지 여부를 지정합니다. |
+| [getShapePermeableY()](#getShapePermeableY--) | 연결기가 도형을 세로로 통과하도록 라우팅할 수 있는지 여부를 지정합니다. |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | 사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | 자식 요소에 대한 배치 스타일을 결정합니다. |
+| [getShapePlowCode()](#getShapePlowCode--) | 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다. |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다. |
+| [getShapeSplit()](#getShapeSplit--) | 이 도형이 분할 가능한 도형을 분할할 수 있는지 여부를 결정합니다. |
+| [getShapeSplittable()](#getShapeSplittable--) | 이 1차원 도형을 분할할 수 있는지 여부를 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layout\#getDel--)을(를) 참조하십시오. |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | 이 속성에 대한 설명은 [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+커넥터가 재경로 지정되는 시점을 결정합니다.
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+두 연결기가 교차할 때 연결기가 점프하는지 여부를 결정합니다,
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+동적 커넥터의 수평 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+동적 커넥터의 수직 구간에서 발생하는 라인 점프의 방향을 결정합니다.
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+동적 커넥터의 라인 점프 스타일을 결정합니다.
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+커넥터의 외관을 결정합니다.
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+도형에 대한 표시 레벨 밴드( Z-순서 그룹화의 상대 범위)를 결정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+컨테이너, 목록, 호출선 및 도형 간의 관계를 저장합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+배치 가능한 도형에 대한 배치 동작을 지정합니다.
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+사용자가 '도형 배치'(도형 메뉴)를 선택할 때 배치 가능한 도형을 기존 도형 위에 배치할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+연결기가 도형을 가로로 통과하도록 라우팅할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+연결기가 도형을 세로로 통과하도록 라우팅할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+자식 요소에 대한 배치 스타일을 결정합니다.
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+이 도형이 분할 가능한 도형을 분할할 수 있는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+이 1차원 도형을 분할할 수 있는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/layout\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+이 속성에 대한 설명은 [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/korean/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Aspose.Diagram for Java API 참조
+description: 레이아웃 방향을 설정하는 데 사용됩니다.
+type: docs
+weight: 216
+url: /ko/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+레이아웃 방향을 설정하는 데 사용됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | 도형을 아래에서 위로 배치합니다. |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | 도형을 먼저 아래쪽으로, 그 다음 왼쪽으로 배치합니다. |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | 도형을 먼저 아래쪽으로, 그 다음 오른쪽으로 배치합니다. |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | 도형을 먼저 왼쪽으로, 그 다음 아래쪽으로 배치합니다. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | 도형을 왼쪽에서 오른쪽으로 배치합니다. |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | 도형을 먼저 오른쪽으로, 그 다음 아래쪽으로 배치합니다. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | 도형을 오른쪽에서 왼쪽으로 배치합니다. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | 도형을 위에서 아래로 배치합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+도형을 아래에서 위로 배치합니다. Flowchart 스타일을 선택한 경우에만 의미가 있습니다.
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+도형을 먼저 아래쪽으로, 그 다음 왼쪽으로 배치합니다. CompactTree 스타일을 선택한 경우에만 의미가 있습니다.
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+도형을 먼저 아래쪽으로, 그 다음 오른쪽으로 배치합니다. CompactTree 스타일을 선택한 경우에만 의미가 있습니다.
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+도형을 먼저 왼쪽으로, 그 다음 아래쪽으로 배치합니다. CompactTree 스타일을 선택한 경우에만 의미가 있습니다.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+도형을 왼쪽에서 오른쪽으로 배치합니다. 흐름도 스타일을 선택한 경우에만 의미가 있습니다.
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+도형을 먼저 오른쪽으로, 그 다음 아래로 배치합니다. CompactTree 스타일을 선택한 경우에만 의미가 있습니다.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+도형을 오른쪽에서 왼쪽으로 배치합니다. 흐름도 스타일을 선택한 경우에만 의미가 있습니다.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+도형을 위에서 아래로 배치합니다. 흐름도 스타일을 선택한 경우에만 의미가 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/korean/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 재배치를 수행하기 위해 도형 레이아웃의 스타일 및 추가 옵션을 지정하는 데 사용됩니다.
+type: docs
+weight: 217
+url: /ko/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+페이지(들)의 레이아웃을 재배치하기 위해 도형 레이아웃의 스타일 및 추가 옵션을 지정하는 데 사용됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | LayoutOptions의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | 도형 레이아웃의 방향을 설정하는 데 사용됩니다. |
+| [getEnlargePage()](#getEnlargePage--) | 그리기에 맞게 페이지를 확대해야 하는지 여부를 정의합니다. |
+| [getLayoutStyle()](#getLayoutStyle--) | 레이아웃 스타일을 지정하는 데 사용됩니다. |
+| [getSpaceShapes()](#getSpaceShapes--) | 도형 간의 간격을 인치 단위로 정의합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | 이 속성에 대한 설명은 [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | 이 속성에 대한 설명은 [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | 이 속성에 대한 설명은 [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+LayoutOptions의 새 인스턴스를 초기화합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+도형 레이아웃의 방향을 설정하는 데 사용됩니다. 기본값은 TopToBottom입니다.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+그리기에 맞게 페이지를 확대해야 하는지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+레이아웃 스타일을 지정하는 데 사용됩니다. 기본값은 FlowChart입니다.
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+도형 간의 간격을 인치 단위로 정의합니다. 기본값은 0.3인치 ~ 7.5mm입니다.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+이 속성에 대한 설명은 [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+이 속성에 대한 설명은 [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/korean/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 레이아웃 스타일을 지정하는 데 사용됩니다.
+type: docs
+weight: 218
+url: /ko/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+레이아웃 스타일을 지정하는 데 사용됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | 원형 스타일. |
+| [COMPACT_TREE](#COMPACT-TREE) | 트리 스타일. |
+| [FLOW_CHART](#FLOW-CHART) | 플로우차트 스타일. |
+| [RADIAL](#RADIAL) | 방사형 스타일. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+원형 스타일.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+트리 스타일.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+플로우차트 스타일.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+방사형 스타일.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/license/_index.md
+++ b/korean/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: 라이선스
+second_title: Aspose.Diagram for Java API 참조
+description: 구성 요소를 라이선스하는 메서드를 제공합니다.
+type: docs
+weight: 219
+url: /ko/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+구성 요소를 라이선스하는 메서드를 제공합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [License()](#License--) | 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | 구성 요소에 라이선스를 적용합니다. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | 구성 요소에 라이선스를 적용합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+이 메서드를 사용하여 스트림에서 라이선스를 로드합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 라이선스를 포함하는 스트림입니다. |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+다음 위치에서 라이선스를 찾으려고 시도합니다:
+
+1. 명시적 경로.
+
+2. 구성 요소 어셈블리 폴더.
+
+3. 클라이언트 호출 어셈블리 폴더.
+
+4. 엔트리 어셈블리 폴더.
+
+5. 클라이언트 호출 어셈블리의 임베디드 리소스.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. 명시적 경로.
+
+2. 클라이언트 호출 어셈블리의 임베디드 리소스.
+
+2. 구성 요소 JAR 파일 폴더.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/korean/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Aspose.Diagram for Java API 참조
+description: 라이트 릭 방향 유형을 나타냅니다.
+type: docs
+weight: 220
+url: /ko/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+라이트 릭 방향 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 하단 |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | 왼쪽 하단. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | 오른쪽 하단. |
+| [LEFT](#LEFT) | Left. |
+| [RIGHT](#RIGHT) | Right. |
+| [TOP](#TOP) | 상단. |
+| [TOP_LEFT](#TOP-LEFT) | 왼쪽 상단. |
+| [TOP_RIGHT](#TOP-RIGHT) | 오른쪽 상단. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+하단
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+왼쪽 하단.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+오른쪽 하단.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+상단.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+왼쪽 상단.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+오른쪽 상단.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/line/_index.md
+++ b/korean/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Aspose.Diagram for Java API 참조
+description: 도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다.
+type: docs
+weight: 221
+url: /ko/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | 선의 첫 번째 정점에 화살촉 또는 기타 선 끝 형식이 있는지 여부를 나타냅니다. |
+| [getBeginArrowSize()](#getBeginArrowSize--) | 선의 시작 부분에 있는 화살촉의 크기를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | 도형의 선 CompoundType을 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getEndArrow()](#getEndArrow--) | 선의 마지막 정점에 화살촉 또는 기타 선 끝 형식이 있는지 여부를 나타냅니다. |
+| [getEndArrowSize()](#getEndArrowSize--) | 선의 끝 부분에 있는 화살촉의 크기를 지정합니다. |
+| [getGradientLine()](#getGradientLine--) | 도형에 대한 현재 그라디언트 선 서식 값을 포함합니다. |
+| [getLineCap()](#getLineCap--) | 선이 둥근 끝인지 사각형 끝인지 여부를 지정합니다. |
+| [getLineColor()](#getLineColor--) | 도형의 선 색상을 지정합니다. |
+| [getLineColorTrans()](#getLineColorTrans--) | 도형 선 색상의 투명도 수준을 지정합니다(0은 불투명, 1은 완전 투명). |
+| [getLinePattern()](#getLinePattern--) | 도형의 선 패턴을 지정합니다. |
+| [getLineWeight()](#getLineWeight--) | 도형의 선 두께를 지정합니다. |
+| [getRounding()](#getRounding--) | 경로의 두 연속 세그먼트가 만나는 지점에 적용되는 라운딩 호의 반경을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)을 참조하십시오. |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | 이 속성에 대한 설명은 [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)을 참조하십시오. |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | 이 속성에 대한 설명은 [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/line\#getDel--)을 참조하십시오. |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)을 참조하십시오. |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | 이 속성에 대한 설명은 [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)을 참조하십시오. |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)을 참조하십시오. |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)을 참조하십시오. |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)을 참조하십시오. |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)을 참조하십시오. |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)을 참조하십시오. |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getRounding()](../../com.aspose.diagram/line\#getRounding--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+선의 첫 번째 정점에 화살촉 또는 기타 선 끝 형식이 있는지 여부를 나타냅니다. 0에서 45 사이의 숫자를 입력하거나 사용자 지정 선 끝 이름과 함께 USE 함수를 사용하십시오.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+선 시작 부분의 화살촉 크기를 결정합니다. 0부터 6까지의 숫자를 입력하십시오.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+도형의 선 CompoundType을 지정합니다.
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+선의 마지막 정점에 화살촉 또는 기타 선 끝 형식이 있는지 여부를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+선의 끝 부분에 있는 화살촉의 크기를 지정합니다.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+도형에 대한 현재 그라디언트 선 서식 값을 포함합니다.
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+선이 둥근 끝인지 사각형 끝인지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+도형의 선 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+도형 선 색상의 투명도 수준을 지정합니다. 0(불투명)부터 1(완전 투명)까지입니다. 기본값은 0입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+도형의 선 패턴을 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+도형의 선 두께를 지정합니다. 선 두께는 도면의 축척과 무관합니다. 도면이 확대/축소되더라도 선 두께는 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+경로의 두 인접 세그먼트가 만나는 지점에 적용되는 라운딩 호의 반경을 지정합니다. 예를 들어, 라운딩을 사용하여 사각형에 둥근 모서리를 만들 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+이 속성에 대한 설명은 [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+이 속성에 대한 설명은 [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/line\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+이 속성에 대한 설명은 [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRounding()](../../com.aspose.diagram/line\#getRounding--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/korean/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustFrom
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+type: docs
+weight: 222
+url: /ko/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/korean/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+type: docs
+weight: 223
+url: /ko/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | 모든 선. |
+| [NO_LINES](#NO-LINES) | 선 없음. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | 라우팅 스타일 기본값. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | 관련 없는 줄입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+모든 선.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+선 없음.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+라우팅 스타일 기본값.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+관련 없는 줄입니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/korean/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+type: docs
+weight: 224
+url: /ko/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/korean/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustToValue
+second_title: Aspose.Diagram for Java API 참조
+description: 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+type: docs
+weight: 225
+url: /ko/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | 서로 가깝게 위치한 모든 선. |
+| [NO_LINES](#NO-LINES) | 선 없음. |
+| [RELATEDLINES](#RELATEDLINES) | 관련 선. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | 라우팅 스타일 기본값. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+서로 가깝게 위치한 모든 선.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+선 없음.
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+관련 선.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+라우팅 스타일 기본값.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/korean/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Aspose.Diagram for Java API 참조
+description: 점프를 추가하려는 동적 커넥터를 결정합니다.
+type: docs
+weight: 226
+url: /ko/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+점프를 추가하려는 동적 커넥터를 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 점프를 추가하려는 동적 커넥터를 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+점프를 추가하려는 동적 커넥터를 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 점프를 추가하려는 동적 커넥터를 결정합니다.
+type: docs
+weight: 227
+url: /ko/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+점프를 추가하려는 동적 커넥터를 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | 첫 번째 표시된 선(표시 순서에서 아래쪽 도형). |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | 수평선. |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | 마지막 표시된 선(표시 순서에서 위쪽 도형). |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | 마지막 라우팅된 선. |
+| [NONE](#NONE) | 없음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | 수직선. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+첫 번째 표시된 선(표시 순서에서 아래쪽 도형).
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+수평선.
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+마지막 표시된 선(표시 순서에서 위쪽 도형).
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+마지막 라우팅된 선.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+없음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+수직선.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/korean/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 그림 페이지의 로컬 라인 점프 스타일이 없는 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+type: docs
+weight: 228
+url: /ko/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그림 페이지의 로컬 라인 점프 스타일이 없는 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+type: docs
+weight: 229
+url: /ko/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ARC](#ARC) | 호. |
+| [DEFAULT](#DEFAULT) | 기본값. |
+| [GAP](#GAP) | 간격. |
+| [SIDES_2](#SIDES-2) | 2면. |
+| [SIDES_3](#SIDES-3) | 3면. |
+| [SIDES_4](#SIDES-4) | 4면. |
+| [SIDES_5](#SIDES-5) | 5면. |
+| [SIDES_6](#SIDES-6) | 6면. |
+| [SIDES_7](#SIDES-7) | 7면. |
+| [SQUARE](#SQUARE) | 정사각형. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+호.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+기본값.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+간격.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2면.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3면.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4면.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5면.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6면.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7면.
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+정사각형.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linerouteext/_index.md
+++ b/korean/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+type: docs
+weight: 230
+url: /ko/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/korean/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+type: docs
+weight: 231
+url: /ko/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CURVED](#CURVED) | 곡선. |
+| [DEFAULT](#DEFAULT) | 기본값. |
+| [STRAIGHT](#STRAIGHT) | 직선. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+곡선.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+기본값.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+직선.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/lineto/_index.md
+++ b/korean/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Aspose.Diagram for Java API 참조
+description: 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 232
+url: /ko/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+직선 세그먼트의 끝 정점에 대한 x 및 y 좌표를 포함합니다. 이러한 좌표는 각각 X 및 Y 요소에 포함됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LineTo()](#LineTo--) | 다음 [LineTo](../../com.aspose.diagram/lineto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 직선 세그먼트 끝 정점의 x 좌표입니다. |
+| [getY()](#getY--) | 직선 세그먼트 끝 정점의 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/lineto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/lineto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/lineto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/lineto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+다음 [LineTo](../../com.aspose.diagram/lineto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+직선 세그먼트 끝 정점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+직선 세그먼트 끝 정점의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/lineto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/lineto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/lineto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/lineto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/linetocollection/_index.md
+++ b/korean/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: LineTo 컬렉션.
+type: docs
+weight: 233
+url: /ko/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+LineTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: ListBox ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 234
+url: /ko/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+ListBox ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getBorderOleColor()](#getBorderOleColor--) | the ole color of the background. |
+| [getBorderStyle()](#getBorderStyle--) | the type of border used by the control. |
+| [getBoundColumn()](#getBoundColumn--) | Represents how the Value property is determined for a ComboBox or ListBox when the MultiSelect propertys value (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Represents the number of columns to display in a ComboBox or ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | the width of the column. |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getIntegralHeight()](#getIntegralHeight--) | 컨트롤이 부분적인 줄을 표시하지 않고 전체 텍스트 줄만 표시할지 여부를 나타냅니다. |
+| [getListStyle()](#getListStyle--) | 시각적 모양. |
+| [getListWidth()](#getListWidth--) | 포인트 단위의 너비. |
+| [getMatchEntry()](#getMatchEntry--) | 사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getScrollBars()](#getScrollBars--) | 컨트롤에 수직 스크롤 바, 수평 스크롤 바, 둘 다, 또는 전혀 없는지를 나타냅니다. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | 열 머리글이 표시되는지 여부를 나타냅니다. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getTextColumn()](#getTextColumn--) | 사용자에게 표시할 ComboBox 또는 ListBox의 열을 나타냅니다. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getValue()](#getValue--) | 컨트롤의 값. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | 이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오. |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | 이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)을(를) 참조하십시오. |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | 이 속성에 대한 설명은 [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)을(를) 참조하십시오. |
+| [setColumnCount(int value)](#setColumnCount-int-) | 이 속성에 대한 설명은 [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)을(를) 참조하십시오. |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | 이 속성에 대한 설명은 [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)을(를) 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | 이 속성에 대한 설명은 [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)을(를) 참조하십시오. |
+| [setListStyle(int value)](#setListStyle-int-) | 이 속성에 대한 설명은 [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)을(를) 참조하십시오. |
+| [setListWidth(double value)](#setListWidth-double-) | 이 속성에 대한 설명은 [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | 이 속성에 대한 설명은 [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setScrollBars(int value)](#setScrollBars-int-) | 이 속성에 대한 설명은 [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)을(를) 참조하십시오. |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | 이 속성에 대한 설명은 [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)을(를) 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오. |
+| [setTextColumn(int value)](#setTextColumn-int-) | 이 속성에 대한 설명은 [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+the type of border used by the control.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Represents how the Value property is determined for a ComboBox or ListBox when the MultiSelect propertys value (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Represents the number of columns to display in a ComboBox or ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+the width of the column.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+컨트롤이 부분적인 줄을 표시하지 않고 전체 텍스트 줄만 표시할지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+시각적 모양.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+포인트 단위의 너비.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+사용자가 입력할 때 ListBox 또는 ComboBox가 목록을 검색하는 방식을 나타냅니다.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+컨트롤에 수직 스크롤 바, 수평 스크롤 바, 둘 다, 또는 전혀 없는지를 나타냅니다.
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+열 머리글이 표시되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+사용자에게 표시할 ComboBox 또는 ListBox의 열을 나타냅니다.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+컨트롤의 값.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+이 속성에 대한 설명은 [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+이 속성에 대한 설명은 [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+이 속성에 대한 설명은 [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+이 속성에 대한 설명은 [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+이 속성에 대한 설명은 [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/korean/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 형식 선택 로드를 위한 열거형.
+type: docs
+weight: 235
+url: /ko/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+다이어그램 형식 선택 로드를 위한 열거형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [VDW](#VDW) | MS Visio Vdw 웹 도면 형식. |
+| [VDX](#VDX) | MS Visio VDX XML 형식. |
+| [VSD](#VSD) | MS Visio Vsd 바이너리 형식. |
+| [VSDM](#VSDM) | 매크로를 활성화하는 MS Visio Vsdm 파일 형식. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx 파일 형식. |
+| [VSS](#VSS) | MS Visio Vss 바이너리 스텐실 형식. |
+| [VSSM](#VSSM) | 매크로를 활성화하는 MS Visio Vssm 파일 형식. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx 파일 형식. |
+| [VST](#VST) | MS Visio Vst 바이너리 템플릿 형식. |
+| [VSTM](#VSTM) | 매크로를 활성화하는 MS Visio Vstm 파일 형식. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx 템플릿 파일 형식. |
+| [VSX](#VSX) | MS Visio Vsx xml 스텐실 형식. |
+| [VTX](#VTX) | MS Visio Vtx XML 템플릿 형식. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio Vdw 웹 도면 형식.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX XML 형식.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio Vsd 바이너리 형식.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+매크로를 활성화하는 MS Visio Vsdm 파일 형식.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx 파일 형식.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio Vss 바이너리 스텐실 형식.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+매크로를 활성화하는 MS Visio Vssm 파일 형식.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx 파일 형식.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio Vst 바이너리 템플릿 형식.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+매크로를 활성화하는 MS Visio Vstm 파일 형식.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx 템플릿 파일 형식.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml 스텐실 형식.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vtx XML 템플릿 형식.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/loadoptions/_index.md
+++ b/korean/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램을 Diagram 객체에 로드할 때 추가 옵션을 지정할 수 있습니다.
+type: docs
+weight: 236
+url: /ko/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+다이어그램을 Diagram 객체에 로드할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | 이 클래스의 새 인스턴스를 기본값으로 초기화합니다. |
+| [LoadOptions(int format)](#LoadOptions-int-) | 지정된 형식으로 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | 인터럽트 모니터. |
+| [getLoadFormat()](#getLoadFormat--) | 로드할 다이어그램의 형식을 지정합니다. |
+| [getLocale()](#getLocale--) | 파일이 로드될 때 다이어그램에 사용된 로케일. |
+| [getPages()](#getPages--) | 로드할 페이지의 인덱스를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | 이 속성에 대한 설명은 [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)을(를) 참조하십시오. |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | 이 속성에 대한 설명은 [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)을(를) 참조하십시오. |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | 이 속성에 대한 설명은 [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)을(를) 참조하십시오. |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | 이 속성에 대한 설명은 [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+이 클래스의 새 인스턴스를 기본값으로 초기화합니다. 기본 파일 형식은 Aspose.Diagram.LoadFileFormat으로 설정됩니다.
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+지정된 형식으로 이 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 형식 | int | Aspose.Diagram.LoadFileFormat load file format. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+인터럽트 모니터.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Specifies the format of the diagram to be loaded. Default is Aspose.Diagram.LoadFileFormat. Read/write Aspose.Diagram.LoadFileFormat.
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+파일이 로드될 때 다이어그램에 사용된 로케일.
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+로드할 페이지의 인덱스를 지정합니다.
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+이 속성에 대한 설명은 [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+이 속성에 대한 설명은 [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+이 속성에 대한 설명은 [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/localizefont/_index.md
+++ b/korean/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트를 다른 언어로 현지화 번역할지 여부를 지정합니다.
+type: docs
+weight: 237
+url: /ko/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/localizefont\\#getUfe--)을 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/localizefont\\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/localizefont\\#getUfe--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/localizefont\\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/korean/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트를 다른 언어로 현지화 번역할지 여부를 지정합니다.
+type: docs
+weight: 238
+url: /ko/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+도형 텍스트를 현지화(다른 언어로 번역)할지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | 항상 글꼴을 현지화합니다. |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | 글꼴이 Arial 또는 Symbol(기본값)인 경우에만 현지화합니다. |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | 글꼴을 절대 현지화하지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+항상 글꼴을 현지화합니다.
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+글꼴이 Arial 또는 Symbol(기본값)인 경우에만 현지화합니다.
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+글꼴을 절대 현지화하지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/margin/_index.md
+++ b/korean/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Aspose.Diagram for Java API 참조
+description: 여백을 지정합니다.
+type: docs
+weight: 239
+url: /ko/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+여백을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | 단위 측정값을 나타냅니다. |
+| [getValue()](#getValue--) | 여백을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | 이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/margin\#getUnit--)을(를) 참조하십시오. |
+| [setValue(double value)](#setValue-double-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/margin\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+| 단위 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+단위 측정값을 나타냅니다. 기본값은 DP입니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+여백을 지정합니다.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/margin\#getUnit--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/margin\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/master/_index.md
+++ b/korean/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Aspose.Diagram for Java API 참조
+description: 문서의 마스터를 정의하는 요소를 포함합니다.
+type: docs
+weight: 240
+url: /ko/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+문서에 대한 마스터를 정의하는 요소를 포함합니다. 마스터는 스텐실에 있는 도형으로, 그림을 만들 때 반복해서 사용합니다. 스텐실에서 도형을 그림 페이지로 끌어오면, 해당 도형은 그 마스터의 인스턴스가 되며, 마스터의 로컬 복사본이 문서에 포함됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Master()](#Master--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [dispose()](#dispose--) | 관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | 스텐실 창에서 마스터의 텍스트가 왼쪽, 오른쪽 또는 가운데 정렬인지 지정합니다. |
+| [getBaseID()](#getBaseID--) | 문서 전반에 걸쳐 마스터를 식별하는 GUID(전역 고유 식별자)입니다. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | 그림에서 두 도형 사이의 각 연결에 대한 Connect 요소를 포함합니다. |
+| [getHidden()](#getHidden--) | 사용자 인터페이스에서 마스터가 숨겨져 있는지 지정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIcon()](#getIcon--) | 문서의 Master 또는 MasterShortcut 요소에 대한 MIME(다목적 인터넷 메일 확장) 인코딩된 바이너리 아이콘(.ico 형식)을 지정합니다. |
+| [getIconSize()](#getIconSize--) | 요소 아이콘의 크기입니다. |
+| [getIconUpdate()](#getIconUpdate--) | 아이콘이 마스터 자체에서 자동으로 생성되는지 여부를 지정합니다. |
+| [getMatchByName()](#getMatchByName--) | MatchByName 속성은 마스터 인스턴스를 그림 페이지에 놓을 때 Microsoft Visio가 문서 마스터가 이미 존재하는지를 판단하는 방식을 결정합니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPageSheet()](#getPageSheet--) | 페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다. |
+| [getPatternFlags()](#getPatternFlags--) | PatternFlags 속성은 마스터가 사용자 지정 패턴으로 동작하는지를 결정합니다. |
+| [getPrompt()](#getPrompt--) | 요소에 대한 상태 표시줄 및 툴팁 프롬프트입니다. |
+| [getShapes()](#getShapes--) | Shape 객체들의 컬렉션입니다. |
+| [getUniqueID()](#getUniqueID--) | 문서 내에서 마스터를 식별하는 GUID입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | 이 속성에 대한 설명은 [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)을(를) 참조하십시오. |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | 이 속성에 대한 설명은 [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)을(를) 참조하십시오. |
+| [setHidden(int value)](#setHidden-int-) | 이 속성에 대한 설명은 [getHidden()](../../com.aspose.diagram/master\#getHidden--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/master\#getID--)을(를) 참조하십시오. |
+| [setIcon(byte[] value)](#setIcon-byte---) | 이 속성에 대한 설명은 [getIcon()](../../com.aspose.diagram/master\#getIcon--)을(를) 참조하십시오. |
+| [setIconSize(int value)](#setIconSize-int-) | 이 속성에 대한 설명은 [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)을(를) 참조하십시오. |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | 이 속성에 대한 설명은 [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)을(를) 참조하십시오. |
+| [setMatchByName(int value)](#setMatchByName-int-) | 이 속성에 대한 설명은 [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/master\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/master\#getNameU--)을(를) 참조하십시오. |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | 이 속성에 대한 설명은 [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)을(를) 참조하십시오. |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | 이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)을(를) 참조하십시오. |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | 이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+스텐실 창에서 마스터의 텍스트가 왼쪽, 오른쪽 또는 가운데 정렬인지 지정합니다.
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+문서 전반에 걸쳐 마스터를 식별하는 GUID(전역 고유 식별자)입니다.
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+그림에서 두 도형 사이의 각 연결에 대한 Connect 요소를 포함합니다.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+사용자 인터페이스에서 마스터가 숨겨져 있는지 지정합니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+문서의 Master 또는 MasterShortcut 요소에 대한 MIME(다목적 인터넷 메일 확장) 인코딩된 바이너리 아이콘(.ico 형식)을 지정합니다.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+요소 아이콘의 크기입니다.
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+아이콘이 마스터 자체에서 자동으로 생성되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+MatchByName 속성은 Microsoft Visio가 마스터 인스턴스를 그리기 페이지에 놓을 때 해당 문서 마스터가 이미 존재하는지를 판단하는 방식을 결정합니다. 이를 통해 문서 마스터에 대한 변경 사항이 새 마스터 인스턴스에도 적용되며, 인스턴스가 독립 스텐실 파일에서 끌어온 경우에도 적용됩니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+PatternFlags 속성은 마스터가 사용자 지정 패턴으로 동작하는지를 결정합니다.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+요소에 대한 상태 표시줄 및 툴팁 프롬프트입니다.
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Shape 객체들의 컬렉션입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+문서 내에서 마스터를 식별하는 GUID입니다.
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+이 속성에 대한 설명은 [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+이 속성에 대한 설명은 [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+이 속성에 대한 설명은 [getHidden()](../../com.aspose.diagram/master\#getHidden--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/master\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getIcon()](../../com.aspose.diagram/master\#getIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+이 속성에 대한 설명은 [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+이 속성에 대한 설명은 [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+이 속성에 대한 설명은 [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/master\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/master\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+이 속성에 대한 설명은 [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/mastercollection/_index.md
+++ b/korean/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Master 컬렉션.
+type: docs
+weight: 241
+url: /ko/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+Master 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | 컬렉션에 Master 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getMaster(int ID)](#getMaster-int-) | Gets the element at the specified ID. |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | 이름으로 마스터를 가져옵니다. |
+| [getMasterShortcuts()](#getMasterShortcuts--) | MasterShortcut 컬렉션. |
+| [getMaxRelID()](#getMaxRelID--) | 컬렉션에서 최대 rel id를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [isExist(String name)](#isExist-java.lang.String-) | 컬렉션에 마스터가 존재하는지 확인합니다. |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | 컬렉션에 마스터 rel id가 존재하는지 확인합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | 컬렉션에서 Master 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+컬렉션에 Master 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+이름으로 마스터를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+MasterShortcut 컬렉션.
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+컬렉션에서 최대 rel id를 가져옵니다.
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+컬렉션에 마스터가 존재하는지 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+컬렉션에 마스터 rel id가 존재하는지 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+컬렉션에서 Master 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/korean/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에 정의된 마스터 바로가기를 지정합니다.
+type: docs
+weight: 242
+url: /ko/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+문서에 정의된 마스터 바로가기를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | 스텐실 창에서 요소의 텍스트가 왼쪽, 오른쪽 또는 가운데 정렬되는지 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIcon()](#getIcon--) | 문서의 Master 또는 MasterShortcut 요소에 대한 MIME(다목적 인터넷 메일 확장) 인코딩된 바이너리 아이콘(.ico 형식)을 지정합니다. |
+| [getIconSize()](#getIconSize--) | 요소 아이콘의 크기입니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPatternFlags()](#getPatternFlags--) | 마스터가 사용자 지정 패턴으로 동작하는지 여부를 결정합니다. |
+| [getPrompt()](#getPrompt--) | 요소에 대한 상태 표시줄 및 툴팁 프롬프트입니다. |
+| [getShortcutHelp()](#getShortcutHelp--) | 요소에 대한 도움말 문자열입니다. |
+| [getShortcutURL()](#getShortcutURL--) | MasterShortcut 요소에 대한 URL입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | 이 속성에 대한 설명은 [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/mastershortcut\#getID--)을(를) 참조하십시오. |
+| [setIcon(byte[] value)](#setIcon-byte---) | 이 속성에 대한 설명은 [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)을(를) 참조하십시오. |
+| [setIconSize(int value)](#setIconSize-int-) | 이 속성에 대한 설명은 [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/mastershortcut\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)을(를) 참조하십시오. |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | 이 속성에 대한 설명은 [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)을(를) 참조하십시오. |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | 이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)을(를) 참조하십시오. |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | 이 속성에 대한 설명은 [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)을(를) 참조하십시오. |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | 이 속성에 대한 설명은 [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+스텐실 창에서 요소의 텍스트가 왼쪽, 오른쪽 또는 가운데 정렬되는지 지정합니다.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+문서의 Master 또는 MasterShortcut 요소에 대한 MIME(다목적 인터넷 메일 확장) 인코딩된 바이너리 아이콘(.ico 형식)을 지정합니다.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+요소 아이콘의 크기입니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+마스터가 사용자 지정 패턴으로 동작하는지 여부를 결정합니다.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+요소에 대한 상태 표시줄 및 툴팁 프롬프트입니다.
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+요소에 대한 도움말 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+MasterShortcut 요소에 대한 URL입니다. 이 속성이 존재하면 해당 MasterShortcut 요소는 바로 가기입니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+이 속성에 대한 설명은 [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/mastershortcut\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+이 속성에 대한 설명은 [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/mastershortcut\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+이 속성에 대한 설명은 [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+이 속성에 대한 설명은 [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+이 속성에 대한 설명은 [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/korean/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Aspose.Diagram for Java API 참조
+description: MasterShortcut 컬렉션.
+type: docs
+weight: 243
+url: /ko/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+MasterShortcut 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | 컬렉션에 Master 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | 컬렉션에서 MasterShortcut 개체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+컬렉션에 Master 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+컬렉션에서 MasterShortcut 개체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/measureconst/_index.md
+++ b/korean/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Aspose.Diagram for Java API 참조
+description: 측정 단위.
+type: docs
+weight: 244
+url: /ko/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+단위\ 측정.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AC](#AC) | 에이커. |
+| [AD](#AD) | 도. |
+| [AM](#AM) | 분. |
+| [AS](#AS) | 초. |
+| [BOOL](#BOOL) | 불리언. |
+| [C](#C) | 시세로. |
+| [CM](#CM) | 센티미터. |
+| [COLOR](#COLOR) | 색상 값. |
+| [CY](#CY) | 통화. |
+| [C_D](#C-D) | 시세로/디딧. |
+| [D](#D) | 디돗. |
+| [DA](#DA) | 기본 각도 단위. |
+| [DATE](#DATE) | 날짜 및 시간. |
+| [DE](#DE) | 기본 지속 시간 단위. |
+| [DEG](#DEG) | 소수 각도. |
+| [DL](#DL) | 기본 길이 단위. |
+| [DP](#DP) | 기본 페이지 단위. |
+| [DT](#DT) | 기본 유형 단위. |
+| [ED](#ED) | 경과 일수. |
+| [EH](#EH) | 경과 시간. |
+| [EM](#EM) | 경과 분. |
+| [ES](#ES) | 경과 초. |
+| [EW](#EW) | 경과 주. |
+| [FT](#FT) | 피트. |
+| [F_I](#F-I) | 피트/인치. |
+| [GUID](#GUID) | 전역 고유 식별자. |
+| [HA](#HA) | 헥타르. |
+| [IN](#IN) | 인치. |
+| [IN_F](#IN-F) | 인치 소수. |
+| [KM](#KM) | 킬로미터. |
+| [M](#M) | 미터. |
+| [MI](#MI) | 마일. |
+| [MI_F](#MI-F) | 마일 소수. |
+| [MM](#MM) | 밀리미터. |
+| [MULTIDIM](#MULTIDIM) | 다차원 값. |
+| [NM](#NM) | 해리. |
+| [NUM](#NUM) | 숫자. |
+| [NURBS](#NURBS) | Nurbs 곡선 데이터. |
+| [P](#P) | 파이카. |
+| [PER](#PER) | 백분율. |
+| [PNT](#PNT) | 2-D 좌표. |
+| [POLYLINE](#POLYLINE) | 폴리라인 포인트 데이터. |
+| [PT](#PT) | 포인트. |
+| [P_PT](#P-PT) | 파이카/포인트. |
+| [RAD](#RAD) | 라디안. |
+| [STR](#STR) | 문자열. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [YD](#YD) | 야드. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+에이커.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+도.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+분.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+초.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+불리언.
+
+### C {#C}
+```
+public static final int C
+```
+
+
+시세로.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+센티미터.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+색상 값.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+통화.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+시세로/디딧.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+디돗.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+기본 각도 단위.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+날짜 및 시간.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+기본 지속 시간 단위.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+소수 각도.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+기본 길이 단위.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+기본 페이지 단위.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+기본 유형 단위.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+경과 일수.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+경과 시간.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+경과 분.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+경과 초.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+경과 주.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+피트.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+피트/인치.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+전역 고유 식별자.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+헥타르.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+인치.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+인치 소수.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+킬로미터.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+미터.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+마일.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+마일 소수.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+밀리미터.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+다차원 값.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+해리.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+숫자.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Nurbs 곡선 데이터.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+파이카.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+백분율.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+2-D 좌표.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+폴리라인 포인트 데이터.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+포인트.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+파이카/포인트.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+라디안.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+문자열.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+야드.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/korean/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Aspose.Diagram for Java API 참조
+description: 메모리에 저장된 단일 TrueType 폰트 파일을 나타냅니다.
+type: docs
+weight: 245
+url: /ko/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+메모리에 저장된 단일 TrueType 폰트 파일을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | 이진 폰트 데이터. |
+| [getType()](#getType--) | 폰트 소스의 유형을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fontData | byte[] | 이진 폰트 데이터. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+이진 폰트 데이터.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+폰트 소스의 유형을 반환합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/korean/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Aspose.Diagram for Java API 참조
+description: MilestoneHelper를 사용하여 마일스톤 도형의 속성을 설정합니다.
+type: docs
+weight: 246
+url: /ko/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+MilestoneHelper를 사용하여 마일스톤 도형의 속성을 설정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | 마일스톤 날짜 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | 마일스톤 새로 고침 |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | 타임라인에서 마커(마일스톤, 구간)를 이동할 때 데이터를 업데이트할지 여부 |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | 모양의 DateFormat /// |
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | 모양의 DateFormat 문자열 |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | 모양의 유형 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+마일스톤 날짜
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+마일스톤 새로 고침
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+타임라인에서 마커(마일스톤, 구간)를 이동할 때 데이터를 업데이트할지 여부
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+모양의 DateFormat ///
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+모양의 DateFormat 문자열
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+모양의 유형
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/misc/_index.md
+++ b/korean/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: 기타
+second_title: Aspose.Diagram for Java API 참조
+description: 선택 강조 및 가시성을 제어하는 요소와 같은 도형 및 그룹의 다양한 요소를 포함합니다.
+type: docs
+weight: 247
+url: /ko/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+선택 강조 및 가시성을 제어하는 요소와 같이 도형 및 그룹의 다양한 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Microsoft Visio에서 생성된 트리거 수식을 포함하며, 이는 1차원 도형의 시작점을 이동하여 다른 도형과의 연결을 유지할지 여부를 결정합니다. |
+| [getCalendar()](#getCalendar--) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | 도형에 대한 주석 텍스트를 문자열 형식으로 포함합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDropOnPageScale()](#getDropOnPageScale--) | 도형을 그리기 페이지에 놓을 때 도형이 확대되는 비율을 결정합니다. |
+| [getDynFeedback()](#getDynFeedback--) | 연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다. |
+| [getEndTrigger()](#getEndTrigger--) | Microsoft Visio에서 생성된 트리거 수식을 포함합니다. |
+| [getGlueType()](#getGlueType--) | 도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다. |
+| [getHideText()](#getHideText--) | 도형의 텍스트를 숨깁니다. |
+| [getLangID()](#getLangID--) | 셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다. |
+| [getLocalizeMerge()](#getLocalizeMerge--) | 도형이 문서 간에 복사될 때 도형이 현지화되는지(그들의 LangID 요소가 재설정되는지) 여부를 결정합니다. |
+| [getNoAlignBox()](#getNoAlignBox--) | 도형이 선택될 때 선택 사각형이 표시되는지 여부를 지정합니다. |
+| [getNoCtlHandles()](#getNoCtlHandles--) | 도형이 선택될 때 제어 핸들이 표시되는지 여부를 지정합니다. |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | 사용자가 도형을 조작할 때 도형이 동적으로 크기 조정되거나 회전하는지 여부를 지정합니다. |
+| [getNoObjHandles()](#getNoObjHandles--) | 도형이 선택될 때 선택 핸들이 표시되는지 여부를 지정합니다. |
+| [getNonPrinting()](#getNonPrinting--) | 선택된 도형을 인쇄할 수 있는지 여부를 지정합니다. |
+| [getObjType()](#getObjType--) | Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다. |
+| [getShapeKeywords()](#getShapeKeywords--) | 맞춤 마스터 도형에 할당된 검색 키워드를 포함합니다. |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | 제어 핸들이 이동될 때마다 도형의 선택 사각형을 재계산할지 여부를 지정합니다. |
+| [getWalkPreference()](#getWalkPreference--) | 동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | 도형을 그룹에 끌어다 놓아 그룹에 추가할 수 있는지 여부를 지정합니다. |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | 마스터 도형의 지정된 셀 값이 도형 교체 작업 중 교체되는 도형의 값(로컬 값 포함)을 덮어쓰는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/misc\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Microsoft Visio에서 생성된 트리거 수식을 포함하며, 이는 1차원 도형의 시작점을 이동하여 다른 도형과의 연결을 유지할지 여부를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+도형에 대한 주석 텍스트를 문자열 형식으로 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+도형을 그리기 페이지에 놓을 때 도형이 확대되는 비율을 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+연결자를 끌 때 사용자에게 제공되는 시각적 피드백 유형을 지정합니다.
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Microsoft Visio에서 생성된 트리거 수식을 포함합니다. 이 트리거 수식은 1차원 도형의 끝점을 이동하여 다른 도형과의 연결을 유지할지 여부를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+도형에 연결할 때 동적(도형 간) 접착이 허용되는지 여부를 지정합니다.
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+도형의 텍스트를 숨깁니다. 텍스트 블록의 텍스트를 보고, 속성을 편집하고, 스타일을 적용할 수 있지만, HideText 요소를 0으로 지정할 때까지 변경 사항이 표시되지 않습니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+도형이 문서 간에 복사될 때 도형이 현지화되는지(그들의 LangID 요소가 재설정되는지) 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+도형이 선택될 때 선택 사각형이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+도형이 선택될 때 제어 핸들이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+사용자가 도형을 조작할 때 도형이 동적으로 크기 조정되거나 회전하는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+도형이 선택될 때 선택 핸들이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+선택된 도형을 인쇄할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+맞춤 마스터 도형에 할당된 검색 키워드를 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+제어 핸들이 이동될 때마다 도형의 선택 사각형을 재계산할지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다.
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+도형을 그룹에 끌어다 놓아 그룹에 추가할 수 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+마스터 도형의 지정된 셀 값이 도형 교체 작업 중 교체되는 도형의 값(로컬 값 포함)을 덮어쓰는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/misc\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/moveto/_index.md
+++ b/korean/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Aspose.Diagram for Java API 참조
+description: 형상의 첫 번째 정점의 x 및 y 좌표를 포함하거나 경로에서 끊김 후 첫 번째 정점의 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 248
+url: /ko/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로 중단 후 첫 번째 정점의 x 및 y 좌표를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | 다음 [MoveTo](../../com.aspose.diagram/moveto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | X 요소는 경로의 첫 번째 정점의 x 좌표를 나타냅니다. |
+| [getY()](#getY--) | Y 요소는 경로의 첫 번째 정점의 y 좌표를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/moveto\\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/moveto\\#getIX--)을 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/moveto\\#getX--)을 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/moveto\\#getY--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+다음 [MoveTo](../../com.aspose.diagram/moveto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X 요소는 경로의 첫 번째 정점의 x 좌표를 나타냅니다. MoveTo 요소가 두 요소 사이에 나타나는 경우, X 요소는 경로 끊김 후 첫 번째 정점의 x 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y 요소는 경로의 첫 번째 정점의 y 좌표를 나타냅니다. MoveTo 요소가 두 요소 사이에 나타나는 경우, Y 요소는 경로 끊김 후 첫 번째 정점의 y 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/moveto\\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/moveto\\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/moveto\\#getX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/moveto\\#getY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/movetocollection/_index.md
+++ b/korean/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: MoveTo 컬렉션.
+type: docs
+weight: 249
+url: /ko/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+MoveTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/nurbsto/_index.md
+++ b/korean/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Aspose.Diagram for Java API 참조
+description: 비균일 유리 B-스플라인(NURBS)의 x 및 y 좌표 위치, 두 번째 마지막 매듭 위치, 마지막 가중치 위치, 첫 번째 매듭 위치, 첫 번째 가중치 위치 및 공식을 포함합니다.
+type: docs
+weight: 250
+url: /ko/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+x 및 y 좌표, 두 번째 마지막 매듭 위치, 마지막 가중치 위치, 첫 번째 매듭 위치, 첫 번째 가중치 위치 및 비균일 유리 B-스플라인(NURBS) 공식을 포함합니다. 이 정보는 각각 X, Y, A, B, C, D, E 요소에 지정됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | 다음 클래스의 인스턴스를 생성합니다: [NURBSTo](../../com.aspose.diagram/nurbsto). |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 비균일 유리 B-스플라인(NURBS)의 두 번째 마지막 매듭. |
+| [getB()](#getB--) | 비균일 유리 B-스플라인(NURBS)의 마지막 가중치. |
+| [getC()](#getC--) | 비균일 유리 B-스플라인(NURBS)의 첫 번째 매듭. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 비균일 유리 B-스플라인(NURBS)의 첫 번째 가중치 |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getE()](#getE--) | 비균일 유리 B-스플라인(NURBS) 공식을 포함합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 비균일 유리 B-스플라인(NURBS)의 마지막 제어점의 x 좌표. |
+| [getY()](#getY--) | 비균일 유리 B-스플라인(NURBS)의 마지막 제어점의 y 좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/nurbsto\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/nurbsto\#getB--)을(를) 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/nurbsto\#getC--)을(를) 참조하십시오. |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/nurbsto\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)을(를) 참조하십시오. |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getE()](../../com.aspose.diagram/nurbsto\#getE--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/nurbsto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/nurbsto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+다음 클래스의 인스턴스를 생성합니다: [NURBSTo](../../com.aspose.diagram/nurbsto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 두 번째 마지막 매듭.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 마지막 가중치.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 첫 번째 매듭.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 첫 번째 가중치
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+비균일 유리 B-스플라인(NURBS) 공식을 포함합니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 마지막 제어점의 x 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+비균일 유리 B-스플라인(NURBS)의 마지막 제어점의 y 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/nurbsto\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/nurbsto\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/nurbsto\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/nurbsto\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getE()](../../com.aspose.diagram/nurbsto\#getE--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/nurbsto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/nurbsto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/korean/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: NURBSTo 컬렉션.
+type: docs
+weight: 251
+url: /ko/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+NURBSTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/objectkind/_index.md
+++ b/korean/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 필드 유형을 나타냅니다.
+type: docs
+weight: 254
+url: /ko/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+텍스트 필드 유형을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 텍스트 필드 유형을 나타냅니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/objectkind\#getValue--) 를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+텍스트 필드 유형을 나타냅니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/objectkind\#getValue--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/korean/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 필드 유형을 나타냅니다.
+type: docs
+weight: 255
+url: /ko/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+텍스트 필드 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | 수직에서 수평. |
+| [STANDARD](#STANDARD) | 표준. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+수직에서 수평.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+표준.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/objecttype/_index.md
+++ b/korean/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Aspose.Diagram for Java API 참조
+description: ForeignType 속성이 Object인 경우 ForeignData 요소에도 ObjectType 속성이 있어야 합니다.
+type: docs
+weight: 256
+url: /ko/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+ForeignType 속성이 "Object"인 경우, ForeignData 요소에도 ObjectType 속성이 있어야 합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CONTROL](#CONTROL) | 제어. |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | 내장 개체. |
+| [LINKED_OBJECT](#LINKED-OBJECT) | 링크된 개체. |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 명명됨. |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | OLE2 개체. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+제어.
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+내장 개체.
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+링크된 개체.
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 명명됨.
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+OLE2 개체.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/objtype/_index.md
+++ b/korean/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+type: docs
+weight: 252
+url: /ko/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+type: docs
+weight: 253
+url: /ko/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Microsoft Visio를 사용하여 도면 페이지에 도형을 배치할 때 객체가 다이어그램에서 배치 가능하거나 라우팅 가능한지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio는 도면 컨텍스트를 기반으로 결정합니다. |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | 도형을 배치할 수 없으며, 라우팅할 수도 없습니다. |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | 도형을 배치할 수 있습니다. |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | 그룹에 배치 가능/라우팅 가능한 도형이 포함되어 있습니다. |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape은 라우팅 가능합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio는 도면 컨텍스트를 기반으로 결정합니다.
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+도형을 배치할 수 없으며, 라우팅할 수도 없습니다.
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+도형을 배치할 수 있습니다.
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+그룹에 배치 가능/라우팅 가능한 도형이 포함되어 있습니다.
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape은 라우팅 가능합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Aspose.Diagram for Java API 참조
+description: 옵션인 부호 없는 정수.
+type: docs
+weight: 257
+url: /ko/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+옵션 선택적 부호 없는 정수. 데이터 레코드셋에 적용할 옵션입니다. 가능한 값은 다음 표에 표시된 하나 이상을 조합한 것이 될 수 있습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | 데이터 레코드셋이 다음에 새로 고침될 때까지 명령 문자열 쿼리를 실행하지 않습니다. |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | 데이터 레코드셋에 대한 '새로 고침 구성' 대화 상자에서 사용자가 데이터 레코드셋을 새로 고치는 방식을 제한합니다. |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | 데이터 레코드셋의 데이터가 외부 데이터 창에 표시되는 것을 방지합니다. |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | 도형을 복사하거나 잘라낼 때 도형 데이터 링크를 클립보드에 복사하지 않습니다. |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | 데이터 레코드셋이 '데이터 새로 고침' 대화 상자에 표시되는 것을 방지합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+데이터 레코드셋이 다음에 새로 고침될 때까지 명령 문자열 쿼리를 실행하지 않습니다.
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+데이터 레코드셋에 대한 '새로 고침 구성' 대화 상자에서 사용자가 데이터 레코드셋을 새로 고치는 방식을 제한합니다. 특히, 사용자는 기본 키를 변경하거나 도형 데이터가 언제 덮어써질지 지정할 수 없지만, 새로 고침 간격을 설정하고 데이터 원본을 변경할 수 있습니다.
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+데이터 레코드셋의 데이터가 외부 데이터 창에 표시되는 것을 방지합니다.
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+도형을 복사하거나 잘라낼 때 도형 데이터 링크를 클립보드에 복사하지 않습니다.
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+데이터 레코드셋이 '데이터 새로 고침' 대화 상자에 표시되는 것을 방지합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/outputformat/_index.md
+++ b/korean/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 도면의 출력 형식을 지정합니다.
+type: docs
+weight: 258
+url: /ko/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+도면의 출력 형식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도면의 출력 형식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/outputformat\#getValue--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도면의 출력 형식을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/outputformat\#getValue--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/korean/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도면의 출력 형식을 지정합니다.
+type: docs
+weight: 259
+url: /ko/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+도면의 출력 형식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | 기본값. |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | HTML 또는 GIF 출력. |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | PowerPoint 슬라이드 쇼. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+기본값. 인쇄.
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+HTML 또는 GIF 출력.
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+PowerPoint 슬라이드 쇼.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/page/_index.md
+++ b/korean/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: Page
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에서 페이지를 정의하는 요소를 포함합니다.
+type: docs
+weight: 260
+url: /ko/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+문서에서 페이지를 정의하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Page()](#Page--) | 생성자. |
+| [Page(int ID)](#Page-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Activex 컨트롤을 생성합니다. |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | 도형에 주석을 추가합니다. |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | 정의된 PinX 및 PinY와 함께 주석을 추가합니다. |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | 도형의 ID와 함께 도형에 주석을 추가합니다. |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | 마스터에서 만든 도형을 특정 페이지에 추가합니다. |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | 정의된 PinX, PinY, Width 및 Height를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다. |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | 정의된 PinX 및 PinY를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다. |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | 정의된 PinX 및 PinY와 함께 텍스트를 추가합니다. |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | 정의된 PinX 및 PinY와 함께 텍스트를 추가합니다. |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | 전체 페이지에 스타일을 적용합니다. |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | 도형 자동 간격 |
+| [bringForward(long shapeId)](#bringForward-long-) | ID로 정의된 도형을 Z-순서에서 한 단계 앞으로 이동합니다. |
+| [bringToFront(long shapeId)](#bringToFront-long-) | ID로 정의된 도형을 Z-순서의 앞쪽으로 이동합니다. |
+| [centerDrawing()](#centerDrawing--) | 페이지의 범위에 맞춰 페이지 내 도형을 중앙에 배치합니다. |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | 연결자를 사용하여 도형을 연결합니다. |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | 연결자를 사용하여 도형을 연결합니다. |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | 연결자를 사용하여 도형을 연결합니다. |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | 연결자 인덱스를 사용하여 도형을 연결합니다. |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | 연결자 인덱스를 사용하여 도형을 연결합니다. |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | 관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다. |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | 타원을 그리는 과정입니다. |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | 단일 선을 그리는 과정입니다. |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | 선을 그리는 과정입니다. |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | 폴리라인을 그리는 과정입니다. |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | 사각형을 그리는 과정입니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | 그림 검토자들이 별도의 마크업 오버레이에 표시한 원본 도면 페이지의 ID. |
+| [getBackPage()](#getBackPage--) | 페이지의 배경 페이지. |
+| [getBackground()](#getBackground--) | 페이지가 배경 페이지인지 여부를 나타내는 플래그. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | 그림에서 두 도형 사이의 각 연결에 대한 Connect 요소를 포함합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPageSheet()](#getPageSheet--) | 페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다. |
+| [getPages()](#getPages--) | 페이지 컬렉션. |
+| [getReviewerID()](#getReviewerID--) | 마크업 오버레이와 연결된 검토자의 ID. |
+| [getShapes()](#getShapes--) | 도형 컬렉션. |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX와 ViewCenterY는 새 뷰(창)가 처음 열릴 때 페이지에서 가정하는 중심점을 지정합니다. |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX와 ViewCenterY는 새 뷰(창)가 처음 열릴 때 페이지에서 가정하는 중심점을 지정합니다. |
+| [getViewScale()](#getViewScale--) | 페이지의 새 뷰(창)가 열릴 때 사용할 기본 확대 배율. |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | Connector의 BeginX에 도형을 붙이기 |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | Connector의 EndX에 도형을 붙이기 |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | 도형을 붙이기. |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | 도형을 붙이기 |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | 컨테이너 내 도형을 붙이기 |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | 연결 이름을 사용하여 컨테이너 내 도형을 붙이기 |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | 연결 ID로 컨테이너 내 도형을 붙이기 |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | 페이지의 도형을 배치하고/또는 커넥터를 재배치합니다. |
+| [moveTo(int index)](#moveTo-int-) | 페이지를 페이지 목록의 다른 위치로 이동합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | ID로 정의된 도형을 Z-순서에서 한 단계 뒤로 이동합니다. |
+| [sendToBack(long shapeId)](#sendToBack-long-) | ID로 정의된 도형을 Z-순서의 가장 뒤로 이동합니다. |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | 이 속성에 대한 설명은 [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)을(를) 참조하십시오. |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | 이 속성에 대한 설명은 [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)을(를) 참조하십시오. |
+| [setBackground(int value)](#setBackground-int-) | 이 속성에 대한 설명은 [getBackground()](../../com.aspose.diagram/page\#getBackground--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/page\#getID--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/page\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/page\#getNameU--)을(를) 참조하십시오. |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | 이 속성에 대한 설명은 [getPages()](../../com.aspose.diagram/page\#getPages--)을(를) 참조하십시오. |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | 이 페이지에 사전 설정된 테마를 적용합니다. |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | 이 페이지에 사전 설정된 테마 변형 퀵스타일을 적용합니다. |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | 이 페이지에 사전 설정된 테마 변형을 적용합니다. |
+| [setReviewerID(int value)](#setReviewerID-int-) | 이 속성에 대한 설명은 [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)을(를) 참조하십시오. |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | 이 속성에 대한 설명은 [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)을(를) 참조하십시오. |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | 이 속성에 대한 설명은 [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)을(를) 참조하십시오. |
+| [setViewScale(double value)](#setViewScale-double-) | 이 속성에 대한 설명은 [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+생성자.
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Activex 컨트롤을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 유형 | int | 컨트롤의 유형입니다. |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 인치 단위로 지정합니다. |
+| height | double | 도형의 높이를 인치 단위로 지정합니다. |
+
+**Returns:**
+long -
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+도형에 주석을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | 주석을 추가하는 도형을 지정합니다. |
+| comment | java.lang.String | 주석 문자열입니다. |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+정의된 PinX 및 PinY와 함께 주석을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 주석 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 주석 핀(회전 중심)의 y 좌표를 지정합니다. |
+| comment | java.lang.String | 주석 문자열입니다. |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+도형의 ID와 함께 도형에 주석을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeID | long |  |
+| comment | java.lang.String | 주석 문자열입니다. |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+마스터에서 만든 도형을 특정 페이지에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | 새 도형 객체[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | 마스터 이름입니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| 스트림 | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+정의된 PinX, PinY, Width 및 Height를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 인치 단위로 지정합니다. |
+| height | double | 도형의 높이를 인치 단위로 지정합니다. |
+| masterName | java.lang.String | 마스터 이름입니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+정의된 PinX 및 PinY를 사용하여 페이지에 마스터에서 만든 도형을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| masterName | java.lang.String | 마스터 이름입니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+정의된 PinX 및 PinY와 함께 텍스트를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 텍스트 핀(회전 중심)의 x좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 텍스트 핀(회전 중심)의 y좌표를 지정합니다. |
+| width | double |  |
+| height | double |  |
+| text | java.lang.String | 텍스트 문자열. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+정의된 PinX 및 PinY와 함께 텍스트를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 텍스트 핀(회전 중심)의 x좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 텍스트 핀(회전 중심)의 y좌표를 지정합니다. |
+| width | double | 텍스트의 너비를 지정합니다. |
+| height | double | 텍스트의 높이를 지정합니다. |
+| text | java.lang.String | 텍스트 문자열. |
+| fontName | java.lang.String | 텍스트 글꼴 이름. |
+| fontColor | java.lang.String | 텍스트 글꼴 색상. |
+| size | double | 텍스트 글꼴 크기. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+전체 페이지에 스타일을 적용합니다. 기본값은 -1입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| textStyle | int | 텍스트 스타일 ID. |
+| lineStyle | int | 선 스타일 ID. |
+| fillStyle | int | 채우기 스타일 ID. |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+도형 자동 간격
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | 도형이 자동으로 간격을 두도록 지정합니다. |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+ID로 정의된 도형을 Z-순서에서 한 단계 앞으로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeId | long | shape.long의 ID |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+ID로 정의된 도형을 Z-순서의 앞쪽으로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeId | long | shape.long의 ID |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+페이지의 범위에 따라 페이지의 도형을 중앙에 배치합니다. 도형을 중앙에 배치해도 서로 간의 위치는 변경되지 않습니다.
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+연결자를 사용하여 도형을 연결합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | 연결기가 시작되는 도형 [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | 연결기가 연결될 첫 번째 도형의 위치 Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | 연결기가 끝나는 도형 [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | 연결기가 연결될 두 번째 도형의 위치 Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connector | [Shape](../../com.aspose.diagram/shape) | Dynamic connector 유형을 가진 도형 [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+연결자를 사용하여 도형을 연결합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | 연결기가 시작되는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | 연결기가 연결될 첫 번째 도형의 위치 Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | 연결기가 끝나는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | 연결기가 연결될 두 번째 도형의 위치 Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connectorId | long | Dynamic connector 유형을 가진 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+연결자를 사용하여 도형을 연결합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | 연결기가 시작되는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| fromConnectionName | java.lang.String | 연결기가 연결될 첫 번째 도형의 연결 이름. |
+| shapeToId | long | 연결기가 끝나는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| toConnectionName | java.lang.String | 연결기가 연결될 두 번째 도형의 연결 이름. |
+| connectorId | long | Dynamic connector 유형을 가진 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+연결자 인덱스를 사용하여 도형을 연결합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | 연결기가 시작되는 도형 [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | 첫 번째 도형의 연결 인덱스 |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | 연결기가 끝나는 도형 [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | 두 번째 도형의 연결 인덱스 |
+| connector | [Shape](../../com.aspose.diagram/shape) | Dynamic connector 유형을 가진 도형 [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+연결자 인덱스를 사용하여 도형을 연결합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | 연결기가 시작되는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | 첫 번째 도형의 연결 인덱스 |
+| shapeToId | long | 연결기가 끝나는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | 두 번째 도형의 연결 인덱스 |
+| connectorId | long | Dynamic connector 유형을 가진 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다.
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+타원을 그리는 과정입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 지정합니다 |
+| height | double | 도형의 높이를 지정합니다 |
+
+**Returns:**
+long -
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+단일 선을 그리는 과정입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| beginX | double | 페이지에 대한 도형 위치의 시작 x좌표를 지정합니다. |
+| beginY | double | 페이지에 대한 도형 위치의 시작 y좌표를 지정합니다. |
+| endX | double | 페이지에 대한 도형 위치의 끝 x좌표를 지정합니다. |
+| endY | double | 페이지와 관련된 도형 위치의 끝 y좌표를 지정합니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+선을 그리는 과정입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 지정합니다 |
+| height | double | 도형의 높이를 지정합니다 |
+| xyArray | double[] | 새 도형의 점을 정의하는 교차되는 x 및 y 값 배열입니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+폴리라인을 그리는 과정입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 지정합니다 |
+| height | double | 도형의 높이를 지정합니다 |
+| xyArray | double[] | 새 도형의 점을 정의하는 교차되는 x 및 y 값 배열입니다. |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+사각형을 그리는 과정입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pinX | double | 페이지와 관련하여 도형 핀(회전 중심)의 x 좌표를 지정합니다. |
+| pinY | double | 페이지와 관련하여 도형 핀(회전 중심)의 y 좌표를 지정합니다. |
+| width | double | 도형의 너비를 지정합니다 |
+| height | double | 도형의 높이를 지정합니다 |
+
+**Returns:**
+long - 지정된 페이지의 도형 컬렉션 내에서 도형의 고유 ID입니다.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+그림 검토자들이 별도의 마크업 오버레이에 표시한 원본 도면 페이지의 ID.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+페이지의 배경 페이지.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+페이지가 배경 페이지인지 여부를 나타내는 플래그.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+그림에서 두 도형 사이의 각 연결에 대한 Connect 요소를 포함합니다.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+페이지 컬렉션.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+마크업 오버레이와 연결된 검토자의 ID.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+도형 컬렉션.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX와 ViewCenterY는 새 뷰(창)가 처음 열릴 때 페이지에서 가정하는 중심점을 지정합니다.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX와 ViewCenterY는 새 뷰(창)가 처음 열릴 때 페이지에서 가정하는 중심점을 지정합니다.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+페이지의 새 보기(창)가 열릴 때 사용할 기본 확대 비율입니다. 예를 들어, 1 = 100%; 1.5 = 150% 등입니다.
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+Connector의 BeginX에 도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | 연결기가 시작되는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | 연결기가 연결될 도형의 연결 이름입니다. |
+| connectorId | long | Dynamic connector 유형을 가진 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+Connector의 EndX에 도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeToId | long | 연결기가 끝나는 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | 연결기가 연결될 두 번째 도형의 연결 이름. |
+| connectorId | long | Dynamic connector 유형을 가진 도형의 ID [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+도형을 붙이기.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | [Shape](../../com.aspose.diagram/shape)에서 접착되는 도형입니다. |
+| placeTo | int | 첫 번째 도형에서 Aspose.Diagram.Manipulation.ConnectionPointPlace를 접착할 위치입니다. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | [Shape](../../com.aspose.diagram/shape)로 접착할 도형입니다. |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape)에서 접착되는 도형의 ID입니다. |
+| placeTo | int | 첫 번째 도형에서 Aspose.Diagram.Manipulation.ConnectionPointPlace를 접착할 위치입니다. |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape)로 접착할 도형의 ID입니다. |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+컨테이너 내 도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape)에서 접착되는 도형의 ID입니다. |
+| shapeToBeginConnectionIndex | int | 첫 번째 연결 인덱스에서 접착할 위치입니다. |
+| shapeToEndConnectionIndex | int | 끝 연결 인덱스에서 접착할 위치입니다. |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape)로 접착할 도형의 ID입니다. |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+연결 이름을 사용하여 컨테이너 내 도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape)에서 접착되는 도형의 ID입니다. |
+| shapeToBeginConnectionName | java.lang.String | 첫 번째 연결 이름에서 접착할 위치입니다. |
+| shapeToEndConnectionName | java.lang.String | 끝 연결 이름에서 접착할 위치입니다. |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape)로 접착할 도형의 ID입니다. |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+연결 ID로 컨테이너 내 도형을 붙이기
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeFromId | long | [Shape](../../com.aspose.diagram/shape)에서 접착되는 도형의 ID입니다. |
+| shapeToBeginConnectionID | int | 첫 번째 연결 ID에서 접착할 위치입니다. |
+| shapeToEndConnectionID | int | 끝 연결 ID에서 접착할 위치입니다. |
+| shapeToId | long | [Shape](../../com.aspose.diagram/shape)로 접착할 도형의 ID입니다. |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+페이지의 도형을 배치하고/또는 커넥터를 재배치합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | [LayoutOptions](../../com.aspose.diagram/layoutoptions)를 사용하여 레이아웃 옵션을 구성합니다. |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+페이지를 페이지 목록의 다른 위치로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 대상 페이지 인덱스. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+ID로 정의된 도형을 Z-순서에서 한 단계 뒤로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeId | long | shape.long의 ID |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+ID로 정의된 도형을 Z-순서의 가장 뒤로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shapeId | long | shape.long의 ID |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+이 속성에 대한 설명은 [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+이 속성에 대한 설명은 [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackground()](../../com.aspose.diagram/page\#getBackground--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/page\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/page\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/page\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+이 속성에 대한 설명은 [getPages()](../../com.aspose.diagram/page\#getPages--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+이 페이지에 사전 설정된 테마를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+이 페이지에 사전 설정된 테마 변형 퀵스타일을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+이 페이지에 사전 설정된 테마 변형을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+이 속성에 대한 설명은 [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagecollection/_index.md
+++ b/korean/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 컬렉션.
+type: docs
+weight: 261
+url: /ko/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+페이지 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | 컬렉션에 페이지를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [dispose()](#dispose--) | 관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getPage(int ID)](#getPage-int-) | Gets the element at the specified ID. |
+| [getPage(String name)](#getPage-java.lang.String-) | Gets the element at the specified name. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | 컬렉션에서 페이지를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+컬렉션에 페이지를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+관리되지 않는 리소스를 해제, 릴리스 또는 재설정과 관련된 애플리케이션 정의 작업을 수행합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+Gets the element at the specified name.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+컬렉션에서 페이지를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/korean/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 저장 프로세스 종료에 대한 정보.
+type: docs
+weight: 262
+url: /ko/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+페이지 저장 프로세스 종료에 대한 정보.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 전체 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 현재 페이지 인덱스, 0부터 시작합니다. |
+| [hasMorePages()](#hasMorePages--) | 출력할 추가 페이지가 있는지 여부를 나타내는 값입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | 이 속성에 대한 설명은 [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+전체 페이지 수.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+현재 페이지 인덱스, 0부터 시작합니다.
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+출력할 추가 페이지가 있는지 여부를 나타내는 값입니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+이 속성에 대한 설명은 [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagelayout/_index.md
+++ b/korean/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지의 도형 및 연결선에 대한 페이지 레이아웃 설정을 제어하는 셀을 포함합니다. 여기에는 페이지의 모든 도형 사이 간격, 모든 연결선 사이 간격 및 모든 연결선의 라우팅 스타일이 포함됩니다.
+type: docs
+weight: 263
+url: /ko/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 셀을 포함합니다. 예를 들어 페이지 내 모든 도형 간 간격, 모든 커넥터 간 간격, 그리고 모든 커넥터의 라우팅 스타일 등이 있습니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수직 간격을 결정합니다. |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수직 간격을 결정합니다. |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | 사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다. |
+| [getBlockSizeX()](#getBlockSizeX--) | Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지에서 각 도형이 들어가야 하는 영역인 수직 블록 크기를 결정합니다. |
+| [getBlockSizeY()](#getBlockSizeY--) | Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수평 간격을 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | 제어 핸들을 사용하여 도형을 조작할 때 어떤 도형이 부모인지 결정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDynamicsOff()](#getDynamicsOff--) | 배치 가능한 도형이 이동하고 연결선이 그리기 페이지의 다른 도형 및 연결선 주위를 재경로 지정할지 여부를 지정합니다. |
+| [getEnableGrid()](#getEnableGrid--) | 사용자가 Lay Out Shapes (Shape 메뉴)를 선택할 때 Microsoft Visio가 내부 페이지 그리드를 기반으로 도형을 배치할지 여부를 지정합니다. |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다. |
+| [getLineAdjustTo()](#getLineAdjustTo--) | 동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다. |
+| [getLineJumpCode()](#getLineJumpCode--) | 로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다. |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | 페이지의 동적 연결선 수평 구간에서 라인 점프 크기를 지정합니다. 이 값은 LineToLineX 요소 값의 백분율이며, 해당 요소는 그리기 페이지의 모든 연결선 간 수평 간격을 지정합니다. |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | 페이지의 동적 연결선 수직 구간에서 라인 점프 크기를 지정합니다. 이 값은 LineToLineY 요소 값의 백분율이며, 해당 요소는 그리기 페이지의 모든 연결선 간 수직 간격을 지정합니다. |
+| [getLineJumpStyle()](#getLineJumpStyle--) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다. |
+| [getLineRouteExt()](#getLineRouteExt--) | 페이지의 모든 커넥터에 대한 기본 외관을 지정합니다. |
+| [getLineToLineX()](#getLineToLineX--) | 그리기 페이지의 동적 연결선 간 최소 수평 간격을 지정합니다. |
+| [getLineToLineY()](#getLineToLineY--) | 그리기 페이지의 동적 연결선 간 최소 수직 간격을 지정합니다. |
+| [getLineToNodeX()](#getLineToNodeX--) | 그리기 페이지의 동적 연결선과 도형 간 최소 수직 간격을 지정합니다. |
+| [getLineToNodeY()](#getLineToNodeY--) | Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지에서 각 도형이 들어가야 하는 영역인 수평 블록 크기를 결정합니다. |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다. |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | 그리기 페이지의 동적 연결선과 도형 간 최소 수평 간격을 지정합니다. |
+| [getPageShapeSplit()](#getPageShapeSplit--) | 페이지의 도형을 자동으로 분할할 수 있는지 여부를 나타냅니다. |
+| [getPlaceDepth()](#getPlaceDepth--) | 사용자가 배치 가능한 도형을 다른 배치 가능한 도형 근처로 끌어다 놓을 때 배치 가능한 도형이 멀어지도록 이동할지 여부를 지정합니다. |
+| [getPlaceFlip()](#getPlaceFlip--) | Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [getPlaceStyle()](#getPlaceStyle--) | 로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다. |
+| [getPlowCode()](#getPlowCode--) | 점프를 추가하려는 동적 커넥터를 결정합니다. |
+| [getResizePage()](#getResizePage--) | 사용자가 Lay Out Shapes (Shapes 메뉴)를 선택한 후 페이지를 확대하여 그리기를 포함시킬지 여부를 지정합니다. |
+| [getRouteStyle()](#getRouteStyle--) | 자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/pagelayout\\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수직 간격을 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수직 간격을 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지에서 각 도형이 들어가야 하는 영역인 수직 블록 크기를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지의 도형 간 수평 간격을 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+제어 핸들을 사용하여 도형을 조작할 때 어떤 도형이 부모인지 결정합니다. 이 요소는 그리기 페이지의 모든 도형에 대한 동작을 설정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+배치 가능한 도형이 이동하고 연결선이 그리기 페이지의 다른 도형 및 연결선 주위를 재경로 지정할지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+사용자가 Lay Out Shapes (Shape 메뉴)를 선택할 때 Microsoft Visio가 내부 페이지 그리드를 기반으로 도형을 배치할지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 간격을 두도록 할지 지정합니다.
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+동적 커넥터가 서로 겹쳐 라우팅될 경우 어느 커넥터를 서로 정렬하도록 할지 지정합니다.
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+로컬 라인 점프 스타일이 없는 그리기 페이지의 모든 커넥터에 대한 라인 점프 스타일을 지정합니다.
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+페이지의 동적 연결선 수평 구간에서 라인 점프 크기를 지정합니다. 이 값은 LineToLineX 요소 값의 백분율이며, 해당 요소는 그리기 페이지의 모든 연결선 간 수평 간격을 지정합니다. 이 요소의 값은 0에서 10 사이입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+페이지의 동적 연결선 수직 구간에서 라인 점프 크기를 지정합니다. 이 값은 LineToLineY 요소 값의 백분율이며, 해당 요소는 그리기 페이지의 모든 연결선 간 수직 간격을 지정합니다. 이 요소는 0에서 10 사이의 값을 가질 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다.
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+페이지의 모든 커넥터에 대한 기본 외관을 지정합니다.
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+그리기 페이지의 동적 연결선 간 최소 수평 간격을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+그리기 페이지의 동적 연결선 간 최소 수직 간격을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+그리기 페이지의 동적 연결선과 도형 간 최소 수직 간격을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Microsoft Visio를 사용하여 도형을 배치할 때 그리기 페이지에서 각 도형이 들어가야 하는 영역인 수평 블록 크기를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다.
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+그리기 페이지의 동적 연결선과 도형 간 최소 수평 간격을 지정합니다.
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+페이지의 도형을 자동으로 분할할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+사용자가 배치 가능한 도형을 다른 배치 가능한 도형 근처로 끌어다 놓을 때 배치 가능한 도형이 멀어지도록 이동할지 여부를 지정합니다.
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Microsoft Visio에서 'Lay Out Shapes' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 어떻게 뒤집히거나 회전하는지를 지정합니다. 다음 16진수 값을 허용합니다.
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+점프를 추가하려는 동적 커넥터를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+사용자가 Lay Out Shapes (Shapes 메뉴)를 선택한 후 페이지를 확대하여 그리기를 포함시킬지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/pagelayout\\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/korean/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 세그먼트에 대한 라인 점프 방향을 지정합니다.
+type: docs
+weight: 264
+url: /ko/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/korean/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 세그먼트에 대한 라인 점프 방향을 지정합니다.
+type: docs
+weight: 265
+url: /ko/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 동적 커넥터의 수평 구간에 대한 라인 점프 방향을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | 기본 위. |
+| [DOWN](#DOWN) | 아래 |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [UP](#UP) | 위. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+기본 위.
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+아래
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+위.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/korean/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터의 라인 점프 방향을 지정합니다.
+type: docs
+weight: 266
+url: /ko/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/korean/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터의 라인 점프 방향을 지정합니다.
+type: docs
+weight: 267
+url: /ko/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+그림 페이지에서 로컬 점프 방향을 적용하지 않은 수직 동적 커넥터에 대한 라인 점프 방향을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | 기본값 왼쪽. |
+| [LEFT](#LEFT) | Left. |
+| [RIGHT](#RIGHT) | Right. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+기본값 왼쪽.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pageprops/_index.md
+++ b/korean/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 너비, 높이 및 스케일과 같은 페이지 속성을 제어하는 셀을 포함합니다.
+type: docs
+weight: 268
+url: /ko/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+페이지 너비, 높이 및 축척과 같은 페이지 속성을 제어하는 셀을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDrawingResizeType()](#getDrawingResizeType--) | 그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다. |
+| [getDrawingScale()](#getDrawingScale--) | 현재 도면 스케일에서 도면 단위의 값을 나타냅니다. |
+| [getDrawingScaleType()](#getDrawingScaleType--) | 페이지에 사용할 그리기 축척 유형을 지정합니다. |
+| [getDrawingSizeType()](#getDrawingSizeType--) | 페이지의 그리기 크기를 지정합니다. |
+| [getInhibitSnap()](#getInhibitSnap--) | 전경 페이지의 도형이 페이지의 다른 객체 및 배경 페이지의 도형에 스냅되는지 여부를 지정합니다. |
+| [getPageHeight()](#getPageHeight--) | 도면 단위로 페이지 높이를 지정합니다. |
+| [getPageScale()](#getPageScale--) | 현재 도면 스케일에서 기본 페이지 단위의 값을 지정합니다. |
+| [getPageWidth()](#getPageWidth--) | 도면 단위로 페이지 너비를 지정합니다. |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | 기본 페이지 그림자 유형이 적용될 때 비스듬한 방향의 각도를 지정하는 숫자를 포함합니다. |
+| [getShdwOffsetX()](#getShdwOffsetX--) | 도형의 그림자 드롭이 도형으로부터 수평으로 오프셋되는 거리를 페이지 단위로 지정합니다. |
+| [getShdwOffsetY()](#getShdwOffsetY--) | 도형의 그림자 드롭이 도형으로부터 수직으로 오프셋되는 거리를 페이지 단위로 지정합니다. |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | 도형 그림자를 확대하거나 축소할 비율을 지정합니다. |
+| [getShdwType()](#getShdwType--) | 페이지에 대한 기본 그림자 유형을 나타냅니다. |
+| [getUIVisibility()](#getUIVisibility--) | 페이지 이름이 사용자 인터페이스(UI)에 표시되는지 여부를 결정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/pageprops\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+그리기 페이지가 다이어그램에 맞게 자동으로 크기가 조정되는지를 결정합니다.
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+현재 도면 스케일에서 도면 단위의 값을 나타냅니다. 페이지의 도면 스케일은 PageScale 요소에 포함된 페이지 단위와 도면 단위의 비율입니다. 이 요소의 단위는 페이지의 기본 길이(DL) 단위를 결정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+페이지에 사용할 그리기 축척 유형을 지정합니다.
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+페이지의 그리기 크기를 지정합니다.
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+전경 페이지의 도형이 페이지의 다른 객체 및 배경 페이지의 도형에 스냅되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+도면 단위로 페이지 높이를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+현재 도면 스케일에서 기본 페이지 단위의 값을 지정합니다. 페이지의 도면 스케일은 PageScale 요소에 있는 페이지 단위와 DrawingScale 요소에 표시된 도면 단위의 비율입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+도면 단위로 페이지 너비를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+기본 페이지 그림자 유형이 적용될 때 비스듬한 방향의 각도를 지정하는 숫자를 포함합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+도형의 그림자 드롭이 도형으로부터 수평으로 오프셋되는 거리를 페이지 단위로 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+도형의 그림자 드롭이 도형으로부터 수직으로 오프셋되는 거리를 페이지 단위로 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+도형 그림자를 확대하거나 축소할 비율을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+페이지에 대한 기본 그림자 유형을 나타냅니다.
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+페이지 이름이 사용자 인터페이스(UI)에 표시되는지 여부를 결정합니다. 값이 1이면 페이지가 보이지 않으며, 값이 0이면 페이지가 표시됩니다.
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/pageprops\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/korean/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 저장 프로세스에 대한 정보.
+type: docs
+weight: 269
+url: /ko/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+페이지 저장 프로세스에 대한 정보.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 전체 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 현재 페이지 인덱스, 0부터 시작합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+전체 페이지 수.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+현재 페이지 인덱스, 0부터 시작합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagesheet/_index.md
+++ b/korean/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다.
+type: docs
+weight: 270
+url: /ko/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+페이지 또는 마스터 요소에 대한 페이지 시트를 정의하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | 소스 객체에서 페이지시트를 복사합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Act 요소들의 컬렉션을 포함합니다. |
+| [getAnnotations()](#getAnnotations--) | 문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 요소의 컬렉션을 포함합니다. |
+| [getConnections()](#getConnections--) | Connection 요소의 컬렉션을 포함합니다. |
+| [getFillStyle()](#getFillStyle--) | PageSheet가 채우기 서식을 상속받는 StyleSheet 요소. |
+| [getForeign()](#getForeign--) | Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다. |
+| [getForeignData()](#getForeignData--) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 요소들의 컬렉션을 포함합니다. |
+| [getLayers()](#getLayers--) | Layer 요소들의 컬렉션을 포함합니다. |
+| [getLineStyle()](#getLineStyle--) | PageSheet가 선 서식을 상속받는 StyleSheet 요소. |
+| [getPageLayout()](#getPageLayout--) | 페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 Diagram을 포함합니다. 여기에는 페이지 내 모든 도형 사이의 간격, 모든 커넥터 사이의 간격, 그리고 모든 커넥터의 라우팅 스타일이 포함됩니다. |
+| [getPageProps()](#getPageProps--) | 페이지 너비, 높이 및 축척과 같은 페이지 속성을 제어하는 Diagram을 포함합니다. |
+| [getPrintProps()](#getPrintProps--) | 그리기 페이지가 프린터 페이지에 어떻게 형식이 지정되는지(표시되는지) 제어하는 요소를 포함합니다. |
+| [getProps()](#getProps--) | Prop 요소들의 컬렉션을 포함합니다. |
+| [getRulerGrid()](#getRulerGrid--) | 페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다. |
+| [getScratchs()](#getScratchs--) | Scratch 요소의 컬렉션을 포함합니다. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | SmartTagDef 요소들의 컬렉션을 포함합니다. |
+| [getTextStyle()](#getTextStyle--) | PageSheet가 텍스트 서식을 상속받는 StyleSheet 요소. |
+| [getUniqueID()](#getUniqueID--) | 요소에 대한 GUID(전역 고유 식별자)입니다. |
+| [getUsers()](#getUsers--) | User 요소의 컬렉션을 포함합니다. |
+| [getXForm()](#getXForm--) | 도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--)을 참조하십시오. |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--)을 참조하십시오. |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+소스 객체에서 페이지시트를 복사합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | source pagesheet. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Act 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+문서 페이지에 삽입된 주석에 대한 정보를 포함하는 요소를 포함합니다.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+PageSheet가 채우기 서식을 상속받는 StyleSheet 요소.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체의 너비와 높이를 지정하는 요소를 포함합니다. 또한 객체 이미지가 경계 내에서 오프셋되는 거리를 지정하는 요소도 포함합니다.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Layer 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+PageSheet가 선 서식을 상속받는 StyleSheet 요소.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 Diagram을 포함합니다. 여기에는 페이지 내 모든 도형 사이의 간격, 모든 커넥터 사이의 간격, 그리고 모든 커넥터의 라우팅 스타일이 포함됩니다.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+페이지 너비, 높이 및 축척과 같은 페이지 속성을 제어하는 Diagram을 포함합니다.
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+그리기 페이지가 프린터 페이지에 어떻게 형식이 지정되는지(표시되는지) 제어하는 요소를 포함합니다.
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+SmartTagDef 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+PageSheet가 텍스트 서식을 상속받는 StyleSheet 요소.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+요소에 대한 GUID(전역 고유 식별자)입니다.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+For the description of this property, please see [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+For the description of this property, please see [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagesize/_index.md
+++ b/korean/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Aspose.Diagram for Java API 참조
+description: 생성된 이미지의 페이지 크기에 대한 정보를 포함합니다.
+type: docs
+weight: 271
+url: /ko/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+생성된 이미지의 페이지 크기에 대한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | 생성된 이미지의 페이지 크기를 설정하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다. |
+| [PageSize(float width, float height)](#PageSize-float-float-) | 생성된 이미지의 페이지 크기를 설정하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | 생성된 이미지의 페이지 높이(포인트)입니다. |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | 생성된 이미지의 용지 크기 형식입니다. |
+| [getWidth()](#getWidth--) | 생성된 이미지의 페이지 너비(포인트)입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)을(를) 참조하십시오. |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | 이 속성에 대한 설명은 [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)을(를) 참조하십시오. |
+| [setWidth(float value)](#setWidth-float-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+생성된 이미지의 페이지 크기를 설정하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| paperSizeFormat | int | Aspose.Diagram.Saving.PaperSizeFormat일 수 있습니다. |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+생성된 이미지의 페이지 크기를 설정하는 데 사용할 수 있는 이 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| width | float | 생성된 이미지의 페이지 너비(포인트)입니다. |
+| height | float | 생성된 이미지의 페이지 높이(포인트)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+생성된 이미지의 페이지 높이(포인트)입니다. 값은 0보다 커야 합니다. Height가 설정된 경우,Width도 설정되어야 합니다.
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+생성된 이미지의 용지 크기 형식입니다. Aspose.Diagram.Saving.PaperSizeFormat일 수 있습니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+생성된 이미지의 페이지 너비(포인트)입니다. 값은 0보다 커야 합니다. Width가 설정된 경우, Height도 설정되어야 합니다.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/korean/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 저장 프로세스 시작에 대한 정보.
+type: docs
+weight: 272
+url: /ko/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+페이지 저장 프로세스 시작에 대한 정보.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | 전체 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 현재 페이지 인덱스, 0부터 시작합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | 페이지를 출력할지 여부를 나타내는 값입니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | 이 속성에 대한 설명은 [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+전체 페이지 수.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+현재 페이지 인덱스, 0부터 시작합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+페이지를 출력할지 여부를 나타내는 값입니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/korean/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 용지 크기 형식 선택을 저장하기 위한 열거형.
+type: docs
+weight: 273
+url: /ko/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+용지 크기 형식 선택을 저장하기 위한 열거형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [A_0](#A-0) | A0 용지 크기 형식(841mm x 1189mm). |
+| [A_1](#A-1) | A1 용지 크기 형식(594mm x 841mm). |
+| [A_2](#A-2) | A2 용지 크기 형식(420mm x 594mm). |
+| [A_3](#A-3) | A3 용지 크기 형식(297mm x 420mm). |
+| [A_4](#A-4) | A4 용지 크기 형식(210mm x 297mm). |
+| [A_5](#A-5) | A5 용지 크기 형식(148mm x 210mm). |
+| [A_6](#A-6) | A6 용지 크기 형식(105mm x 148mm). |
+| [A_7](#A-7) | A7 용지 크기 형식(74mm x 105mm). |
+| [B_0](#B-0) | B0 용지 크기 형식(1000mm x 1414mm). |
+| [B_1](#B-1) | B1 용지 크기 형식(707mm x 1000mm). |
+| [B_2](#B-2) | B2 용지 크기 형식(500mm x 707mm). |
+| [B_3](#B-3) | B3 용지 크기 형식(353mm x 500mm). |
+| [B_4](#B-4) | B4 용지 크기 형식(250mm x 353mm). |
+| [B_5](#B-5) | B5 용지 크기 형식(176mm x 250mm). |
+| [B_6](#B-6) | B6 용지 크기 형식(125mm x 176mm). |
+| [B_7](#B-7) | B7 용지 크기 형식(88mm x 125mm). |
+| [COM_10](#COM-10) | COM10 용지 크기 형식(104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | COM9 용지 크기 형식(98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | 사용자 정의 용지 크기 형식. |
+| [C_0](#C-0) | C0 용지 크기 형식(917mm x 1297mm). |
+| [C_1](#C-1) | C1 용지 크기 형식(648mm x 917mm). |
+| [C_2](#C-2) | C2 용지 크기 형식(458mm x 648mm). |
+| [C_3](#C-3) | C3 용지 크기 형식(324mm x 458mm). |
+| [C_4](#C-4) | C4 용지 크기 형식(229mm x 324mm). |
+| [C_5](#C-5) | C5 용지 크기 형식(162mm x 229mm). |
+| [C_6](#C-6) | C6 용지 크기 형식(114mm x 162mm). |
+| [C_7](#C-7) | C7 용지 크기 형식(81mm x 114mm). |
+| [DL](#DL) | DL 용지 크기 형식(110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Executive 용지 크기 형식(184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Legal 용지 크기 형식(215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Legal13 용지 크기 형식(215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Letter 용지 크기 형식(215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Monarch 용지 크기 형식(98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Tabloid 용지 크기 형식(279.4mm x 431.8mm). |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+A0 용지 크기 형식(841mm x 1189mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+A1 용지 크기 형식(594mm x 841mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+A2 용지 크기 형식(420mm x 594mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+A3 용지 크기 형식(297mm x 420mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+A4 용지 크기 형식(210mm x 297mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+A5 용지 크기 형식(148mm x 210mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+A6 용지 크기 형식(105mm x 148mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+A7 용지 크기 형식(74mm x 105mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+B0 용지 크기 형식(1000mm x 1414mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+B1 용지 크기 형식(707mm x 1000mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+B2 용지 크기 형식(500mm x 707mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+B3 용지 크기 형식(353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+B4 용지 크기 형식(250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+B5 용지 크기 형식(176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+B6 용지 크기 형식(125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+B7 용지 크기 형식(88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+COM10 용지 크기 형식(104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+COM9 용지 크기 형식(98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+사용자 정의 용지 크기 형식.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+C0 용지 크기 형식(917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+C1 용지 크기 형식(648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+C2 용지 크기 형식(458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+C3 용지 크기 형식(324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+C4 용지 크기 형식(229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+C5 용지 크기 형식(162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+C6 용지 크기 형식(114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+C7 용지 크기 형식(81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+DL 용지 크기 형식(110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Executive 용지 크기 형식(184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Legal 용지 크기 형식(215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Legal13 용지 크기 형식(215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Letter 용지 크기 형식(215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Monarch 용지 크기 형식(98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Tabloid 용지 크기 형식(279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/para/_index.md
+++ b/korean/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 들여쓰기, 줄 간격, 글머리표 및 단락의 수평 정렬과 같은 단락 서식 요소를 포함합니다.
+type: docs
+weight: 274
+url: /ko/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+도형 텍스트에 대한 단락 서식 요소를 포함합니다. 예: 들여쓰기, 행 간격, 글머리표, 단락의 가로 정렬 등.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Para()](#Para--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | 글머리표 스타일을 결정합니다. |
+| [getBulletFont()](#getBulletFont--) | 사용자 정의 글머리표 문자열이 지정되고 Bullet 요소의 값이 0이 아닌 경우 텍스트 서식에 사용되는 글꼴 번호를 나타냅니다. |
+| [getBulletFontSize()](#getBulletFontSize--) | 글머리표의 크기를 지정합니다. |
+| [getBulletStr()](#getBulletStr--) | "사용자 정의 글머리표 스타일을 만드는 데 사용됩니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getFlags()](#getFlags--) | 텍스트 방향이 왼쪽에서 오른쪽인지 오른쪽에서 왼쪽인지 나타냅니다. |
+| [getHorzAlign()](#getHorzAlign--) | 도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getIndFirst()](#getIndFirst--) | 도형 텍스트 블록에서 각 단락의 첫 번째 줄이 단락의 왼쪽 들여쓰기에서 얼마나 떨어져 있는지를 지정합니다. |
+| [getIndLeft()](#getIndLeft--) | 단락의 모든 텍스트 줄이 텍스트 블록의 왼쪽 여백에서 얼마나 떨어져 있는지를 지정합니다. |
+| [getIndRight()](#getIndRight--) | 문단의 모든 텍스트 줄이 텍스트 블록의 오른쪽 여백으로부터 들여쓰기되는 거리를 지정합니다. |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | 글머리 기호 폰트를 현지화(다른 언어로 번역)해야 하는지 여부를 지정합니다. |
+| [getSpAfter()](#getSpAfter--) | 도형의 텍스트 블록에서 각 문단 뒤에 삽입되는 공간의 양을 지정합니다. |
+| [getSpBefore()](#getSpBefore--) | 도형의 텍스트 블록에서 각 문단 앞에 삽입되는 공간의 양을 지정합니다. |
+| [getSpLine()](#getSpLine--) | 텍스트 한 줄과 다음 줄 사이의 거리를 지정합니다. 여기서 100%는 텍스트 줄의 높이입니다. |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | 문단의 첫 번째 줄과 글머리 기호 사이의 거리를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | 이 속성에 대한 설명은 [getBullet()](../../com.aspose.diagram/para\#getBullet--)을(를) 참조하십시오. |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)을(를) 참조하십시오. |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)을(를) 참조하십시오. |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | 이 속성에 대한 설명은 [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/para\#getDel--)을(를) 참조하십시오. |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getFlags()](../../com.aspose.diagram/para\#getFlags--)을(를) 참조하십시오. |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | 이 속성에 대한 설명은 [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/para\#getIX--)을(를) 참조하십시오. |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)을(를) 참조하십시오. |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)을(를) 참조하십시오. |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)을(를) 참조하십시오. |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | 이 속성에 대한 설명은 [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)을(를) 참조하십시오. |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)을(를) 참조하십시오. |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)을(를) 참조하십시오. |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)을(를) 참조하십시오. |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+글머리표 스타일을 결정합니다.
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+사용자 정의 글머리표 문자열이 지정되고 Bullet 요소의 값이 0이 아닌 경우 텍스트 서식에 사용되는 글꼴 번호를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+글머리표의 크기를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+"사용자 정의 글머리 기호 스타일을 만들 때 사용됩니다. 스타일을 문자열(따옴표 안)로 입력하십시오. 예를 들어, 문자열 \"\"ooo.\"\"을(를) 입력할 수 있습니다."
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+텍스트 방향이 왼쪽에서 오른쪽인지 오른쪽에서 왼쪽인지 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+도형 텍스트 블록 내 텍스트의 가로 정렬을 지정합니다.
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+도형의 텍스트 블록에서 각 문단의 첫 번째 줄이 문단의 왼쪽 들여쓰기에서 떨어진 거리를 지정합니다. 이 값은 도면의 축척에 영향을 받지 않습니다. 도면이 축척될 경우에도 첫 번째 줄 들여쓰기는 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+문단의 모든 텍스트 줄이 텍스트 블록의 왼쪽 여백으로부터 들여쓰기되는 거리를 지정합니다. 이 값은 도면의 축척에 영향을 받지 않습니다. 도면이 축척될 경우에도 왼쪽 들여쓰기는 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+문단의 모든 텍스트 줄이 텍스트 블록의 오른쪽 여백에서 들여쓰기되는 거리를 지정합니다. 이 값은 도면의 축척과 무관합니다. 도면이 축척되더라도 오른쪽 들여쓰기는 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+글머리 기호 폰트를 현지화(다른 언어로 번역)해야 하는지 여부를 지정합니다.
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+도형의 텍스트 블록에서 각 문단 뒤에 삽입되는 공간의 양을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+도형의 텍스트 블록에서 각 문단 앞에 삽입되는 공간의 양을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+텍스트 한 줄과 다음 줄 사이의 거리를 지정합니다. 여기서 100%는 텍스트 줄의 높이입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+문단의 첫 번째 줄과 글머리 기호 사이의 거리를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+이 속성에 대한 설명은 [getBullet()](../../com.aspose.diagram/para\#getBullet--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+이 속성에 대한 설명은 [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/para\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getFlags()](../../com.aspose.diagram/para\#getFlags--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+이 속성에 대한 설명은 [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/para\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+이 속성에 대한 설명은 [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/paracollection/_index.md
+++ b/korean/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 단락 컬렉션.
+type: docs
+weight: 275
+url: /ko/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+단락 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | 컬렉션에 Para 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getPara(int IX)](#getPara-int-) | 지정된 인덱스 IX에 있는 요소를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | 컬렉션에서 Para 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+컬렉션에 Para 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+지정된 인덱스 IX에 있는 요소를 가져옵니다. 요소가 존재하지 않으면 Null을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+컬렉션에서 Para 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/korean/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Aspose.Diagram for Java API 참조
+description: 출력 파일의 PDF 준수 수준을 지정합니다.
+type: docs
+weight: 276
+url: /ko/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+출력 파일의 PDF 준수 수준을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [PDF_15](#PDF-15) | The output file will be PDF 1.5 compliant. |
+| [PDF_A_1_A](#PDF-A-1-A) | The output file will be PDF/A-1a compliant. |
+| [PDF_A_1_B](#PDF-A-1-B) | The output file will be PDF/A-1b compliant. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+The output file will be PDF 1.5 compliant.
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+The output file will be PDF/A-1a compliant.
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+The output file will be PDF/A-1b compliant.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/korean/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Aspose.Diagram for Java API 참조
+description: 디지털 서명에 사용되는 디지털 해시 알고리즘을 지정합니다.
+type: docs
+weight: 277
+url: /ko/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+디지털 서명에 사용되는 디지털 해시 알고리즘을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [MD_5](#MD-5) | SHA-1 해시 알고리즘. |
+| [SHA_1](#SHA-1) | SHA-1 해시 알고리즘. |
+| [SHA_256](#SHA-256) | SHA-256 해시 알고리즘. |
+| [SHA_384](#SHA-384) | SHA-384 해시 알고리즘. |
+| [SHA_512](#SHA-512) | SHA-512 해시 알고리즘. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+SHA-1 해시 알고리즘.
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+SHA-1 해시 알고리즘.
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+SHA-256 해시 알고리즘.
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+SHA-384 해시 알고리즘.
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+SHA-512 해시 알고리즘.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/korean/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Aspose.Diagram for Java API 참조
+description: PDF 문서를 암호화하는 데 사용할 암호화 알고리즘을 지정합니다.
+type: docs
+weight: 278
+url: /ko/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+PDF 문서를 암호화하는 데 사용할 암호화 알고리즘을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | RC4 encryption, key length of 128 bits. |
+| [RC_4_40](#RC-4-40) | RC4 encryption, key length of 40 bits. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+RC4 encryption, key length of 128 bits.
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+RC4 encryption, key length of 40 bits.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/korean/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Aspose.Diagram for Java API 참조
+description: PDF 암호화에 대한 세부 정보를 포함합니다.
+type: docs
+weight: 279
+url: /ko/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+PDF 암호화에 대한 세부 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | 암호화 모드입니다. |
+| [getOwnerPassword()](#getOwnerPassword--) | 소유자 비밀번호입니다. |
+| [getPermissions()](#getPermissions--) | 권한입니다. |
+| [getUserPassword()](#getUserPassword--) | 사용자 비밀번호입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | 이 속성에 대한 설명은 [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)을(를) 참조하십시오. |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | 이 속성에 대한 설명은 [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)을(를) 참조하십시오. |
+| [setPermissions(int value)](#setPermissions-int-) | 이 속성에 대한 설명은 [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)을(를) 참조하십시오. |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | 이 속성에 대한 설명은 [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+암호화 모드입니다.
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+소유자 비밀번호. 올바른 소유자 비밀번호로 문서를 열면(사용자 비밀번호와 동일하지 않다고 가정) 문서에 대한 전체(소유자) 액세스가 허용됩니다. 이 무제한 액세스에는 문서\\u9225\\u6a9a 비밀번호 및 액세스 권한을 변경할 수 있는 기능이 포함됩니다.
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+권한입니다.
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+사용자 비밀번호. 올바른 사용자 비밀번호로 문서를 열거나(사용자 비밀번호가 없는 문서를 열 경우) 문서에 지정된 사용자 액세스 권한에 따라 추가 작업을 수행할 수 있습니다. 이 작업은 문서\\u9225\\u6a9a 암호화 사전에서 지정된 사용자 액세스 권한에 따라 수행됩니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+이 속성에 대한 설명은 [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+이 속성에 대한 설명은 [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+이 속성에 대한 설명은 [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+이 속성에 대한 설명은 [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/korean/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Aspose.Diagram for Java API 참조
+description: PDF 문서에 대한 사용자 권한을 지정합니다.
+type: docs
+weight: 280
+url: /ko/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+PDF 문서에 대한 사용자 권한을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | PDF 문서에 대한 모든 작업을 허용합니다. |
+| [CONTENT_COPY](#CONTENT-COPY) | 문서에서 텍스트와 그래픽을 복사하거나 추출하는 것을 허용합니다. 접근성 목적을 위한 추출도 포함됩니다. |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | 장애인 접근성을 지원하거나 기타 목적을 위해 텍스트와 그래픽을 추출하는 것을 허용합니다. |
+| [DISALLOW_ALL](#DISALLOW-ALL) | PDF 문서에 대한 모든 작업을 금지합니다. |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | 문서를 조립하는 것을 허용합니다: 페이지 삽입, 회전, 삭제 및 북마크나 썸네일 이미지와 같은 탐색 요소 생성. |
+| [FILL_IN](#FILL-IN) | 양식을 작성하고 문서에 서명하는 것을 허용합니다. |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | 가능한 최고 해상도로 문서를 인쇄하는 것을 허용합니다. RC4 40비트 암호화를 사용하는 경우 이 옵션은 무시되며, Printing이 설정된 경우 고해상도 인쇄가 허용됩니다. |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | 텍스트 주석을 추가하거나 수정할 수 있습니다. |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | 문서\u9225\u6a9a 내용을 수정할 수 있습니다. |
+| [PRINTING](#PRINTING) | 문서를 인쇄할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+PDF 문서에 대한 모든 작업을 허용합니다.
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+문서에서 텍스트와 그래픽을 복사하거나 추출하는 것을 허용합니다. 접근성 목적을 위한 추출도 포함됩니다.
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+장애인 접근성을 지원하거나 기타 목적을 위해 텍스트와 그래픽을 추출할 수 있습니다. RC4 40비트 암호화를 사용할 경우 이 옵션은 무시되며 ContentCopy가 설정된 경우 언제든지 접근성이 허용됩니다.
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+PDF 문서에 대한 모든 작업을 허용하지 않습니다. 이것이 기본값입니다.
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+문서를 조립할 수 있습니다: 페이지 삽입, 회전 또는 삭제와 북마크나 썸네일 이미지와 같은 탐색 요소를 생성합니다. RC4 40비트 암호화를 사용할 경우 이 옵션은 무시되며 ModifyContents가 설정된 경우 문서 조립이 허용됩니다.
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+양식을 작성하고 문서에 서명할 수 있습니다. RC4 40비트 암호화를 사용할 경우 이 옵션은 무시되며 ModifyAnnotations가 설정된 경우 언제든지 양식 작성이 허용됩니다.
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+가능한 최고 해상도로 문서를 인쇄하는 것을 허용합니다. RC4 40비트 암호화를 사용하는 경우 이 옵션은 무시되며, Printing이 설정된 경우 고해상도 인쇄가 허용됩니다.
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+텍스트 주석을 추가하거나 수정할 수 있습니다. RC4 40비트 암호화를 사용할 경우 이 옵션은 양식 필드 작성도 허용합니다.
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+문서\u9225\u6a9a 내용을 수정할 수 있습니다.
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+문서를 인쇄할 수 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+type: docs
+weight: 281
+url: /ko/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+다이어그램 페이지를 PDF로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | 이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | 생성된 PDF 문서에 대한 원하는 호환성 수준. |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | 암호화 세부 정보. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 숨겨진 페이지를 내보낼지 여부를 정의합니다. |
+| [getHorizontalResolution()](#getHorizontalResolution--) | 생성된 이미지의 수평 해상도, 인치당 도트 수. |
+| [getJpegQuality()](#getJpegQuality--) | 이미지에 대한 JPEG 압축 품질을 지정합니다( JPEG 압축을 사용하는 경우). |
+| [getPageCount()](#getPageCount--) | PDF에서 렌더링할 페이지 수입니다. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 첫 번째 페이지의 0 기반 인덱스. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | 페이지 저장 프로세스의 진행 상황을 제어/표시합니다. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 모든 페이지를 이미지로 저장할지, 전경만 저장할지 여부를 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getSplitMultiPages()](#getSplitMultiPages--) | 페이지 설정에 따라 다이어그램을 여러 페이지로 분할할지 여부를 정의합니다. |
+| [getTextCompression()](#getTextCompression--) | 이미지를 제외한 모든 콘텐츠 스트림에 사용할 압축 유형을 지정합니다. |
+| [getVerticalResolution()](#getVerticalResolution--) | 생성된 이미지의 수직 해상도, 인치당 도트 수. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | 이 속성에 대한 설명은 [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)을(를) 참조하십시오. |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | 이 속성에 대한 설명은 [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)을(를) 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | 이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오. |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | 이 속성에 대한 설명은 [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)을(를) 참조하십시오. |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | 이 속성에 대한 설명은 [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)을(를) 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)을(를) 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)을(를) 참조하십시오. |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | 이 속성에 대한 설명은 [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)을(를) 참조하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | 이 속성에 대한 설명은 [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)을(를) 참조하십시오. |
+| [setTextCompression(int value)](#setTextCompression-int-) | 이 속성에 대한 설명은 [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)을(를) 참조하십시오. |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | 이 속성에 대한 설명은 [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+생성된 PDF 문서에 대한 원하는 호환성 수준입니다. 기본값은 PdfCompliance.PDF\_15입니다.
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+암호화 세부 정보입니다. 설정되지 않으면 암호화가 수행되지 않습니다.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+숨겨진 페이지를 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+생성된 이미지의 수평 해상도, 인치당 도트 수입니다. EMF 형식 이미지를 제외한 이미지 생성 메서드에 적용됩니다. 기본값은 96입니다.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+이미지에 대한 JPEG 압축 품질을 지정합니다( JPEG 압축을 사용하는 경우). 기본값은 95입니다.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+PDF에서 렌더링할 페이지 수입니다. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 첫 번째 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+페이지 저장 프로세스의 진행 상황을 제어/표시합니다.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+이미지에 모든 페이지를 저장할지 아니면 전경만 저장할지 지정합니다. true인 경우 전경 페이지만 렌더링됩니다(배경이 있으면 포함). false인 경우 전경 페이지가 렌더링된 뒤 빈 배경 페이지가 렌더링됩니다. PageCount가 1보다 클 때만 true를 반환할 수 있습니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat만 사용할 수 있습니다.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+페이지 설정에 따라 다이어그램을 여러 페이지로 분할할지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+이미지를 제외한 모든 콘텐츠 스트림에 사용할 압축 유형을 지정합니다. 기본값은 PdfTextCompression.FLATE입니다.
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+생성된 이미지의 수직 해상도(인치당 도트 수)입니다. Emf 형식 이미지를 제외한 이미지 생성 메서드에 적용됩니다. 기본값은 96입니다.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+이 속성에 대한 설명은 [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+이 속성에 대한 설명은 [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+이 속성에 대한 설명은 [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+이 속성에 대한 설명은 [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+이 속성에 대한 설명은 [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+이 속성에 대한 설명은 [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+이 속성에 대한 설명은 [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/korean/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Aspose.Diagram for Java API 참조
+description: 이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다.
+type: docs
+weight: 282
+url: /ko/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FLATE](#FLATE) | Flate (ZIP) 압축. |
+| [NONE](#NONE) | 압축 없음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Flate (ZIP) 압축.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+압축 없음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/korean/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 핀 위치를 지정합니다.
+type: docs
+weight: 283
+url: /ko/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+도형의 핀 위치를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | bottom-center |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | bottom-left. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | bottom-right |
+| [CENTER_CENTER](#CENTER-CENTER) | center-center |
+| [CENTER_LEFT](#CENTER-LEFT) | center-left. |
+| [CENTER_RIGHT](#CENTER-RIGHT) | center-right |
+| [TOP_CENTER](#TOP-CENTER) | 상단-중앙 |
+| [TOP_LEFT](#TOP-LEFT) | 왼쪽-상단 |
+| [TOP_RIGHT](#TOP-RIGHT) | 오른쪽-상단 |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+bottom-center
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+bottom-left.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+bottom-right
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+center-center
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+center-left.
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+center-right
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+상단-중앙
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+왼쪽-상단
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+오른쪽-상단
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/korean/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Aspose.Diagram for Java API 참조
+description: 렌더링 중 픽셀 오프셋 방식을 지정합니다.
+type: docs
+weight: 284
+url: /ko/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+렌더링 중 픽셀 오프셋 방식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | 기본 모드를 지정합니다. |
+| [HALF](#HALF) | 픽셀이 수평 및 수직으로 -.5 단위만큼 오프셋된다고 지정합니다. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 고품질, 저속 렌더링을 지정합니다. |
+| [HIGH_SPEED](#HIGH-SPEED) | 고속, 저품질 렌더링을 지정합니다. |
+| [INVALID](#INVALID) | 잘못된 모드를 지정합니다. |
+| [NONE](#NONE) | 픽셀 오프셋을 지정하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+기본 모드를 지정합니다.
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+픽셀이 수평 및 수직으로 -.5 단위만큼 오프셋된다고 지정합니다.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+고품질, 저속 렌더링을 지정합니다.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+고속, 저품질 렌더링을 지정합니다.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+잘못된 모드를 지정합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+픽셀 오프셋을 지정하지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placedepth/_index.md
+++ b/korean/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Aspose.Diagram for Java API 참조
+description: 자동으로 레이아웃되는 도면에 대해 레이아웃을 생성하기 전에 도면을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+type: docs
+weight: 285
+url: /ko/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/placedepth\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/placedepth\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/korean/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Aspose.Diagram for Java API 참조
+description: 자동으로 레이아웃되는 도면에 대해 레이아웃을 생성하기 전에 도면을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+type: docs
+weight: 286
+url: /ko/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+자동으로 레이아웃되는 그림에 대해 레이아웃을 만들기 전에 그림을 분석하는 방법을 지정하고 레이아웃 유형을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEEP](#DEEP) | 깊음. |
+| [MEDIUM](#MEDIUM) | 보통. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [SHALLOW](#SHALLOW) | 얕음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+깊음.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+보통.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+얕음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placeflip/_index.md
+++ b/korean/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+type: docs
+weight: 287
+url: /ko/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Microsoft Visio에서 'Lay Out Shapes' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 어떻게 뒤집히거나 회전하는지를 지정합니다. 다음 16진수 값을 허용합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Microsoft Visio에서 'Lay Out Shapes' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 어떻게 뒤집히거나 회전하는지를 지정합니다. 다음 16진수 값을 허용합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/korean/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio에서 '도형 레이아웃' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+type: docs
+weight: 288
+url: /ko/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Microsoft Visio에서 'Lay Out Shapes' 명령을 사용하여 도형을 배치할 때 배치 가능한 도형이 페이지에서 어떻게 뒤집히거나 회전하는지를 지정합니다. 다음 16진수 값을 허용합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | 기본값. |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | 90도 단위로 뒤집기. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | 수평 뒤집기. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | 수직 뒤집기. |
+| [NO_FLIP](#NO-FLIP) | 뒤집지 않음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+기본값. 뒤집지 않음.
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+90도 단위로 뒤집기.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+수평 뒤집기.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+수직 뒤집기.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+뒤집지 않음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placestyle/_index.md
+++ b/korean/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 'Lay Out Shapes Shape' 메뉴를 선택했을 때, 페이지에 도형이 배치되는 방식을 지정합니다.
+type: docs
+weight: 289
+url: /ko/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/placestyle\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/placestyle\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 'Lay Out Shapes Shape' 메뉴를 선택했을 때, 페이지에 도형이 배치되는 방식을 지정합니다.
+type: docs
+weight: 290
+url: /ko/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+사용자가 '도형 레이아웃'(도형 메뉴)을 선택하여 도형을 배치할 때 도형이 페이지에 배치되는 방식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | 아래에서 위로. |
+| [CIRCULAR](#CIRCULAR) | 원형. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | 기본값. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | 왼쪽에서 오른쪽으로. |
+| [RADIAL](#RADIAL) | 방사형. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | 오른쪽에서 왼쪽으로. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | 위에서 아래로. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+아래에서 위로.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+원형.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+기본값. 방사형.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+왼쪽에서 오른쪽으로.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+방사형.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+오른쪽에서 왼쪽으로.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+위에서 아래로.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/polylineto/_index.md
+++ b/korean/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Aspose.Diagram for Java API 참조
+description: 폴리라인의 마지막 점과 폴리라인 수식의 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 291
+url: /ko/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+폴리라인의 마지막 점의 x 및 y 좌표와 폴리라인 수식을 포함합니다. 좌표는 X 및 Y 요소에 지정되고, 수식은 A 요소에 지정됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | [PolylineTo](../../com.aspose.diagram/polylineto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 폴리라인 수식입니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 폴리라인 끝 정점의 x 좌표입니다. |
+| [getY()](#getY--) | 폴리라인 끝 정점의 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/polylineto\#getA--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/polylineto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/polylineto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/polylineto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/polylineto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+[PolylineTo](../../com.aspose.diagram/polylineto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+폴리라인 수식입니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+폴리라인 끝 정점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+폴리라인 끝 정점의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/polylineto\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/polylineto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/polylineto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/polylineto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/polylineto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/korean/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: PolylineTo 컬렉션.
+type: docs
+weight: 292
+url: /ko/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+PolylineTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pos/_index.md
+++ b/korean/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 기준선에 대한 위치를 지정합니다.
+type: docs
+weight: 293
+url: /ko/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+도형 텍스트의 기준선에 대한 위치를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형 텍스트의 기준선에 대한 위치를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/pos\#getUfe--)을(를) 확인하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pos\#getValue--)을(를) 확인하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형 텍스트의 기준선에 대한 위치를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/pos\#getUfe--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/pos\#getValue--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/posvalue/_index.md
+++ b/korean/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트의 기준선에 대한 위치를 지정합니다.
+type: docs
+weight: 294
+url: /ko/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+도형 텍스트의 기준선에 대한 위치를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | 보통 위치입니다. |
+| [SUBSCRIPT](#SUBSCRIPT) | 아래 첨자. |
+| [SUPERSCRIPT](#SUPERSCRIPT) | 위 첨자. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+보통 위치입니다.
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+아래 첨자.
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+위 첨자.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/pp/_index.md
+++ b/korean/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Aspose.Diagram for Java API 참조
+description: 단락 속성 실행의 시작을 지정합니다.
+type: docs
+weight: 295
+url: /ko/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+단락 속성 실행의 시작을 지정합니다. 실행은 텍스트 끝까지 또는 다음까지 정의됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | 생성자 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+생성자
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int | 이 실행에 적용된 서식을 지정하는 Para 요소의 인덱스입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/korean/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Aspose.Diagram for Java API 참조
+description: 위치를 포함한 모든 카메라 속성을 설정하는 다양한 알고리즘 방법을 나타냅니다.
+type: docs
+weight: 296
+url: /ko/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+위치를 포함한 모든 카메라 속성을 설정하기 위한 다양한 알고리즘 방법을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Aspose.Diagram for Java API 참조
+description: Used to set Shape theme styles color property
+type: docs
+weight: 297
+url: /ko/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Shape 테마 스타일의 색상 속성을 설정하는 데 사용됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Color1. |
+| [COLOR_2](#COLOR-2) | Color2. |
+| [COLOR_3](#COLOR-3) | Color3. |
+| [COLOR_4](#COLOR-4) | Color4. |
+| [COLOR_5](#COLOR-5) | Color5. |
+| [COLOR_6](#COLOR-6) | Color6. |
+| [COLOR_7](#COLOR-7) | Color7. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Color1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Color2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Color3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Color4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Color5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Color6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Color7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 테마 빠른 스타일 값을 지정합니다.
+type: docs
+weight: 298
+url: /ko/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+테마 빠른 스타일 값을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/korean/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Aspose.Diagram for Java API 참조
+description: 미리 설정된 그림자 유형을 나타냅니다.
+type: docs
+weight: 299
+url: /ko/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+미리 설정된 그림자 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BELOW](#BELOW) | 아래쪽 외부 그림자. |
+| [CUSTOM](#CUSTOM) | 사용자 정의 그림자. |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | 하단 내부 그림자. |
+| [INSIDE_CENTER](#INSIDE-CENTER) | 중앙 내부 그림자. |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | 왼쪽 하단 대각선 내부 그림자. |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | 오른쪽 하단 대각선 내부 그림자. |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | 왼쪽 상단 대각선 내부 그림자. |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | 오른쪽 상단 대각선 내부 그림자. |
+| [INSIDE_LEFT](#INSIDE-LEFT) | 왼쪽 내부 그림자. |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | 오른쪽 내부 그림자. |
+| [INSIDE_TOP](#INSIDE-TOP) | 상단 내부 그림자. |
+| [NO_SHADOW](#NO-SHADOW) | 그림자 없음. |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | 하단 외부 그림자 오프셋. |
+| [OFFSET_CENTER](#OFFSET-CENTER) | 중앙 외부 그림자 오프셋. |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | 왼쪽 하단 대각선 외부 그림자 오프셋. |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | 오른쪽 하단 대각선 외부 그림자 오프셋. |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | 왼쪽 상단 대각선 외부 그림자 오프셋. |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | 오른쪽 상단 대각선 외부 그림자 오프셋. |
+| [OFFSET_LEFT](#OFFSET-LEFT) | 왼쪽 외부 그림자 오프셋. |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | 오른쪽 외부 그림자 오프셋. |
+| [OFFSET_TOP](#OFFSET-TOP) | 상단 외부 그림자 오프셋. |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | 좌하단 대각선 외부 그림자 원근. |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | 우하단 대각선 외부 그림자 원근. |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | 좌상단 대각선 외부 그림자 원근. |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | 우상단 대각선 외부 그림자 원근. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+아래쪽 외부 그림자.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+사용자 정의 그림자.
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+하단 내부 그림자.
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+중앙 내부 그림자.
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+왼쪽 하단 대각선 내부 그림자.
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+오른쪽 하단 대각선 내부 그림자.
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+왼쪽 상단 대각선 내부 그림자.
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+오른쪽 상단 대각선 내부 그림자.
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+왼쪽 내부 그림자.
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+오른쪽 내부 그림자.
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+상단 내부 그림자.
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+그림자 없음.
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+하단 외부 그림자 오프셋.
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+중앙 외부 그림자 오프셋.
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+왼쪽 하단 대각선 외부 그림자 오프셋.
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+오른쪽 하단 대각선 외부 그림자 오프셋.
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+왼쪽 상단 대각선 외부 그림자 오프셋.
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+오른쪽 상단 대각선 외부 그림자 오프셋.
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+왼쪽 외부 그림자 오프셋.
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+오른쪽 외부 그림자 오프셋.
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+상단 외부 그림자 오프셋.
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+좌하단 대각선 외부 그림자 원근.
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+우하단 대각선 외부 그림자 원근.
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+좌상단 대각선 외부 그림자 원근.
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+우상단 대각선 외부 그림자 원근.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Aspose.Diagram for Java API 참조
+description: Shape 테마 스타일 속성을 설정하는 데 사용됩니다.
+type: docs
+weight: 300
+url: /ko/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Shape 테마 스타일 속성을 설정하는 데 사용됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/korean/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 테마 값을 지정합니다.
+type: docs
+weight: 301
+url: /ko/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+테마 값을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | 버블 |
+| [CLOUDS](#CLOUDS) | 구름 |
+| [DAYBREAK](#DAYBREAK) | 새벽 |
+| [FACET](#FACET) | 면 |
+| [GEMSTONE](#GEMSTONE) | 보석 |
+| [INTEGRAL](#INTEGRAL) | Integral |
+| [ION](#ION) | Ion |
+| [LINEAR](#LINEAR) | Linear |
+| [LINES](#LINES) | Lines |
+| [MARKER](#MARKER) | Marker |
+| [NO_THEME](#NO-THEME) | NoTheme |
+| [OFFICE](#OFFICE) | Office |
+| [ORGANIC](#ORGANIC) | Organic |
+| [PARALLEL](#PARALLEL) | Parallel |
+| [PEN](#PEN) | Pen |
+| [PENCIL](#PENCIL) | Pencil |
+| [PROMINENCE](#PROMINENCE) | Prominence |
+| [RADIANCE](#RADIANCE) | Radiance |
+| [RETROSPECT](#RETROSPECT) | Retrospect |
+| [SEQUENCE](#SEQUENCE) | Sequence |
+| [SHADE](#SHADE) | Shade |
+| [SIMPLE](#SIMPLE) | Simple |
+| [SLICE](#SLICE) | Slice |
+| [SMOKE](#SMOKE) | Smoke |
+| [WHISP](#WHISP) | Whisp |
+| [WHITE_BOARD](#WHITE-BOARD) | WhiteBoard |
+| [ZEPHYR](#ZEPHYR) | Zephyr |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+버블
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+구름
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+새벽
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+면
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+보석
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integral
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ion
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Lines
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marker
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NoTheme
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Office
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organic
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallel
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Pen
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Pencil
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Prominence
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Radiance
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospect
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequence
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Shade
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Slice
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Smoke
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Whisp
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+WhiteBoard
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zephyr
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/korean/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Aspose.Diagram for Java API 참조
+description: 테마 변형 값을 지정합니다.
+type: docs
+weight: 302
+url: /ko/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+테마 변형 값을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/previewscope/_index.md
+++ b/korean/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에 미리보기가 포함되어 있는지, 포함된 경우 미리보기가 첫 페이지만 표시하는지 전체 페이지를 표시하는지 지정합니다.
+type: docs
+weight: 303
+url: /ko/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/previewscope\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/previewscope\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/korean/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에 미리보기가 포함되어 있는지, 포함된 경우 미리보기가 첫 페이지만 표시하는지 전체 페이지를 표시하는지 지정합니다.
+type: docs
+weight: 304
+url: /ko/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+문서에 미리 보기가 포함되는지 여부와 포함되는 경우 미리 보기가 첫 페이지만 표시할지 문서의 모든 페이지를 표시할지 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | 모든 페이지. |
+| [FIRST_PAGE](#FIRST-PAGE) | 첫 번째 페이지. |
+| [NO_PREVIEW](#NO-PREVIEW) | 미리보기 없음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+모든 페이지.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+첫 번째 페이지.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+미리보기 없음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/korean/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+type: docs
+weight: 305
+url: /ko/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/korean/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+type: docs
+weight: 306
+url: /ko/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | 가로. |
+| [PORTRAIT](#PORTRAIT) | 세로. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | 프린터와 동일. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+가로.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+세로.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+프린터와 동일.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/printprops/_index.md
+++ b/korean/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지가 프린터 페이지에 표시되는 방식을 제어하는 요소를 포함합니다.
+type: docs
+weight: 307
+url: /ko/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+그리기 페이지가 프린터 페이지에 어떻게 형식이 지정되는지(표시되는지) 제어하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | 그리기 페이지가 인쇄된 페이지에서 가로로 가운데 정렬되는지 여부를 결정합니다. |
+| [getCenterY()](#getCenterY--) | 그리기 페이지가 인쇄된 페이지에서 세로로 가운데 정렬되는지 여부를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getOnPage()](#getOnPage--) | 그리기가 특정 수의 프린터 페이지에 인쇄되는지 여부를 나타냅니다. |
+| [getPageBottomMargin()](#getPageBottomMargin--) | 인쇄된 페이지 하단의 여백을 지정합니다. |
+| [getPageLeftMargin()](#getPageLeftMargin--) | 인쇄된 페이지 왼쪽의 여백을 지정합니다. |
+| [getPageRightMargin()](#getPageRightMargin--) | 인쇄된 페이지 오른쪽의 여백을 지정합니다. |
+| [getPageTopMargin()](#getPageTopMargin--) | 프린터 페이지 상단의 여백을 지정합니다. |
+| [getPagesX()](#getPagesX--) | 그리기 페이지를 가로 방향으로 맞추기 위한 프린터 페이지 수를 결정합니다. |
+| [getPagesY()](#getPagesY--) | 그리기 페이지를 세로 방향으로 맞추기 위한 프린터 페이지 수를 결정합니다. |
+| [getPaperKind()](#getPaperKind--) | 페이지를 인쇄할 용지 종류를 지정합니다. |
+| [getPaperSource()](#getPaperSource--) | 페이지의 용지 공급원을 결정합니다. |
+| [getPrintGrid()](#getPrintGrid--) | 문서 페이지를 인쇄할 때 격자를 인쇄할지 여부를 지정합니다. |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | 페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다. |
+| [getScaleX()](#getScaleX--) | 프린터 페이지에서 그리기 페이지의 확대 비율을 x(가로) 방향으로 백분율로 지정합니다. |
+| [getScaleY()](#getScaleY--) | 그림 페이지를 프린터 페이지에 확대하는 비율을 y(수직) 방향으로 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/printprops\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+그리기 페이지가 인쇄된 페이지에서 가로로 가운데 정렬되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+그리기 페이지가 인쇄된 페이지에서 세로로 가운데 정렬되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+그리기가 특정 수의 프린터 페이지에 인쇄되는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+인쇄된 페이지 하단의 여백을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+인쇄된 페이지 왼쪽의 여백을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+인쇄된 페이지 오른쪽의 여백을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+프린터 페이지 상단의 여백을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+그리기 페이지를 가로 방향으로 맞추기 위한 프린터 페이지 수를 결정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+그리기 페이지를 세로 방향으로 맞추기 위한 프린터 페이지 수를 결정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+페이지를 인쇄할 용지 종류를 지정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+페이지의 용지 공급원을 결정합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+문서 페이지를 인쇄할 때 격자를 인쇄할지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+페이지가 세로 방향으로 인쇄되는지 가로 방향으로 인쇄되는지 결정합니다.
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+프린터 페이지에서 그리기 페이지의 확대 비율을 x(가로) 방향으로 백분율로 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+그림 페이지를 프린터 페이지에 확대하는 비율을 y(수직) 방향으로 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/printprops\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램을 인쇄할 때 추가 옵션을 지정할 수 있습니다.
+type: docs
+weight: 308
+url: /ko/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+다이어그램을 인쇄할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getPageCount()](#getPageCount--) | 다중 페이지 파일로 저장할 때 렌더링할 페이지 수입니다. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 전체 페이지를 인쇄할지 전경만 인쇄할지 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)을(를) 확인하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)을(를) 확인하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+다중 페이지 파일로 저장할 때 렌더링할 페이지 수입니다. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 인쇄됨을 의미합니다.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+전체 페이지를 인쇄할지 전경만 인쇄할지를 지정합니다. true인 경우 전경 페이지만 인쇄합니다(배경이 있으면 포함). false인 경우 전경 페이지를 인쇄하고 그 뒤에 빈 배경 페이지가 따라옵니다(배경이 있으면 포함). true를 반환할 수 있는 조건은 PageCount > 1일 때만이며, 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)을(를) 확인하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/prop/_index.md
+++ b/korean/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: 속성
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자 지정 속성을 정의하는 요소와 도형에 데이터를 연결하는 요소를 포함합니다.
+type: docs
+weight: 309
+url: /ko/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+사용자 지정 속성을 정의하는 요소와 도형에 데이터를 연결하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Prop()](#Prop--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | 사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getFormat()](#getFormat--) | Format 요소는 문자열, 고정 목록, 숫자, 가변 목록, 날짜 또는 시간, 기간, 통화인 사용자 정의 속성의 서식을 지정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getInvisible()](#getInvisible--) | Invisible 요소는 Microsoft Visio의 사용자 정의 속성 대화 상자에서 사용자 정의 속성이 표시되는지 여부를 지정합니다. |
+| [getLabel()](#getLabel--) | 사용자 정의 속성 대화 상자에 사용자에게 표시되는 레이블을 지정합니다. |
+| [getLangID()](#getLangID--) | 셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPrompt()](#getPrompt--) | Prompt 요소는 속성이 선택될 때 사용자 정의 속성 대화 상자에 사용자에게 표시되는 설명 또는 안내 텍스트를 지정합니다. |
+| [getSortKey()](#getSortKey--) | 이것은 애플리케이션 UI에 사용자 정의 속성이 나열되는 순서를 결정하는 키를 지정합니다. |
+| [getType()](#getType--) | Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다. |
+| [getValue()](#getValue--) | 명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다. |
+| [getVerify()](#getVerify--) | 인스턴스가 생성되거나 도형이 복제·복사될 때 사용자가 도형에 대한 사용자 정의 속성 정보를 입력하도록 요청받는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/prop\#getDel--)을(를) 참조하십시오 |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/prop\#getID--)을(를) 참조하십시오 |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/prop\#getIX--)을(를) 참조하십시오 |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/prop\#getName--)을(를) 참조하십시오 |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/prop\#getNameU--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+사용자 지정 속성, 텍스트 필드 및 요소 수식에 사용되는 달력을 결정합니다.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+Format 요소는 문자열, 고정 목록, 숫자, 가변 목록, 날짜 또는 시간, 기간, 통화인 사용자 정의 속성의 형식을 지정합니다. 사용자 정의 속성 유형은 해당 Type 요소에 지정됩니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Invisible 요소는 Microsoft Visio의 사용자 정의 속성 대화 상자에서 사용자 정의 속성이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+사용자 정의 속성 대화 상자에 사용자에게 표시되는 레이블을 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+셀 수식, 텍스트, 사용자 정의 속성 또는 주석이 입력된 언어의 로케일 ID(LCID)를 나타냅니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Prompt 요소는 속성이 선택될 때 사용자에게 Custom Properties 대화 상자에 표시되는 설명 또는 안내 텍스트를 지정합니다. 이 텍스트는 Custom Properties 창에서 마우스 포인터를 속성 위에 올려 놓을 때 툴팁으로도 표시됩니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+이것은 애플리케이션 UI에 사용자 정의 속성이 나열되는 순서를 결정하는 키를 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+인스턴스가 생성되거나 도형이 복제·복사될 때 사용자가 도형에 대한 사용자 정의 속성 정보를 입력하도록 요청받는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/prop\#getDel--)을(를) 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/prop\#getID--)을(를) 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/prop\#getIX--)을(를) 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/prop\#getName--)을(를) 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/prop\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/propcollection/_index.md
+++ b/korean/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Prop 컬렉션.
+type: docs
+weight: 310
+url: /ko/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Prop 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | Add the Prop object in the collection. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getProp(int ID)](#getProp-int-) | Gets the element at the specified ID. |
+| [getProp(String name)](#getProp-java.lang.String-) | Gets the element at the specified name. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | Remove the Prop object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+Add the Prop object in the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+Gets the element at the specified name.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+Remove the Prop object from the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/proptype/_index.md
+++ b/korean/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Aspose.Diagram for Java API 참조
+description: 속성 유형.
+type: docs
+weight: 311
+url: /ko/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+속성 유형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOOL](#BOOL) | 불리언. |
+| [DATE](#DATE) | 날짜. |
+| [NUMBER](#NUMBER) | 숫자. |
+| [STRING](#STRING) | 문자열. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+불리언.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+날짜.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+숫자.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+문자열.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/protection/_index.md
+++ b/korean/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: 보호
+second_title: Aspose.Diagram for Java API 참조
+description: 잠금은 도형에 대한 실수로 인한 변경을 방지하는 데 도움이 되지만 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다.
+type: docs
+weight: 312
+url: /ko/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+잠금은 모양에 대한 의도치 않은 변경을 방지하는 데 도움이 되지만, 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. 또한 ShapeSheet 창에서 이루어지는 변경으로부터 보호하지도 않습니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getLockAspect()](#getLockAspect--) | 도형의 가로세로 비율이 잠겨 있는지 여부를 지정합니다. |
+| [getLockBegin()](#getLockBegin--) | 1차원 도형의 시작점이 특정 위치에 고정되어 있는지 여부를 지정합니다. |
+| [getLockCalcWH()](#getLockCalcWH--) | 도형의 선택 사각형이 잠겨 있어 정점이 편집되거나 Geom 요소에서 요소 유형이 변경될 때 재계산되지 않도록 지정합니다. |
+| [getLockCrop()](#getLockCrop--) | Microsoft Visio의 자르기 도구로 외부 객체가 잘려지는 것을 방지하도록 잠겨 있는지 여부를 지정합니다. |
+| [getLockCustProp()](#getLockCustProp--) | 사용자가 정의된 사용자 속성 대화 상자를 사용하여 UI에서 사용자 정의 속성을 추가, 삭제 또는 수정할 수 있는지 여부를 결정합니다. |
+| [getLockDelete()](#getLockDelete--) | 도형이 삭제되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다. |
+| [getLockEnd()](#getLockEnd--) | 1차원 도형의 끝점이 특정 위치에 고정되어 있는지 여부를 지정합니다. |
+| [getLockFormat()](#getLockFormat--) | 도형의 서식이 잠겨 있어 변경할 수 없는지 여부를 지정합니다. |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | Visio 사용자 인터페이스에서 상위 그룹 도형에 적용되는 서식 변경이 하위 도형에 의해 차단되도록 허용하며, 그렇지 않으면 개별 그룹 도형으로 전파됩니다. |
+| [getLockGroup()](#getLockGroup--) | 그룹이 잠겨 있어 그룹 해제가 불가능하도록 지정합니다. |
+| [getLockHeight()](#getLockHeight--) | 도형의 높이가 잠겨 있는지 여부를 지정합니다. |
+| [getLockMoveX()](#getLockMoveX--) | 도형의 가로 위치가 잠겨 있어 수평으로 이동할 수 없는지 여부를 지정합니다. |
+| [getLockMoveY()](#getLockMoveY--) | 도형의 세로 위치가 잠겨 있어 수직으로 이동할 수 없는지 여부를 지정합니다. |
+| [getLockRotate()](#getLockRotate--) | Microsoft Visio의 회전 도구 또는 왼쪽 회전/오른쪽 회전 명령으로 도형이 회전되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다. |
+| [getLockSelect()](#getLockSelect--) | 도형의 선택 사각형이 잠겨 있어 정점이 편집되거나 Geom 요소에서 요소 유형이 변경될 때 재계산되지 않도록 지정합니다. |
+| [getLockTextEdit()](#getLockTextEdit--) | 도형의 텍스트가 잠겨 있어 편집할 수 없는지 여부를 지정합니다. |
+| [getLockThemeColors()](#getLockThemeColors--) | 사용자가 도형에 테마 색상을 적용하는 것을 방지합니다. |
+| [getLockThemeEffects()](#getLockThemeEffects--) | 사용자가 모양에 테마 효과를 적용하는 것을 방지합니다. |
+| [getLockVtxEdit()](#getLockVtxEdit--) | 모양의 정점이 잠겨 있어 도구 모음의 어떤 도구로도 편집할 수 없는지 여부를 지정합니다. |
+| [getLockWidth()](#getLockWidth--) | 모양의 너비가 잠겨 있어 크기를 조정할 때 변경되지 않는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/protection\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+모양의 종횡비가 잠겨 있는지 여부를 지정합니다. 잠겨 있으면 모양을 비례적으로만 크기 조정할 수 있으며, 단일 차원으로는 크기 조정할 수 없습니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+1차원 도형의 시작점이 특정 위치에 고정되어 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+도형의 선택 사각형이 잠겨 있어 정점이 편집되거나 Geom 요소에서 요소 유형이 변경될 때 재계산되지 않도록 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Microsoft Visio의 자르기 도구로 외부 객체가 잘려지는 것을 방지하도록 잠겨 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+사용자가 정의된 사용자 속성 대화 상자를 사용하여 UI에서 사용자 정의 속성을 추가, 삭제 또는 수정할 수 있는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+도형이 삭제되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+1차원 도형의 끝점이 특정 위치에 고정되어 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+모양의 서식이 잠겨 있어 변경할 수 없는지 여부를 지정합니다. 구체적으로, 이 요소는 텍스트, 선, 채우기 서식 변경이나 모양이 상속받는 Style 요소 변경을 방지합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+Visio 사용자 인터페이스에서 상위 그룹 도형에 적용되는 서식 변경이 하위 도형에 의해 차단되도록 허용하며, 그렇지 않으면 개별 그룹 도형으로 전파됩니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+그룹이 잠겨 있어 그룹 해제가 불가능하도록 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+모양의 높이가 잠겨 있는지 여부를 지정합니다. 잠겨 있으면 모양을 크기 조정할 때 높이가 변경되지 않습니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+도형의 가로 위치가 잠겨 있어 수평으로 이동할 수 없는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+도형의 세로 위치가 잠겨 있어 수직으로 이동할 수 없는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Microsoft Visio의 회전 도구 또는 왼쪽 회전/오른쪽 회전 명령으로 도형이 회전되는 것을 방지하도록 잠겨 있는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+도형의 선택 사각형이 잠겨 있어 정점이 편집되거나 Geom 요소에서 요소 유형이 변경될 때 재계산되지 않도록 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+모양의 텍스트가 잠겨 있어 편집할 수 없는지 여부를 지정합니다. 그러나 텍스트는 스타일을 적용하거나 텍스트 대화 상자의 글꼴 탭에 있는 Style 옵션을 사용하여 서식은 적용할 수 있습니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+사용자가 도형에 테마 색상을 적용하는 것을 방지합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+사용자가 모양에 테마 효과를 적용하는 것을 방지합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+모양의 정점이 잠겨 있어 도구 모음의 어떤 도구로도 편집할 수 없는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+모양의 너비가 잠겨 있어 크기를 조정할 때 변경되지 않는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/protection\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: RadioButton ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 313
+url: /ko/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+RadioButton ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | 컨트롤의 단축키입니다. |
+| [getAlignment()](#getAlignment--) | 컨트롤에 대한 Caption의 위치입니다. |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getCaption()](#getCaption--) | 컨트롤에 표시되는 설명 텍스트입니다. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getGroupName()](#getGroupName--) | 그룹의 이름입니다. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPicturePosition()](#getPicturePosition--) | 컨트롤 캡션에 상대적인 그림의 위치. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getValue()](#getValue--) | 컨트롤이 선택되었는지 여부를 나타냅니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isTripleState()](#isTripleState--) | 지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다. |
+| [isWordWrapped()](#isWordWrapped--) | 컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | 이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)를 참조하십시오. |
+| [setAlignment(int value)](#setAlignment-int-) | 이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)를 참조하십시오. |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setCaption(String value)](#setCaption-java.lang.String-) | 이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)를 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | 이 속성에 대한 설명은 [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)를 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)를 참조하십시오. |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | 이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)를 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)를 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | 이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)를 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)를 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | 이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+컨트롤의 단축키입니다.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+컨트롤에 대한 Caption의 위치입니다.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+컨트롤에 표시되는 설명 텍스트입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+그룹의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+컨트롤 캡션에 상대적인 그림의 위치.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+컨트롤이 선택되었는지 여부를 나타냅니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 설정 | 설명 |
+| True    | 컨트롤은 Yes, No 및 Null 값에 대한 상태를 순환합니다. Value 속성이 Null로 설정되면 컨트롤이 흐리게(회색) 표시됩니다. |
+| False   | (기본값) 컨트롤은 Yes와 No 값에 대한 상태를 순환합니다. Null 값은 No 값처럼 표시됩니다. |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+이 속성에 대한 설명은 [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/korean/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Aspose.Diagram for Java API 참조
+description: 두 사각형을 서로 상대적으로 배치하는 방법을 나타냅니다.
+type: docs
+weight: 314
+url: /ko/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+두 사각형을 서로 상대적으로 배치하는 방법을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 하단 |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | BottomLeft |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | BottomRight |
+| [CENTER](#CENTER) | Center |
+| [LEFT](#LEFT) | Left |
+| [RIGHT](#RIGHT) | Right |
+| [TOP](#TOP) | Top |
+| [TOP_LEFT](#TOP-LEFT) | TopLeft |
+| [TOP_RIGHT](#TOP-RIGHT) | TopRight |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+하단
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+BottomLeft
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+BottomRight
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Center
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Left
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Right
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Top
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+TopLeft
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+TopRight
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/korean/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Aspose.Diagram for Java API 참조
+description: 
+type: docs
+weight: 315
+url: /ko/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | 사용자 지정 반사 효과입니다. |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | 전체 반사, 4pt 오프셋. |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | 전체 반사, 8pt 오프셋. |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | 전체 반사, 접촉. |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | 절반 반사, 4pt 오프셋. |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | 절반 반사, 8pt 오프셋. |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | 절반 반사, 접촉. |
+| [NONE](#NONE) | 반사 효과 없음. |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | 조밀한 반사, 4pt 오프셋. |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | 조밀한 반사, 8pt 오프셋. |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | 조밀한 반사, 접촉. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+사용자 지정 반사 효과입니다.
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+전체 반사, 4pt 오프셋.
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+전체 반사, 8pt 오프셋.
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+전체 반사, 접촉.
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+절반 반사, 4pt 오프셋.
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+절반 반사, 8pt 오프셋.
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+절반 반사, 접촉.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+반사 효과 없음.
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+조밀한 반사, 4pt 오프셋.
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+조밀한 반사, 8pt 오프셋.
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+조밀한 반사, 접촉.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/korean/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Aspose.Diagram for Java API 참조
+description: RelCubBezTos 포인트에 대한 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 316
+url: /ko/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+RelCubBezTo 점들의 x 및 y 좌표를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) |  [RelCubBezTo](../../com.aspose.diagram/relcubbezto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 곡선 시작 부분에 있는 제어점의 x 좌표(상대 좌표). |
+| [getB()](#getB--) | 곡선 시작 부분에 있는 제어점의 y 좌표(상대 좌표). |
+| [getC()](#getC--) | 곡선 끝 부분에 있는 제어점의 x 좌표(상대 좌표). |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 곡선 끝 부분에 있는 제어점의 y 좌표(상대 좌표). |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 상대 좌표계에서 끝점의 x 좌표입니다. |
+| [getY()](#getY--) | 상대 좌표에서 끝점의 y좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relcubbezto\#getA--)을 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relcubbezto\#getB--)을 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/relcubbezto\#getC--)을 참조하십시오. |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/relcubbezto\#getD--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)을 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relcubbezto\#getX--)을 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relcubbezto\#getY--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+ [RelCubBezTo](../../com.aspose.diagram/relcubbezto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+곡선 시작 부분에 있는 제어점의 x 좌표(상대 좌표).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+곡선 시작 부분에 있는 제어점의 y 좌표(상대 좌표).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+곡선 끝 부분에 있는 제어점의 x 좌표(상대 좌표).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+곡선 끝 부분에 있는 제어점의 y 좌표(상대 좌표).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+상대 좌표계에서 끝점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+상대 좌표에서 끝점의 y좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relcubbezto\#getA--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relcubbezto\#getB--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/relcubbezto\#getC--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/relcubbezto\#getD--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relcubbezto\#getX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relcubbezto\#getY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/korean/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RelCubBezTo 컬렉션.
+type: docs
+weight: 317
+url: /ko/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+RelCubBezTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/korean/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Aspose.Diagram for Java API 참조
+description: 타원 호에 대한 정보를 지정하는 요소를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+type: docs
+weight: 318
+url: /ko/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+타원 호에 대한 정보를 지정하는 요소를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | 다음 [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 호의 제어점 x좌표. |
+| [getB()](#getB--) | 호의 제어점 y좌표. |
+| [getC()](#getC--) | 부모의 x축에 대한 호의 장축 각도. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 호의 장축과 단축의 비율. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 타원형 호 끝 정점의 x좌표. |
+| [getY()](#getY--) | 타원형 호 끝 정점의 y좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)을(를) 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)을(를) 참조하십시오. |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+다음 [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+호의 제어점의 x좌표입니다. 제어점은 호의 시작 정점과 끝 정점 사이 중간 정도에 위치하는 것이 가장 좋습니다. 그렇지 않으면 제어점을 통과하기 위해 호가 극도로 커질 수 있으며, 예측할 수 없는 결과가 발생할 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+호의 제어점 y좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+부모의 x축에 대한 호의 장축 각도.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+호의 장축과 단축의 비율입니다. 일반적인 의미와 달리 장축이 단축보다 크지 않아도 되므로 이 비율이 1보다 커야 할 필요는 없습니다. 이 요소를 0 이하 또는 1000 초과 값으로 설정하면 예측할 수 없는 결과가 발생할 수 있습니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+타원형 호 끝 정점의 x좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+타원형 호 끝 정점의 y좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/korean/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RelEllipticalArcTo  컬렉션.
+type: docs
+weight: 319
+url: /ko/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+RelEllipticalArcTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rellineto/_index.md
+++ b/korean/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Aspose.Diagram for Java API 참조
+description: 직선 세그먼트의 끝 정점의 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 320
+url: /ko/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+직선 세그먼트의 끝 정점에 대한 x 및 y 좌표를 포함합니다. 이러한 좌표는 각각 X 및 Y 요소에 포함됩니다. 좌표는 상대 좌표로 지정됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | 다음 [LineTo](../../com.aspose.diagram/lineto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 직선 세그먼트 끝 정점의 x 좌표입니다. |
+| [getY()](#getY--) | 직선 세그먼트 끝 정점의 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/rellineto\\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/rellineto\\#getIX--)을 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/rellineto\\#getX--)을 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/rellineto\\#getY--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+다음 [LineTo](../../com.aspose.diagram/lineto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+직선 세그먼트 끝 정점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+직선 세그먼트 끝 정점의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/rellineto\\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/rellineto\\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/rellineto\\#getX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/rellineto\\#getY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/korean/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RelLineTo 컬렉션.
+type: docs
+weight: 321
+url: /ko/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+RelLineTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relmoveto/_index.md
+++ b/korean/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Aspose.Diagram for Java API 참조
+description: 형상의 첫 번째 꼭짓점의 x 및 y 좌표를 포함하거나 경로에서 끊어진 후 첫 번째 꼭짓점의 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+type: docs
+weight: 322
+url: /ko/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+도형의 첫 번째 정점의 x 및 y 좌표를 포함하거나, 경로에서 끊김 후 첫 번째 정점의 x 및 y 좌표를 포함합니다. 좌표는 상대 좌표로 지정됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | 다음 [MoveTo](../../com.aspose.diagram/moveto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | X 요소는 경로의 첫 번째 정점의 x 좌표를 나타냅니다. |
+| [getY()](#getY--) | Y 요소는 경로의 첫 번째 정점의 y 좌표를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relmoveto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relmoveto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+다음 [MoveTo](../../com.aspose.diagram/moveto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X 요소는 경로의 첫 번째 정점의 x 좌표를 나타냅니다. MoveTo 요소가 두 요소 사이에 나타나는 경우, X 요소는 경로 끊김 후 첫 번째 정점의 x 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y 요소는 경로의 첫 번째 정점의 y 좌표를 나타냅니다. MoveTo 요소가 두 요소 사이에 나타나는 경우, Y 요소는 경로 끊김 후 첫 번째 정점의 y 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relmoveto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relmoveto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/korean/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RelMoveTo 컬렉션.
+type: docs
+weight: 323
+url: /ko/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+RelMoveTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/korean/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Aspose.Diagram for Java API 참조
+description: RelQuadBezTo 점에 대한 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 324
+url: /ko/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+RelQuadBezTo의 점에 대한 x 및 y 좌표를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) |  [RelCubBezTo](../../com.aspose.diagram/relcubbezto) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 상대 좌표계에서 제어점의 x 좌표입니다. |
+| [getB()](#getB--) | 상대 좌표계에서 제어점의 y 좌표입니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 상대 좌표계에서 끝점의 x 좌표입니다. |
+| [getY()](#getY--) | 상대 좌표에서 끝점의 y좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relquadbezto\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relquadbezto\#getB--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relquadbezto\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relquadbezto\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+ [RelCubBezTo](../../com.aspose.diagram/relcubbezto) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+상대 좌표계에서 제어점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+상대 좌표계에서 제어점의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+상대 좌표계에서 끝점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+상대 좌표에서 끝점의 y좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/relquadbezto\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/relquadbezto\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/relquadbezto\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/relquadbezto\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/korean/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RelQuadBezTo 컬렉션.
+type: docs
+weight: 325
+url: /ko/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+RelQuadBezTo 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/korean/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램에 대한 숨김 정보 제거를 지정합니다.
+type: docs
+weight: 326
+url: /ko/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+다이어그램에 대한 숨김 정보 제거를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 이것은 사용자가 다이어그램을 특정 형식으로 저장할 때 추가 옵션을 지정할 수 있도록 하는 클래스들을 위한 추상 기본 클래스입니다.
+type: docs
+weight: 327
+url: /ko/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+이것은 사용자가 다이어그램을 특정 형식으로 저장할 때 추가 옵션을 지정할 수 있도록 하는 클래스들을 위한 추상 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/resizemode/_index.md
+++ b/korean/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Aspose.Diagram for Java API 참조
+description: 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+type: docs
+weight: 328
+url: /ko/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)을 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/resizemode\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/resizemode\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+type: docs
+weight: 329
+url: /ko/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | 재배치만. |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | 그룹과 함께 스케일링. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | 그룹 설정 사용 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+재배치만.
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+그룹과 함께 스케일링.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+그룹 설정 사용
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/reviewer/_index.md
+++ b/korean/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: Reviewer
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 검토자에 대한 식별 정보를 포함하는 요소를 포함합니다.
+type: docs
+weight: 330
+url: /ko/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+문서 검토자에 대한 식별 정보를 포함하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Color element specifies an RGB value representing the color assigned to a document reviewer's markup. |
+| [getCurrentIndex()](#getCurrentIndex--) | Indicates the value of the MarkerIndex element that will be added when the current reviewer adds another comment to the document. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getInitials()](#getInitials--) | Contains the initials of a document reviewer. |
+| [getName()](#getName--) | Name element specifies the name of a document reviewer. |
+| [getReviewerID()](#getReviewerID--) | 문서에 마크업을 추가하는 검토자의 ID 번호를 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | For the description of this property, please see [getDel()](../../com.aspose.diagram/reviewer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | For the description of this property, please see [getIX()](../../com.aspose.diagram/reviewer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Color element specifies an RGB value representing the color assigned to a document reviewer's markup.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+Indicates the value of the MarkerIndex element that will be added when the current reviewer adds another comment to the document.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+Contains the initials of a document reviewer.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name element specifies the name of a document reviewer.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+문서에 마크업을 추가하는 검토자의 ID 번호를 포함합니다.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+For the description of this property, please see [getDel()](../../com.aspose.diagram/reviewer\#getDel--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+For the description of this property, please see [getIX()](../../com.aspose.diagram/reviewer\#getIX--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/korean/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 검토자 컬렉션.
+type: docs
+weight: 331
+url: /ko/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+검토자 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | 컬렉션에 Reviewer 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | 컬렉션에서 Reviewer 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+컬렉션에 Reviewer 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+컬렉션에서 Reviewer 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rotationtype/_index.md
+++ b/korean/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 332
+url: /ko/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 베벨 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+베벨 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 효과 속성에 대한 투영 유형을 지정합니다.
+type: docs
+weight: 333
+url: /ko/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+도형의 효과 속성에 대한 투영 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [NONE](#NONE) | 3D 효과 회전이 없음을 지정합니다. |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | 도형이 경계 상자의 왼쪽 하단 모서리에서 비스듬한 투영으로 회전함을 지정합니다. |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | 도형이 경계 상자의 오른쪽 하단 모서리에서 비스듬한 투영으로 회전함을 지정합니다. |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | 도형이 경계 상자의 왼쪽 상단 모서리에서 비스듬한 투영으로 회전함을 지정합니다. |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | 도형이 경계 상자의 오른쪽 상단 모서리에서 비스듬한 투영으로 회전함을 지정합니다. |
+| [PARALLEL](#PARALLEL) | 3D 효과 속성에 평행 투영이 적용됨을 지정합니다. |
+| [PERSPECTIVE](#PERSPECTIVE) | 도형이 원근 투영으로 회전함을 지정합니다. |
+| [UNDEFINED](#UNDEFINED) | 조명 장비 없음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+3D 효과 회전이 없음을 지정합니다.
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+도형이 경계 상자의 왼쪽 하단 모서리에서 비스듬한 투영으로 회전함을 지정합니다.
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+도형이 경계 상자의 오른쪽 하단 모서리에서 비스듬한 투영으로 회전함을 지정합니다.
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+도형이 경계 상자의 왼쪽 상단 모서리에서 비스듬한 투영으로 회전함을 지정합니다.
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+도형이 경계 상자의 오른쪽 상단 모서리에서 비스듬한 투영으로 회전함을 지정합니다.
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+3D 효과 속성에 평행 투영이 적용됨을 지정합니다.
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+도형이 원근 투영으로 회전함을 지정합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+조명 장비 없음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/routestyle/_index.md
+++ b/korean/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 라우팅 스타일이 없는 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+type: docs
+weight: 334
+url: /ko/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/routestyle\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/routestyle\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 로컬 라우팅 스타일이 없는 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+type: docs
+weight: 335
+url: /ko/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+로컬 라우팅 스타일이 없는 그리기 페이지의 모든 동적 커넥터에 대한 라우팅 스타일 및 방향을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | 중심에서 중심으로. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | 기본값. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | 플로우차트 하단에서 상단으로. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | 플로우 차트 왼쪽에서 오른쪽으로. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | 플로우차트 오른쪽에서 왼쪽으로. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | 플로우 차트 상단에서 하단으로. |
+| [NETWORK](#NETWORK) | 네트워크. |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | 조직도 하단에서 상단으로. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | 조직도 왼쪽에서 오른쪽으로. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | 조직도 오른쪽에서 왼쪽으로. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | 조직도 위에서 아래로. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | 직각. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | 단순 아래에서 위로. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | 단순 가로 세로. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | 단순 왼쪽에서 오른쪽으로. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | 단순 오른쪽에서 왼쪽으로. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | 단순 위에서 아래로. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | 단순 세로 가로. |
+| [STRAIGHT](#STRAIGHT) | 직선. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | 트리 아래에서 위로. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | 트리 왼쪽에서 오른쪽으로. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | 트리 오른쪽에서 왼쪽으로. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | 트리 위에서 아래로. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+중심에서 중심으로.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+기본. 직각.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+플로우차트 하단에서 상단으로.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+플로우 차트 왼쪽에서 오른쪽으로.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+플로우차트 오른쪽에서 왼쪽으로.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+플로우 차트 상단에서 하단으로.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+네트워크.
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+조직도 하단에서 상단으로.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+조직도 왼쪽에서 오른쪽으로.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+조직도 오른쪽에서 왼쪽으로.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+조직도 위에서 아래로.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+직각.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+단순 아래에서 위로.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+단순 가로 세로.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+단순 왼쪽에서 오른쪽으로.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+단순 오른쪽에서 왼쪽으로.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+단순 위에서 아래로.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+단순 세로 가로.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+직선.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+트리 아래에서 위로.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+트리 왼쪽에서 오른쪽으로.
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+트리 오른쪽에서 왼쪽으로.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+트리 위에서 아래로.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/row/_index.md
+++ b/korean/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Aspose.Diagram for Java API 참조
+description: 데이터 레코드셋의 행을 나타냅니다.
+type: docs
+weight: 336
+url: /ko/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+데이터 레코드셋의 행을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Row()](#Row--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | 도형의 페이지 ID입니다. |
+| [getRowID()](#getRowID--) | 원본 행 ID입니다. |
+| [getShapeID()](#getShapeID--) | 도형의 Shape ID입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | 이 속성에 대한 설명은 [getPageID()](../../com.aspose.diagram/row\#getPageID--)을(를) 참조하십시오. |
+| [setRowID(long value)](#setRowID-long-) | 이 속성에 대한 설명은 [getRowID()](../../com.aspose.diagram/row\#getRowID--)을(를) 참조하십시오. |
+| [setShapeID(long value)](#setShapeID-long-) | 이 속성에 대한 설명은 [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+도형의 페이지 ID입니다.
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+원본 행 ID입니다.
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+도형의 Shape ID입니다.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+이 속성에 대한 설명은 [getPageID()](../../com.aspose.diagram/row\#getPageID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+이 속성에 대한 설명은 [getRowID()](../../com.aspose.diagram/row\#getRowID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+이 속성에 대한 설명은 [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rowcollection/_index.md
+++ b/korean/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 행 컬렉션.
+type: docs
+weight: 337
+url: /ko/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+행 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | Add the row in the collection. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | Remove the row from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+Add the row in the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+Remove the row from the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rule/_index.md
+++ b/korean/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 검증 규칙 집합에서 단일 검증 규칙을 나타냅니다.
+type: docs
+weight: 338
+url: /ko/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+다이어그램 검증 규칙 집합에서 단일 검증 규칙을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Rule()](#Rule--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Issues 창의 Category 열에 표시되는 텍스트를 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | 사용자 인터페이스에 표시되는 검증 규칙의 설명. |
+| [getID()](#getID--) | 검증 규칙의 고유 식별자를 지정합니다. |
+| [getIgnored()](#getIgnored--) | 검증 규칙이 현재 무시되는지 여부를 지정합니다. |
+| [getNameU()](#getNameU--) | 검증 규칙의 보편적인 이름을 지정합니다. |
+| [getRuleFilter()](#getRuleFilter--) | 검증 규칙을 대상 객체에 적용할지 여부를 결정하는 논리식을 지정합니다. |
+| [getRuleTarget()](#getRuleTarget--) | 검증 규칙이 적용되는 객체 유형을 지정합니다. |
+| [getRuleTest()](#getRuleTest--) | 대상 객체가 검증 규칙을 만족하는지 여부를 결정하는 논리식을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | 이 속성에 대한 설명은 [getCategory()](../../com.aspose.diagram/rule\#getCategory--)을(를) 참조하십시오. |
+| [setDescription(String value)](#setDescription-java.lang.String-) | 이 속성에 대한 설명은 [getDescription()](../../com.aspose.diagram/rule\#getDescription--)을(를) 참조하십시오. |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/rule\#getID--)을(를) 참조하십시오. |
+| [setIgnored(int value)](#setIgnored-int-) | 이 속성에 대한 설명은 [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/rule\#getNameU--)을(를) 참조하십시오. |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | 이 속성에 대한 설명은 [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)을(를) 참조하십시오. |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | 이 속성에 대한 설명은 [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)을(를) 참조하십시오. |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | 이 속성에 대한 설명은 [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Issues 창의 Category 열에 표시되는 텍스트를 지정합니다. 기본값은 빈 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+사용자 인터페이스에 표시되는 검증 규칙의 설명입니다. 기본값은 "Unknown"입니다.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+검증 규칙의 고유 식별자를 지정합니다.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+검증 규칙이 현재 무시되는지 여부를 지정합니다. 기본값은 False입니다.
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+검증 규칙의 보편적인 이름을 지정합니다.
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+검증 규칙을 대상 객체에 적용할지 여부를 결정하는 논리식을 지정합니다.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+검증 규칙이 적용되는 객체 유형을 지정합니다.
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+대상 객체가 검증 규칙을 만족하는지 여부를 결정하는 논리식을 지정합니다.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+이 속성에 대한 설명은 [getCategory()](../../com.aspose.diagram/rule\#getCategory--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+이 속성에 대한 설명은 [getDescription()](../../com.aspose.diagram/rule\#getDescription--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/rule\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+이 속성에 대한 설명은 [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/rule\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+이 속성에 대한 설명은 [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulecollection/_index.md
+++ b/korean/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 규칙 컬렉션.
+type: docs
+weight: 339
+url: /ko/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+규칙 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | 컬렉션에 규칙을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | 컬렉션에서 규칙을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+컬렉션에 규칙을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+컬렉션에서 규칙을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/korean/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Aspose.Diagram for Java API 참조
+description: 상위 검증 이슈와 관련된 검증 규칙에 대한 정보를 지정합니다.
+type: docs
+weight: 340
+url: /ko/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+상위 검증 이슈와 관련된 검증 규칙에 대한 정보를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | 부모 이슈와 관련된 검증 규칙의 고유 식별자를 지정합니다. |
+| [getRuleSetId()](#getRuleSetId--) | 부모 이슈와 관련된 검증 규칙 집합의 고유 식별자를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | 이 속성에 대한 설명은 [getRuleId()](../../com.aspose.diagram/ruleinfo\\#getRuleId--)을 참조하십시오. |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | 이 속성에 대한 설명은 [getRuleSetId()](../../com.aspose.diagram/ruleinfo\\#getRuleSetId--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+부모 이슈와 관련된 검증 규칙의 고유 식별자를 지정합니다.
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+부모 이슈와 관련된 검증 규칙 집합의 고유 식별자를 지정합니다.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+이 속성에 대한 설명은 [getRuleId()](../../com.aspose.diagram/ruleinfo\\#getRuleId--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+이 속성에 대한 설명은 [getRuleSetId()](../../com.aspose.diagram/ruleinfo\\#getRuleSetId--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/korean/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 눈금자에 대한 수평 구분을 지정합니다.
+type: docs
+weight: 344
+url: /ko/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+페이지 눈금자에 대한 수평 구분을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지 눈금자에 대한 수평 구분을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지 눈금자에 대한 수평 구분을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/korean/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 눈금자에 대한 수평 구분을 지정합니다.
+type: docs
+weight: 345
+url: /ko/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+페이지 눈금자에 대한 수평 구분을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [COARSE](#COARSE) | 거침. |
+| [FINE](#FINE) | 좋음. |
+| [NORMAL](#NORMAL) | 보통. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+거침.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+좋음.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+보통.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulergrid/_index.md
+++ b/korean/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지 눈금 및 그리드 설정을 지정하는 요소를 포함합니다.
+type: docs
+weight: 346
+url: /ko/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getXGridDensity()](#getXGridDensity--) | 페이지의 y축(수직) 눈금에 대한 원점(0점)을 지정합니다. |
+| [getXGridOrigin()](#getXGridOrigin--) | 페이지에 대한 그리드 원점의 수평 좌표를 지정합니다. |
+| [getXGridSpacing()](#getXGridSpacing--) | 고정 그리드에서 수평선 사이의 거리를 지정합니다(즉, XGridDensity 요소가 0으로 설정된 RulerGrid 요소). |
+| [getXRulerDensity()](#getXRulerDensity--) | 페이지 눈금자에 대한 수평 구분을 지정합니다. |
+| [getXRulerOrigin()](#getXRulerOrigin--) | 페이지의 x축(수평) 눈금에 대한 원점(0점)을 지정합니다. |
+| [getYGridDensity()](#getYGridDensity--) | 페이지에 사용할 수직 그리드 유형을 지정합니다. |
+| [getYGridOrigin()](#getYGridOrigin--) | 페이지에 있는 그리드의 수직 원점을 지정합니다. |
+| [getYGridSpacing()](#getYGridSpacing--) | 고정 그리드에서 수직선 사이의 거리를 지정합니다(즉, YGridDensity 요소가 0으로 설정된 RulerGrid 요소). |
+| [getYRulerDensity()](#getYRulerDensity--) | 페이지 눈금의 수직 세분화를 지정합니다. |
+| [getYRulerOrigin()](#getYRulerOrigin--) | 페이지의 y축(수직) 눈금에 대한 원점(0점)을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) 를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+페이지의 y축(수직) 눈금에 대한 원점(0점)을 지정합니다.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+페이지에 대한 그리드 원점의 수평 좌표를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+고정 그리드에서 수평선 사이의 거리를 지정합니다(즉, XGridDensity 요소가 0으로 설정된 RulerGrid 요소).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+페이지 눈금자에 대한 수평 구분을 지정합니다.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+페이지의 x축(수평) 눈금에 대한 원점(0점)을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+페이지에 사용할 수직 그리드 유형을 지정합니다.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+페이지에 있는 그리드의 수직 원점을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+고정 그리드에서 수직선 사이의 거리를 지정합니다(즉, YGridDensity 요소가 0으로 설정된 RulerGrid 요소).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+페이지 눈금의 수직 세분화를 지정합니다.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+페이지의 y축(수직) 눈금에 대한 원점(0점)을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/ruleset/_index.md
+++ b/korean/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 검증 규칙의 한 세트를 나타냅니다.
+type: docs
+weight: 341
+url: /ko/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+다이어그램 검증 규칙의 한 세트를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | 사용자 인터페이스에 표시되는 검증 규칙 집합의 설명을 지정합니다. |
+| [getEnabled()](#getEnabled--) | 현재 문서에 대해 검증이 트리거될 때 지정된 검증 규칙 집합의 규칙이 확인되는지 여부를 지정합니다. |
+| [getID()](#getID--) | 검증 규칙 집합의 고유 식별자를 지정합니다. |
+| [getName()](#getName--) | 검증 규칙 집합의 로컬 이름을 지정합니다. |
+| [getNameU()](#getNameU--) | 검증 규칙 집합의 전역 이름을 지정합니다. |
+| [getRuleSetFlags()](#getRuleSetFlags--) | 규칙 집합이 확인할 규칙 목록에 표시되는지 여부를 지정합니다. |
+| [getRules()](#getRules--) | 규칙 컬렉션. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | 이 속성에 대한 설명은 [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)을 참조하십시오. |
+| [setEnabled(int value)](#setEnabled-int-) | 이 속성에 대한 설명은 [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)을 참조하십시오. |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/ruleset\#getID--)을 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/ruleset\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)을(를) 참조하십시오. |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | 이 속성에 대한 설명은 [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+사용자 인터페이스에 표시되는 검증 규칙 집합의 설명을 지정합니다. 기본값은 빈 문자열입니다.
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+현재 문서에 대해 검증이 트리거될 때 지정된 검증 규칙 집합의 규칙이 검사되는지 여부를 지정합니다. 기본값은 True입니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+검증 규칙 집합의 고유 식별자를 지정합니다.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+검증 규칙 집합의 로컬 이름을 지정합니다. 기본값은 NameU 속성 값입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+검증 규칙 집합의 전역 이름을 지정합니다.
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+규칙 집합이 확인할 규칙 목록에 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+규칙 컬렉션.
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+이 속성에 대한 설명은 [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+이 속성에 대한 설명은 [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/ruleset\#getID--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/ruleset\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+이 속성에 대한 설명은 [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/korean/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Aspose.Diagram for Java API 참조
+description: RuleSet 컬렉션.
+type: docs
+weight: 342
+url: /ko/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+RuleSet 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | 컬렉션에 ruleSet을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | 컬렉션에서 ruleSet을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+컬렉션에 ruleSet을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+컬렉션에서 ruleSet을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/rulevalue/_index.md
+++ b/korean/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 규칙 값.
+type: docs
+weight: 343
+url: /ko/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+규칙 값.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | 요소의 수식을 나타냅니다. |
+| [getValue()](#getValue--) | 규칙 값. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | 이 속성에 대한 설명은 [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)을(를) 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| formula | java.lang.String |  |
+| 값 | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+요소의 수식을 나타냅니다. 이 속성은 다음 문자열 중 하나를 포함할 수 있습니다: "someFormula"는 수식이 로컬에 존재할 때, "No Formula"는 수식이 로컬에서 삭제되었거나 차단되었을 때, "Inh"는 수식이 상속될 때입니다. 속성이 없으면 요소의 수식은 단순 상수입니다.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+규칙 값.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+이 속성에 대한 설명은 [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/savefileformat/_index.md
+++ b/korean/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 형식 선택 저장을 위한 열거형입니다.
+type: docs
+weight: 348
+url: /ko/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+다이어그램 형식 선택 저장을 위한 열거형입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BMP](#BMP) | Bmp 이미지 형식. |
+| [EMF](#EMF) | EMF 이미지 형식. |
+| [GIF](#GIF) | Gif 형식. |
+| [HTML](#HTML) | Html 형식. |
+| [JPEG](#JPEG) | Jpeg 이미지 형식. |
+| [PDF](#PDF) | Pdf 형식. |
+| [PNG](#PNG) | Png 이미지 형식. |
+| [SVG](#SVG) | Svg 형식. |
+| [TIFF](#TIFF) | Tiff 이미지 형식. |
+| [VDX](#VDX) | MS Visio Vdx xml 형식. |
+| [VSDM](#VSDM) | 매크로를 활성화하는 MS Visio Vsdm 파일 형식. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx 파일 형식. |
+| [VSSM](#VSSM) | 매크로를 활성화하는 MS Visio Vssm 파일 형식. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx 파일 형식 |
+| [VSTM](#VSTM) | 매크로를 활성화하는 MS Visio Vstm 파일 형식. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx 파일 형식, 템플릿 파일. |
+| [VSX](#VSX) | MS Visio Vsx xml 스텐실 형식. |
+| [VTX](#VTX) | MS Visio Vst xml 템플릿 형식. |
+| [XAML](#XAML) | Xaml 형식. |
+| [XPS](#XPS) | Xps 형식. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Bmp 이미지 형식.
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+EMF 이미지 형식.
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Gif 형식.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Html 형식.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Jpeg 이미지 형식.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf 형식.
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Png 이미지 형식.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Svg 형식.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Tiff 이미지 형식.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio Vdx xml 형식.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+매크로를 활성화하는 MS Visio Vsdm 파일 형식.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx 파일 형식.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+매크로를 활성화하는 MS Visio Vssm 파일 형식.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx 파일 형식
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+매크로를 활성화하는 MS Visio Vstm 파일 형식.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx 파일 형식, 템플릿 파일.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml 스텐실 형식.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vst xml 템플릿 형식.
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Xaml 형식.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Xps 형식.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/saveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 이것은 사용자가 다이어그램을 특정 형식으로 저장할 때 추가 옵션을 지정할 수 있도록 하는 클래스들을 위한 추상 기본 클래스입니다.
+type: docs
+weight: 349
+url: /ko/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+이는 다이어그램을 특정 형식으로 저장할 때 사용자가 추가 옵션을 지정할 수 있도록 하는 클래스들의 추상 기본 클래스입니다. SaveOptions 클래스 또는 파생 클래스의 인스턴스는 스트림 Save 또는 문자열 Save 오버로드에 전달되어 사용자가 문서를 저장할 때 사용자 정의 옵션을 정의할 수 있게 합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/scratch/_index.md
+++ b/korean/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Aspose.Diagram for Java API 참조
+description: 다른 요소가 참조하는 수식을 입력하고 테스트할 수 있는 작업 영역을 포함합니다.
+type: docs
+weight: 350
+url: /ko/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+다른 요소에서 참조하는 수식을 입력하고 테스트할 수 있는 작업 영역을 포함합니다. 이 요소는 일반적으로 반복되는 복잡한 계산을 분리하는 데 사용됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Scratch()](#Scratch--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 범용 요소입니다. |
+| [getB()](#getB--) | 범용 스크래치 요소입니다. |
+| [getC()](#getC--) | 범용 요소입니다. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 범용 요소입니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 로컬 좌표계에서 모양의 x좌표를 지정합니다. |
+| [getY()](#getY--) | 로컬 좌표계에서 모양의 y좌표를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/scratch\#getA--)을(를) 참조하십시오. |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/scratch\#getB--)을(를) 참조하십시오. |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/scratch\#getC--)을(를) 참조하십시오. |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/scratch\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/scratch\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/scratch\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/scratch\#getX--)을(를) 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/scratch\#getY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+범용 요소입니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+범용 스크래치 요소입니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+범용 요소입니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+범용 요소입니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+로컬 좌표계에서 도형의 x 좌표를 지정합니다. 다음 표는 이를 포함하는 요소를 기준으로 X 요소를 설명합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+로컬 좌표계에서 도형의 y 좌표를 지정합니다. 로컬 좌표계는 페이지가 아니라 도형을 기준으로 하는 좌표계입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/scratch\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/scratch\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/scratch\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/scratch\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/scratch\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/scratch\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/scratch\#getX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/scratch\#getY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/korean/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 스크래치 컬렉션.
+type: docs
+weight: 351
+url: /ko/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+스크래치 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | 컬렉션에 Scratch 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | 컬렉션에서 Scratch 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+컬렉션에 Scratch 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+컬렉션에서 Scratch 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: ScrollBar 컨트롤을 나타냅니다.
+type: docs
+weight: 352
+url: /ko/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+ScrollBar 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getLargeChange()](#getLargeChange--) | Position 속성이 변경되는 양 |
+| [getMax()](#getMax--) | 허용되는 최대값. |
+| [getMin()](#getMin--) | 허용되는 최소값. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getOrientation()](#getOrientation--) | SpinButton 또는 ScrollBar가 수직으로 배치되는지 수평으로 배치되는지 여부. |
+| [getPosition()](#getPosition--) | 값. |
+| [getSmallChange()](#getSmallChange--) | Position 속성이 변경되는 양 |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLargeChange(int value)](#setLargeChange-int-) | 이 속성에 대한 설명은 [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMax(int value)](#setMax-int-) | 이 속성에 대한 설명은 [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)을(를) 참조하십시오. |
+| [setMin(int value)](#setMin-int-) | 이 속성에 대한 설명은 [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setOrientation(int value)](#setOrientation-int-) | 이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)을(를) 참조하십시오. |
+| [setPosition(int value)](#setPosition-int-) | 이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)을(를) 참조하십시오. |
+| [setSmallChange(int value)](#setSmallChange-int-) | 이 속성에 대한 설명은 [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+Position 속성이 변경되는 양
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+허용되는 최대값.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+허용되는 최소값.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+SpinButton 또는 ScrollBar가 수직으로 배치되는지 수평으로 배치되는지 여부.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+값.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+Position 속성이 변경되는 양
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+이 속성에 대한 설명은 [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+이 속성에 대한 설명은 [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+이 속성에 대한 설명은 [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+이 속성에 대한 설명은 [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/selectmode/_index.md
+++ b/korean/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+type: docs
+weight: 353
+url: /ko/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/selectmode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/selectmode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+type: docs
+weight: 354
+url: /ko/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+사용자가 그룹 도형 및 해당 구성원을 선택하는 방식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | 먼저 그룹 모양을 선택합니다. |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | 그룹 모양만 선택합니다. |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | 먼저 그룹의 구성원을 선택합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+먼저 그룹 모양을 선택합니다.
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+그룹 모양만 선택합니다.
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+먼저 그룹의 구성원을 선택합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shape/_index.md
+++ b/korean/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: 도형
+second_title: Aspose.Diagram for Java API 참조
+description: 마스터 페이지 또는 그룹 도형 요소에 도형을 정의하는 요소를 포함합니다.
+type: docs
+weight: 355
+url: /ko/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+마스터, 페이지 또는 그룹 도형 요소에서 도형을 정의하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Shape()](#Shape--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [bringForward()](#bringForward--) | 도형을 Z-순서에서 한 단계 앞으로 이동합니다. |
+| [bringToFront()](#bringToFront--) | 도형을 Z-순서의 앞쪽으로 이동합니다. |
+| [centerDrawing()](#centerDrawing--) | 페이지 범위에 대해 도형을 가운데 정렬합니다. |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | 도형에 연결된 도형들의 식별자(ID)를 포함하는 배열을 반환합니다. |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | 도형에 의존하는 도형들의 식별자를 포함하는 배열을 반환합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | ActiveX 컨트롤을 가져옵니다. |
+| [getActs()](#getActs--) | Act 요소들의 컬렉션을 포함합니다. |
+| [getAlign()](#getAlign--) | 도형이 고정된 가이드 또는 가이드 포인트에 대한 도형의 정렬을 나타냅니다. |
+| [getChars()](#getChars--) | Char 요소의 컬렉션을 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 요소의 컬렉션을 포함합니다. |
+| [getConnections()](#getConnections--) | Connection 요소의 컬렉션을 포함합니다. |
+| [getConnectorRule()](#getConnectorRule--) | 도형에 연결된 도형 ID와 연결 정보를 포함하는 connectorRule을 반환합니다. |
+| [getConnectorsType()](#getConnectorsType--) | 연결자 유형을 가져옵니다. |
+| [getControlData()](#getControlData--) | 컨트롤의 데이터를 가져옵니다. |
+| [getControls()](#getControls--) | Control 요소들의 컬렉션을 포함합니다. |
+| [getData1()](#getData1--) | 도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다. |
+| [getData2()](#getData2--) | 도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다. |
+| [getData3()](#getData3--) | 도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. |
+| [getDiagram()](#getDiagram--) | Visio 개체 계층 구조의 루트 요소. |
+| [getDisplayText()](#getDisplayText--) | 인터페이스에 표시되는 텍스트를 가져옵니다. |
+| [getEvent()](#getEvent--) | 도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다. |
+| [getFields()](#getFields--) | Field 요소들의 컬렉션을 포함합니다. |
+| [getFill()](#getFill--) | 패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다. |
+| [getFillStyle()](#getFillStyle--) | 이 도형이 채우기 서식을 상속받는 StyleSheet입니다. |
+| [getForeign()](#getForeign--) | Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다. |
+| [getForeignData()](#getForeignData--) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [getGeoms()](#getGeoms--) | Geom 요소들의 컬렉션을 포함합니다. |
+| [getGroup()](#getGroup--) | 그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다. |
+| [getHelp()](#getHelp--) | Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다. |
+| [getHyperlinks()](#getHyperlinks--) | Hyperlink 요소들의 컬렉션을 포함합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getImage()](#getImage--) | 비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다. |
+| [getInheritChars()](#getInheritChars--) | 마스터 도형에 의해 상속되는 도형의 문자 값을 포함합니다. |
+| [getInheritFill()](#getInheritFill--) | 부모 스타일 및 마스터 도형에 의해 상속되는 도형의 채우기 서식 값을 포함합니다. |
+| [getInheritGeoms()](#getInheritGeoms--) | 마스터 도형에 의해 상속되는 도형의 Geoms 값을 포함합니다. |
+| [getInheritLine()](#getInheritLine--) | 부모 스타일 및 마스터 도형에 의해 상속되는 도형의 선 서식 값을 포함합니다. |
+| [getInheritParas()](#getInheritParas--) | 부모 스타일 및 마스터 도형에 의해 상속되는 도형의 단락(paras)을 포함합니다. |
+| [getInheritProps()](#getInheritProps--) | 마스터 도형에 의해 상속되는 도형의 속성(props)을 포함합니다. |
+| [getInheritTextBlock()](#getInheritTextBlock--) | 부모 스타일 및 마스터 도형에 의해 상속되는 도형의 텍스트 블록 값을 포함합니다. |
+| [getInheritUsers()](#getInheritUsers--) | 마스터 도형에 의해 상속되는 도형의 사용자(users)를 포함합니다. |
+| [getLayerMem()](#getLayerMem--) | 도형이 할당된 각 레이어를 지정하는 LayerMember 요소를 포함합니다. |
+| [getLayout()](#getLayout--) | 도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다. |
+| [getLine()](#getLine--) | 패턴, 두께 및 색상과 같은 도형의 선 속성을 제어하는 요소를 포함합니다. |
+| [getLineStyle()](#getLineStyle--) | 이 도형이 선 서식을 상속받는 StyleSheet |
+| [getMaster()](#getMaster--) | 도형이 데이터를 상속받는 마스터 |
+| [getMasterShape()](#getMasterShape--) | 이 속성은 그룹 도형의 구성원이며 해당 그룹이 마스터의 인스턴스인 도형에만 존재할 수 있습니다. |
+| [getMisc()](#getMisc--) | Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getOneD()](#getOneD--) | 도형이 1차원(1-D) 객체로 동작하는지 여부를 결정합니다. |
+| [getPage()](#getPage--) | Visio 개체 계층 구조의 루트 요소. |
+| [getParas()](#getParas--) | Para 요소의 컬렉션을 포함합니다. |
+| [getParentShape()](#getParentShape--) | 도형의 부모. |
+| [getProps()](#getProps--) | Prop 요소들의 컬렉션을 포함합니다. |
+| [getProtection()](#getProtection--) | 잠금은 도형에 대한 실수로 인한 변경을 방지하는 데 도움이 되지만 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. |
+| [getPureText()](#getPureText--) | 텍스트 문자열을 가져옵니다 |
+| [getRootShape()](#getRootShape--) | 이 도형이 마스터 인스턴스의 일부인 경우 인스턴스의 최상위 도형을 반환합니다. |
+| [getScratchs()](#getScratchs--) | Scratch 요소의 컬렉션을 포함합니다. |
+| [getShapes()](#getShapes--) | Shape 요소들의 컬렉션을 포함합니다. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | SmartTagDef 요소들의 컬렉션을 포함합니다. |
+| [getTabsCollection()](#getTabsCollection--) | Tab 요소의 컬렉션을 포함합니다. |
+| [getText()](#getText--) | 도형의 텍스트를 포함합니다. |
+| [getTextBlock()](#getTextBlock--) | 도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다. |
+| [getTextStyle()](#getTextStyle--) | 이 도형이 텍스트 서식을 상속받는 StyleSheet. |
+| [getTextXForm()](#getTextXForm--) | 도형 텍스트 블록에 대한 위치 정보를 지정하는 요소를 포함합니다. |
+| [getThreeDFormat()](#getThreeDFormat--) | ThreeDFormat을 가져옵니다. |
+| [getTwoD()](#getTwoD--) | 도형이 2차원(2-D) 객체로 동작하는지 여부를 결정합니다. |
+| [getType()](#getType--) | 도형의 유형. |
+| [getUniqueID()](#getUniqueID--) | 도형에 할당된 GUID(전역 고유 식별자). |
+| [getUsers()](#getUsers--) | User 요소의 컬렉션을 포함합니다. |
+| [getXForm()](#getXForm--) | 도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다. |
+| [getXForm1D()](#getXForm1D--) | 1차원 도형의 시작점과 끝점의 x 및 y 좌표를 포함합니다. |
+| [getZOrderIndex()](#getZOrderIndex--) | 가이드 도형을 제외한 z-순서에서 도형의 인덱스를 반환합니다. |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | 도형에 붙어 있는 도형들의 식별자를 포함하는 배열을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | 이 두 도형이 연결되어 있는지 여부를 나타냅니다. |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | 이 도형이 다른 도형을 포함하고 있는지 여부를 나타냅니다. |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | 이 두 도형이 접착되어 있는지 여부를 나타냅니다. |
+| [isInGroup()](#isInGroup--) | 이 도형이 그룹 도형에 포함되어 있는지 여부를 나타냅니다. |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | 이 도형이 다른 도형과 교차하는지 여부를 나타냅니다. |
+| [isTextEmpty()](#isTextEmpty--) | 도형에 텍스트가 있는지 및 텍스트가 비어 있는지 여부를 나타냅니다. |
+| [move(double dX, double dY)](#move-double-double-) | 도형을 현재 위치에서 dX 및 dY 인치만큼 이동합니다. |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | 도형을 페이지의 새로운 절대 위치로 이동합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | 도형의 텍스트 또는 기타 속성을 변경할 때 xform, 연결 및 geom을 포함한 도형 위치를 새로 고칩니다. |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | 도형의 텍스트 문자열을 교체합니다. |
+| [sendBackward()](#sendBackward--) | 도형을 Z 순서에서 한 단계 뒤로 이동합니다. |
+| [sendToBack()](#sendToBack--) | 도형을 Z 순서의 뒤쪽으로 이동합니다. |
+| [setAngle(double angle)](#setAngle-double-) | 도형의 새로운 각도를 설정합니다. |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | 이 속성에 대한 설명은 [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)을 참조하십시오. |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | 연결자 유형을 설정합니다. |
+| [setData1(String value)](#setData1-java.lang.String-) | 이 속성에 대한 설명은 [getData1()](../../com.aspose.diagram/shape\#getData1--)을 참조하십시오. |
+| [setData2(String value)](#setData2-java.lang.String-) | 이 속성에 대한 설명은 [getData2()](../../com.aspose.diagram/shape\#getData2--)을 참조하십시오. |
+| [setData3(String value)](#setData3-java.lang.String-) | 이 속성에 대한 설명은 [getData3()](../../com.aspose.diagram/shape\#getData3--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/shape\#getDel--)을 참조하십시오. |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | 이 속성에 대한 설명은 [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)을 참조하십시오. |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | 이 속성에 대한 설명은 [getEvent()](../../com.aspose.diagram/shape\#getEvent--)을 참조하십시오. |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)을 참조하십시오. |
+| [setHeight(double height)](#setHeight-double-) | 도형의 새로운 높이를 설정합니다. |
+| [setID(long value)](#setID-long-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/shape\#getID--)을 참조하십시오. |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)을 참조하십시오. |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | 이 속성에 대한 설명은 [getMaster()](../../com.aspose.diagram/shape\#getMaster--)을 참조하십시오. |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | 이 속성에 대한 설명은 [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)을 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/shape\#getName--)을 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/shape\#getNameU--)을 참조하십시오. |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | 이 속성에 대한 설명은 [getPage()](../../com.aspose.diagram/shape\#getPage--)를 참조하십시오. |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | 이 속성에 대한 설명은 [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)를 참조하십시오. |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | 이 도형에 사전 설정 테마를 적용합니다. |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | 이 도형에 사전 설정 테마 변형 퀵스타일을 적용합니다. |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | 이 도형에 사전 설정 테마 변형 퀵스타일을 적용합니다. 도형 스타일 드롭다운 목록의 테마 스타일 옵션과 같습니다. |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | 이 도형에 사전 설정 테마 변형을 적용합니다. |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | 이 속성에 대한 설명은 [getProps()](../../com.aspose.diagram/shape\#getProps--)를 참조하십시오. |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | 이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/shape\#getText--)를 참조하십시오. |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)를 참조하십시오. |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | 이 속성에 대한 설명은 [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)를 참조하십시오. |
+| [setType(int value)](#setType-int-) | 이 속성에 대한 설명은 [getType()](../../com.aspose.diagram/shape\#getType--)를 참조하십시오. |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | 이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)를 참조하십시오. |
+| [setWidth(double width)](#setWidth-double-) | 도형의 새 너비를 설정합니다. |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | 이 속성에 대한 설명은 [getXForm()](../../com.aspose.diagram/shape\#getXForm--)를 참조하십시오. |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | 이 속성에 대한 설명은 [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)를 참조하십시오. |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | 도형 HTML을 생성하고 지정된 형식으로 스트림에 저장합니다. |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | 도형 HTML을 생성하고 지정된 형식으로 스트림에 저장합니다. |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | HTML을 생성하고 파일에 저장합니다. |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | 도형 이미지를 생성하고 지정된 형식으로 스트림에 저장합니다. |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | 도형 이미지를 생성하고 지정된 형식으로 스트림에 저장합니다. |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | 도형 이미지를 생성하고 파일에 저장합니다. |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | 도형 PDF를 생성하고 스트림에 저장합니다. |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | 도형 PDF를 생성하고 스트림에 저장합니다. |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | 도형을 PDF 파일로 저장합니다. |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | 도형을 SVG 파일로 저장합니다. |
+| [ungroup()](#ungroup--) | 도형 그룹 해제 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+생성자.
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+도형을 Z-순서에서 한 단계 앞으로 이동합니다.
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+도형을 Z-순서의 앞쪽으로 이동합니다.
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+페이지 범위에 대해 도형을 가운데 정렬합니다.
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+도형에 연결된 도형들의 식별자(ID)를 포함하는 배열을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 플래그 | int | 연결기의 방향성에 따라 반환된 shape ID 배열을 필터링합니다. 가능한 값은 Remarks를 참조하십시오Aspose.Diagram.ConnectedShapesFlags. |
+| categoryFilter | java.lang.String | 지정된 categoryString과 일치하는 도형의 ID만 포함하도록 반환된 도형 ID 배열을 필터링합니다. |
+
+**Returns:**
+long[] - ID 배열 long.
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+도형에 의존하는 도형들의 식별자를 포함하는 배열을 반환합니다.
+
+**Returns:**
+long[] - ID 배열 long.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+ActiveX 컨트롤을 가져옵니다.
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Act 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+도형이 붙어 있는 가이드 또는 가이드 포인트에 대한 도형의 정렬을 나타냅니다. Align 요소는 가이드 또는 가이드 포인트에 붙어 있는 도형에만 표시됩니다.
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Char 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+도형에 연결된 도형 ID와 연결 정보를 포함하는 connectorRule을 반환합니다.
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+연결자 유형을 가져옵니다.
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+컨트롤의 데이터를 가져옵니다.
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Control 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+도형에 대한 추가 정보를 제공하는 임의의 문자열 값을 포함합니다.
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값이 1이면 요소가 로컬에서 삭제된 것입니다.
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Visio 개체 계층 구조의 루트 요소.
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+인터페이스에 표시되는 텍스트를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Field 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+이 도형이 채우기 서식을 상속받는 StyleSheet입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체의 너비와 높이를 지정하는 요소를 포함합니다. 또한 객체 이미지가 경계 내에서 오프셋되는 거리를 지정하는 요소도 포함합니다.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Geom 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Hyperlink 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+마스터 도형에 의해 상속되는 도형의 문자 값을 포함합니다.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+부모 스타일 및 마스터 도형에 의해 상속되는 도형의 채우기 서식 값을 포함합니다.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+마스터 도형에 의해 상속되는 도형의 Geoms 값을 포함합니다.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+부모 스타일 및 마스터 도형에 의해 상속되는 도형의 선 서식 값을 포함합니다.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+부모 스타일 및 마스터 도형에 의해 상속되는 도형의 단락(paras)을 포함합니다.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+마스터 도형에 의해 상속되는 도형의 속성(props)을 포함합니다.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+부모 스타일 및 마스터 도형에 의해 상속되는 도형의 텍스트 블록 값을 포함합니다.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+마스터 도형에 의해 상속되는 도형의 사용자(users)를 포함합니다.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+도형이 할당된 각 레이어를 지정하는 LayerMember 요소를 포함합니다.
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+모양의 선 속성을 제어하는 요소들을 포함합니다. 예를 들어 패턴, 두께, 색상 등이 있습니다. 이러한 요소들은 선 끝이 형식화되는지 여부(예: 화살표 머리), 선 끝 형식의 크기, 선에 적용되는 둥근 원의 반경, 그리고 선 캡 스타일(둥근 또는 사각)을 결정합니다.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+이 도형이 선 서식을 상속받는 StyleSheet
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+도형이 데이터를 상속받는 마스터
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+이 속성은 그룹 도형의 구성원이며 해당 그룹이 마스터의 인스턴스인 도형에만 존재할 수 있습니다. 이 속성은 마스터에서 해당 하위 도형을 참조하는 ID를 포함합니다.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+도형이 1차원(1-D) 객체로 동작하는지 여부를 결정합니다. 읽기 전용.
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Visio 개체 계층 구조의 루트 요소.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Para 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+도형의 부모.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Prop 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+잠금은 모양에 대한 의도치 않은 변경을 방지하는 데 도움이 되지만, 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. 또한 ShapeSheet 창에서 이루어지는 변경으로부터 보호하지도 않습니다.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+텍스트 문자열을 가져옵니다
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+이 도형이 마스터 인스턴스의 일부인 경우 인스턴스의 최상위 도형을 반환합니다. 읽기 전용.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Scratch 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Shape 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+SmartTagDef 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Tab 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+도형의 텍스트를 포함합니다.
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+이 도형이 텍스트 서식을 상속받는 StyleSheet.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+도형 텍스트 블록에 대한 위치 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+ThreeDFormat을 가져옵니다.
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+도형이 2차원(2-D) 객체로 동작하는지 여부를 결정합니다.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+도형의 유형입니다. 다음 값 중 하나일 수 있습니다: Group, Shape, Guide, 또는 Foreign.
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+도형에 할당된 GUID(전역 고유 식별자).
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+User 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+도형에 대한 일반적인 위치 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+1-D 도형의 시작점과 끝점의 x 및 y 좌표를 포함합니다. 이 요소는 1-D 도형에만 나타납니다.
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+가이드 도형을 제외한 z-순서에서 도형의 인덱스를 반환합니다.
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+도형에 붙어 있는 도형들의 식별자를 포함하는 배열을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 플래그 | int | 반환할 도형의 연결 지점의 차원 및 방향성입니다. 가능한 값은 Remarks를 참조하십시오 Aspose.Diagram.GluedShapesFlags. |
+| categoryFilter | java.lang.String | 지정된 categoryString과 일치하는 도형의 ID만 포함하도록 반환된 도형 ID 배열을 필터링합니다. |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | 옵션: 반환된 도형이 추가로 붙어 있어야 하는 추가 도형이며, [Shape](../../com.aspose.diagram/shape) 또는 null일 수 있습니다. |
+
+**Returns:**
+long[] - ID 배열 long.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+이 두 도형이 연결되어 있는지 여부를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+이 도형이 다른 도형을 포함하고 있는지 여부를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+이 두 도형이 접착되어 있는지 여부를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+이 도형이 그룹 도형에 포함되어 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+이 도형이 다른 도형과 교차하는지 여부를 나타냅니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+도형에 텍스트가 있는지 및 텍스트가 비어 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+도형을 현재 위치에서 dX 및 dY 인치만큼 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dX | double | X 오프셋 double. |
+| dY | double | Y 오프셋 double. |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+도형을 페이지의 새로운 절대 위치로 이동합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| newPinX | double | 부모의 원점에 대한 도형 핀(회전 중심)의 새로운 x 좌표입니다. double. |
+| newPinY | double | 부모의 원점에 대한 도형 핀(회전 중심)의 새로운 y 좌표입니다. double. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+도형의 텍스트 또는 기타 속성을 변경할 때 xform, connection 및 geom을 포함한 도형 위치를 새로 고칩니다. 도형 텍스트와 같은 도형 데이터를 수집한 후 도형 위치를 계산합니다. 이 메서드는 도형 데이터를 새로 고치는 데만 사용됩니다.
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+도형의 텍스트 문자열을 교체합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+도형을 Z 순서에서 한 단계 뒤로 이동합니다.
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+도형을 Z 순서의 뒤쪽으로 이동합니다.
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+도형의 새로운 각도를 설정합니다. 각도의 단위는 라디안입니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| angle | double | 새로운 각도(단위는 라디안이며 degree가 아님) double. |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+이 속성에 대한 설명은 [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+연결자 유형을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 유형 | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+이 속성에 대한 설명은 [getData1()](../../com.aspose.diagram/shape\#getData1--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+이 속성에 대한 설명은 [getData2()](../../com.aspose.diagram/shape\#getData2--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+이 속성에 대한 설명은 [getData3()](../../com.aspose.diagram/shape\#getData3--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/shape\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+이 속성에 대한 설명은 [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+이 속성에 대한 설명은 [getEvent()](../../com.aspose.diagram/shape\#getEvent--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+도형의 새로운 높이를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| height | double | New heightdouble. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/shape\#getID--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+이 속성에 대한 설명은 [getMaster()](../../com.aspose.diagram/shape\#getMaster--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+이 속성에 대한 설명은 [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/shape\#getName--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/shape\#getNameU--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+이 속성에 대한 설명은 [getPage()](../../com.aspose.diagram/shape\#getPage--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+이 속성에 대한 설명은 [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+이 도형에 사전 설정 테마를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+이 도형에 사전 설정 테마 변형 퀵스타일을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+이 도형에 사전 설정 테마 변형 퀵스타일을 적용합니다. 도형 스타일 드롭다운 목록의 테마 스타일 옵션과 같습니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| styleIndex | int | the row of style matrics |
+| colorIndex | int | the column of style matrics |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+이 도형에 사전 설정 테마 변형을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+이 속성에 대한 설명은 [getProps()](../../com.aspose.diagram/shape\#getProps--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/shape\#getText--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+이 속성에 대한 설명은 [getType()](../../com.aspose.diagram/shape\#getType--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+이 속성에 대한 설명은 [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+도형의 새 너비를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| width | double | New widthdouble. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+이 속성에 대한 설명은 [getXForm()](../../com.aspose.diagram/shape\#getXForm--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+이 속성에 대한 설명은 [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+도형 HTML을 생성하고 지정된 형식으로 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+도형 HTML을 생성하고 지정된 형식으로 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+HTML을 생성하고 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | html save options |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+도형 이미지를 생성하고 지정된 형식으로 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+도형 이미지를 생성하고 지정된 형식으로 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Creates the shape image and saves it to a file. The extension of the file name determines the format of the image.
+
+The format of the image is specified by using the extension of the file name. For example, if you specify "myfile.png", then the image will be saved in the PNG format. The following file extensions are recognized: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| imageFile | java.lang.String | The image file name with full path. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+도형 PDF를 생성하고 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | The output stream. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+도형 PDF를 생성하고 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | The output stream. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+도형을 PDF 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| fileName | java.lang.String | the pdf file name with full path |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+도형을 SVG 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+도형 그룹 해제
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapecollection/_index.md
+++ b/korean/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 컬렉션.
+type: docs
+weight: 356
+url: /ko/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+도형 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | Add the shape in the collection. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getShape(String name)](#getShape-java.lang.String-) | Gets the element at the specified name. |
+| [getShape(long ID)](#getShape-long-) | Gets the element at the specified ID. |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | Gets the element including it's child shape at the specified id. |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | Gets the element including it's child shape at the specified name. |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | Group the shapes. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | 컬렉션에서 도형을 제거합니다. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | 컬렉션에서 DEPENDSON 도형을 포함한 도형들을 제거합니다. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | 도형의 그룹을 해제합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+Add the shape in the collection.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+Gets the element at the specified name.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+Gets the element including it's child shape at the specified id.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+Gets the element including it's child shape at the specified name.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+도형들을 그룹화합니다. groupItems에 있는 도형은 그룹화되지 않아야 합니다. 도형은 이 Shapes 컬렉션에 있어야 합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | 그 그룹 항목들. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+컬렉션에서 도형을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | 도형 |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+컬렉션에서 DEPENDSON 도형을 포함한 도형들을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | 도형 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+도형의 그룹을 해제합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | 그 그룹 도형. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/korean/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Aspose.Diagram for Java API 참조
+description: 배치 가능한 도형에 대한 배치 동작을 지정합니다.
+type: docs
+weight: 357
+url: /ko/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+배치 가능한 도형에 대한 배치 동작을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 배치 가능한 도형에 대한 배치 동작을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+배치 가능한 도형에 대한 배치 동작을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 배치 가능한 도형에 대한 배치 동작을 지정합니다.
+type: docs
+weight: 358
+url: /ko/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+배치 가능한 도형에 대한 배치 동작을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | 연결 지점이 있는 면으로만 라우팅을 허용합니다. |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | 라우팅될 때 연결 지점 위치를 무시합니다. |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | 이 도형의 둘레에 붙이지 마세요. |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | 이 도형은 이동하지 않지만 다른 배치 가능한 도형을 그 위에 배치하도록 허용합니다. |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | 이 도형을 이동하지 않으며 다른 배치 가능한 도형을 그 위에 배치하지 못하도록 합니다. |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | Microsoft Visio에서 '도형 배치' 명령을 사용할 때 이 도형을 이동하지 마세요. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+연결 지점이 있는 면으로만 라우팅을 허용합니다.
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+라우팅될 때 연결 지점 위치를 무시합니다.
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+이 도형의 둘레에 붙이지 마세요. 대신 도형의 정렬 상자에 붙입니다.
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+이 도형은 이동하지 않지만 다른 배치 가능한 도형을 그 위에 배치하도록 허용합니다.
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+이 도형을 이동하지 않으며 다른 배치 가능한 도형을 그 위에 배치하지 못하도록 합니다.
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+Microsoft Visio에서 '도형 배치' 명령을 사용할 때 이 도형을 이동하지 마세요.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 Lay Out Shapes Shapes 메뉴를 선택할 때 페이지에서 배치 가능한 도형이 어떻게 뒤집히거나 회전하는지를 지정합니다.
+type: docs
+weight: 359
+url: /ko/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자가 Lay Out Shapes Shapes 메뉴를 선택할 때 페이지에서 배치 가능한 도형이 어떻게 뒤집히거나 회전하는지를 지정합니다.
+type: docs
+weight: 360
+url: /ko/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+사용자가 레이아웃 도형(도형 메뉴)을 선택할 때 배치 가능한 도형이 페이지에서 뒤집히거나 회전하는 방식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | 0에서 270도 사이를 90도 단위로 뒤집습니다. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | 수평 뒤집기. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | 수직 뒤집기. |
+| [NO_FLIP](#NO-FLIP) | 뒤집지 않음. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음 |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | 페이지 기본값을 사용합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+0에서 270도 사이를 90도 단위로 뒤집습니다.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+수평 뒤집기.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+수직 뒤집기.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+뒤집지 않음.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+페이지 기본값을 사용합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 자식 요소에 대한 배치 스타일을 결정합니다.
+type: docs
+weight: 361
+url: /ko/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+자식 요소에 대한 배치 스타일을 결정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 커넥터의 외관을 결정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+커넥터의 외관을 결정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 자식 요소에 대한 배치 스타일을 결정합니다.
+type: docs
+weight: 362
+url: /ko/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+자식 요소에 대한 배치 스타일을 결정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | 아래에서 위로 배치합니다. |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | 원형으로 배치합니다. |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | 왼쪽 아래로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | 오른쪽 아래로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | 왼쪽 아래로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | 왼쪽 위로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | 오른쪽 아래로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | 오른쪽 위로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | 위쪽 왼쪽으로 컴팩트 배치합니다. |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | 위쪽 오른쪽으로 컴팩트 배치합니다. |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | 기본값으로 배치합니다. |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | 계층을 아래에서 가운데로 배치합니다. |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | 계층을 아래에서 왼쪽으로 배치합니다. |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | 계층을 아래에서 오른쪽으로 배치합니다. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | 계층을 왼쪽에서 오른쪽 아래로 배치합니다. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | 계층을 왼쪽에서 가운데 오른쪽으로 배치합니다. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | 계층을 왼쪽에서 오른쪽 위로 배치합니다. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | 계층을 오른쪽에서 왼쪽 아래로 배치합니다. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | 계층을 오른쪽에서 왼쪽 위로 배치합니다. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | 계층을 오른쪽에서 왼쪽 위로 배치합니다. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | 계층을 위에서 아래 가운데로 배치합니다. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | 계층을 위에서 아래 왼쪽으로 배치합니다. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | 계층을 위에서 아래 오른쪽으로 배치합니다. |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | 부모를 기본값으로 배치합니다. |
+| [PLACE_RADIAL](#PLACE-RADIAL) | 방사형으로 배치합니다. |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | 오른쪽에서 왼쪽으로 배치합니다. |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | 위에서 아래로 배치합니다. |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | 오른쪽으로 배치합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+아래에서 위로 배치합니다.
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+원형으로 배치합니다.
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+왼쪽 아래로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+오른쪽 아래로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+왼쪽 아래로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+왼쪽 위로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+오른쪽 아래로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+오른쪽 위로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+위쪽 왼쪽으로 컴팩트 배치합니다.
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+위쪽 오른쪽으로 컴팩트 배치합니다.
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+기본값으로 배치합니다.
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+계층을 아래에서 가운데로 배치합니다.
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+계층을 아래에서 왼쪽으로 배치합니다.
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+계층을 아래에서 오른쪽으로 배치합니다.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+계층을 왼쪽에서 오른쪽 아래로 배치합니다.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+계층을 왼쪽에서 가운데 오른쪽으로 배치합니다.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+계층을 왼쪽에서 오른쪽 위로 배치합니다.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+계층을 오른쪽에서 왼쪽 아래로 배치합니다.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+계층을 오른쪽에서 왼쪽 위로 배치합니다.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+계층을 오른쪽에서 왼쪽 위로 배치합니다.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+계층을 위에서 아래 가운데로 배치합니다.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+계층을 위에서 아래 왼쪽으로 배치합니다.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+계층을 위에서 아래 오른쪽으로 배치합니다.
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+부모를 기본값으로 배치합니다.
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+방사형으로 배치합니다.
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+오른쪽에서 왼쪽으로 배치합니다.
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+위에서 아래로 배치합니다.
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+오른쪽으로 배치합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+type: docs
+weight: 363
+url: /ko/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+type: docs
+weight: 364
+url: /ko/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+그리기 페이지에서 다른 배치 가능한 도형을 해당 도형 근처로 드래그할 때 배치 가능한 도형이 멀어지는지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | 도형을 이동합니다. |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | 도형을 이동하지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | 페이지 기본값을 사용합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+도형을 이동합니다.
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+도형을 이동하지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+페이지 기본값을 사용합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/korean/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+type: docs
+weight: 365
+url: /ko/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: 그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+type: docs
+weight: 366
+url: /ko/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+그리기 페이지에서 커넥터의 라우팅 스타일 및 방향을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | 중심에서 중심으로. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | 플로우차트. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | 플로우차트. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | 플로우차트. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | 플로우차트. |
+| [NETWORK](#NETWORK) | 네트워크 |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | 조직도. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | 조직도. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | 조직도. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | 조직도. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | 페이지 기본값. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | 직각. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | 단순. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | 단순 수평-수직. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | 단순. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | 단순. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | 단순. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | 단순 수직-수평. |
+| [STRAIGHT](#STRAIGHT) | 직선. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | 트리. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | 트리. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | 트리. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | 트리. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+중심에서 중심으로.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+플로우차트. 아래에서 위로.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+플로우차트. 왼쪽에서 오른쪽으로.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+플로우차트. 오른쪽에서 왼쪽으로.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+플로우차트. 위에서 아래로.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+네트워크
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+조직도. 아래에서 위로.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+조직도. 왼쪽에서 오른쪽으로.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+조직도. 오른쪽에서 왼쪽으로.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+조직도. 방향 위에서 아래로.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+페이지 기본값.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+직각.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+단순. 아래에서 위로.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+단순 수평-수직.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+간단합니다. 왼쪽에서 오른쪽으로.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+간단합니다. 오른쪽에서 왼쪽으로.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+간단합니다. 위에서 아래로.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+단순 수직-수평.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+직선.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+트리. 아래에서 위로.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+트리. 왼쪽에서 오른쪽으로
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+트리. 오른쪽에서 왼쪽으로.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+트리. 위에서 아래로.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/korean/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 367
+url: /ko/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형의 그림자 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형의 그림자 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 368
+url: /ko/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+도형의 그림자 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | 그림자 효과 세트가 항상 표시되도록 지정합니다. |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | 그림자 효과 세트는 도형에 Geometry Section\_Type이 있는 경우에만 표시되도록 지정합니다. |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | 그림자 효과 세트는 도형에 Geometry Section\_Type이 있고 해당 도형이 최상위 도형인 경우에만 표시되도록 지정합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+그림자 효과 세트가 항상 표시되도록 지정합니다.
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+그림자 효과 세트는 도형에 Geometry Section\_Type이 있는 경우에만 표시되도록 지정합니다.
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+그림자 효과 세트는 도형에 Geometry Section\_Type이 있고 해당 도형이 최상위 도형인 경우에만 표시되도록 지정합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/korean/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 369
+url: /ko/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+도형의 그림자 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형의 그림자 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형의 그림자 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 그림자 유형을 지정합니다.
+type: docs
+weight: 370
+url: /ko/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+도형의 그림자 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [INNER](#INNER) | 내부 |
+| [OBLIQUE](#OBLIQUE) | 경사. |
+| [SIMPLE](#SIMPLE) | 단순. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [USE_PAGE](#USE-PAGE) | 페이지 기본값 사용(기본값). |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+내부
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+경사.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+단순.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+페이지 기본값 사용(기본값).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shdwtype/_index.md
+++ b/korean/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 대한 기본 그림자 유형을 나타냅니다.
+type: docs
+weight: 371
+url: /ko/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+페이지에 대한 기본 그림자 유형을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 페이지에 대한 기본 그림자 유형을 나타냅니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+페이지에 대한 기본 그림자 유형을 나타냅니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지에 대한 기본 그림자 유형을 나타냅니다.
+type: docs
+weight: 372
+url: /ko/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+페이지에 대한 기본 그림자 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | 경사. |
+| [SIMPLE](#SIMPLE) | 단순. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+경사.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+단순.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/korean/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShowDropButtonType
+second_title: Aspose.Diagram for Java API 참조
+description: 드롭 버튼을 표시할 시점을 지정합니다.
+type: docs
+weight: 373
+url: /ko/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+드롭 버튼을 표시할 시점을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | 드롭 버튼을 항상 표시합니다. |
+| [FOCUS](#FOCUS) | 컨트롤에 포커스가 있을 때 드롭 버튼을 표시합니다. |
+| [NEVER](#NEVER) | 드롭 버튼을 표시하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+드롭 버튼을 항상 표시합니다.
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+컨트롤에 포커스가 있을 때 드롭 버튼을 표시합니다.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+드롭 버튼을 표시하지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/korean/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 또는 페이지에 정의된 각 스마트 태그에 대한 정보를 포함하는 요소를 포함합니다.
+type: docs
+weight: 374
+url: /ko/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+도형 또는 페이지에 정의된 각 스마트 태그에 대한 정보를 포함하는 요소를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | 스마트 태그 버튼에 표시되는 버튼 얼굴 이미지의 ID를 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getDescription()](#getDescription--) | Description 요소는 사용자가 태그 위에 마우스를 올려 놓을 때 툴팁으로 표시되는 스마트 태그를 설명하는 문자열을 포함합니다. |
+| [getDisabled()](#getDisabled--) | Disabled 요소는 스마트 태그가 그리기 창에 표시되는지 여부를 결정합니다. |
+| [getDisplayMode()](#getDisplayMode--) | DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getTagName()](#getTagName--) | 스마트 태그를 해당 작업과 연결하는 키로 사용되는 스마트 태그의 이름을 포함합니다. |
+| [getX()](#getX--) | 스마트 태그 버튼이 배치되는 도형 로컬 좌표계의 x좌표 위치. |
+| [getXJustify()](#getXJustify--) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다. |
+| [getY()](#getY--) | 스마트 태그 버튼이 배치되는 도형 로컬 좌표계의 y좌표 위치. |
+| [getYJustify()](#getYJustify--) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/smarttagdef\#getID--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/smarttagdef\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+스마트 태그 버튼에 표시되는 버튼 얼굴 이미지의 ID를 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Description 요소는 사용자가 태그 위에 마우스를 올려 놓을 때 툴팁으로 표시되는 스마트 태그를 설명하는 문자열을 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Disabled 요소는 스마트 태그가 그리기 창에 표시되는지 여부를 결정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+DisplayMode 요소는 사용자가 태그 위에 마우스를 올려 놓았을 때, 도형이 선택되었을 때, 혹은 항상 스마트 태그가 표시되는지를 결정합니다.
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+스마트 태그를 해당 작업과 연결하는 키로 사용되는 스마트 태그의 이름을 포함합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+스마트 태그 버튼이 배치되는 도형 로컬 좌표계의 x좌표 위치.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+스마트 태그 버튼이 배치되는 도형 로컬 좌표계의 y좌표 위치.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/smarttagdef\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/smarttagdef\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/korean/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Aspose.Diagram for Java API 참조
+description: SmartTagDef 컬렉션.
+type: docs
+weight: 375
+url: /ko/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+SmartTagDef 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | 컬렉션에 SmartTagDef 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | 컬렉션에서 SmartTagDef 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+컬렉션에 SmartTagDef 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+컬렉션에서 SmartTagDef 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/korean/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Aspose.Diagram for Java API 참조
+description: 선과 곡선 및 채워진 영역의 가장자리에 스무딩 안티앨리어싱이 적용되는지 여부를 지정합니다.
+type: docs
+weight: 376
+url: /ko/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+선과 곡선 및 채워진 영역의 가장자리에 스무딩(안티앨리어싱)이 적용되는지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | 안티앨리어싱 렌더링을 지정합니다. |
+| [DEFAULT](#DEFAULT) | 안티앨리어싱을 지정하지 않습니다. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 안티앨리어싱 렌더링을 지정합니다. |
+| [HIGH_SPEED](#HIGH-SPEED) | 안티앨리어싱을 지정하지 않습니다. |
+| [INVALID](#INVALID) | 잘못된 모드를 지정합니다. |
+| [NONE](#NONE) | 안티앨리어싱을 지정하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+안티앨리어싱 렌더링을 지정합니다.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+안티앨리어싱을 지정하지 않습니다.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+안티앨리어싱 렌더링을 지정합니다.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+안티앨리어싱을 지정하지 않습니다.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+잘못된 모드를 지정합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+안티앨리어싱을 지정하지 않습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/snapextensions/_index.md
+++ b/korean/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Aspose.Diagram for Java API 참조
+description: 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다.
+type: docs
+weight: 377
+url: /ko/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다. 값은 여러 값의 합일 수 있습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | 정렬 상자에 스냅 확장. |
+| [CENTER_AXES](#CENTER-AXES) | 중심 축에 스냅 확장. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | 곡선에 스냅 확장. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | 곡선 접선에 스냅 확장. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | 타원 중심에 스냅 확장. |
+| [ENDPOINT](#ENDPOINT) | 끝점에 스냅 확장. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | 끝점 수평에 스냅 확장. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | 끝점에 수직 스냅 확장. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | 끝점에 수직 스냅 확장. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | 등각 각도에 스냅 확장. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | 선형에 스냅 확장. |
+| [MIDPOINT](#MIDPOINT) | 중간점에 스냅 확장. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | 중간점에 수직 스냅 확장. |
+| [NONE](#NONE) | 아무것에도 스냅하지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+정렬 상자에 스냅 확장.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+중심 축에 스냅 확장.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+곡선에 스냅 확장.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+곡선 접선에 스냅 확장.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+타원 중심에 스냅 확장.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+끝점에 스냅 확장.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+끝점 수평에 스냅 확장.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+끝점에 수직 스냅 확장.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+끝점에 수직 스냅 확장.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+등각 각도에 스냅 확장.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+선형에 스냅 확장.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+중간점에 스냅 확장.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+중간점에 수직 스냅 확장.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+아무것에도 스냅하지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Aspose.Diagram for Java API 참조
+description: 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다.
+type: docs
+weight: 378
+url: /ko/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+특정 스냅 확장 설정이 활성 창에 대해 활성화되었는지 비활성화되었는지를 지정합니다. 값은 다음 표에 있는 값들의 합이 될 수 있습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | 정렬 상자에 스냅 확장. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | 중심 축에 스냅 확장. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | 곡선에 스냅 확장. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | 곡선 접선에 스냅 확장. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | 타원 중심에 스냅 확장. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | 끝점에 스냅 확장. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | 끝점 수평에 스냅 확장. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | 끝점에 수직 스냅 확장. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | 끝점에 수직 스냅 확장. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | 등각 각도에 스냅 확장. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | 선형에 스냅 확장. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | 중간점에 스냅 확장. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | 중간점에 수직 스냅 확장. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | 아무것에도 스냅하지 않습니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+정렬 상자에 스냅 확장.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+중심 축에 스냅 확장.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+곡선에 스냅 확장.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+곡선 접선에 스냅 확장.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+타원 중심에 스냅 확장.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+끝점에 스냅 확장.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+끝점 수평에 스냅 확장.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+끝점에 수직 스냅 확장.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+끝점에 수직 스냅 확장.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+등각 각도에 스냅 확장.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+선형에 스냅 확장.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+중간점에 스냅 확장.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+중간점에 수직 스냅 확장.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+아무것에도 스냅하지 않습니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/snapsettings/_index.md
+++ b/korean/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Aspose.Diagram for Java API 참조
+description: 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다.
+type: docs
+weight: 379
+url: /ko/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | 정렬 상자에 스냅합니다. |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | 연결 지점에 스냅합니다. |
+| [DISABLED](#DISABLED) | 스냅이 비활성화되었습니다. |
+| [EXTENSIONS](#EXTENSIONS) | 도형 확장 옵션에 스냅합니다. |
+| [GEOMETRY](#GEOMETRY) | 도형의 보이는 가장자리에 스냅합니다. |
+| [GRID](#GRID) | 그리드에 스냅합니다. |
+| [GUIDES](#GUIDES) | 가이드에 스냅합니다. |
+| [HANDLES](#HANDLES) | 선택 핸들에 스냅합니다. |
+| [INTERSECTIONS](#INTERSECTIONS) | 교차점에 스냅합니다. |
+| [NONE](#NONE) | 아무것에도 스냅하지 않습니다. |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | 눈금자 세분화에 스냅합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VERTICES](#VERTICES) | 정점에 스냅합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+정렬 상자에 스냅합니다.
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+연결 지점에 스냅합니다.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+스냅이 비활성화되었습니다.
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+도형 확장 옵션에 스냅합니다.
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+도형의 보이는 가장자리에 스냅합니다.
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+그리드에 스냅합니다.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+가이드에 스냅합니다.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+선택 핸들에 스냅합니다.
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+교차점에 스냅합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+아무것에도 스냅하지 않습니다.
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+눈금자 세분화에 스냅합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+정점에 스냅합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Aspose.Diagram for Java API 참조
+description: 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다.
+type: docs
+weight: 380
+url: /ko/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | 스냅이 비활성화되었습니다. |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | 정렬 상자에 스냅합니다. |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | 연결 지점에 스냅합니다. |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | 그리드에 스냅합니다. |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | 가이드에 스냅합니다. |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | 교차점에 스냅합니다. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | 아무것에도 스냅하지 않습니다. |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | 눈금자 세분화에 스냅합니다. |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | 선택 핸들에 스냅합니다. |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | 도형 확장 옵션에 스냅합니다. |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | 도형의 보이는 가장자리에 스냅합니다. |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | 정점에 스냅합니다. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+스냅이 비활성화되었습니다.
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+정렬 상자에 스냅합니다.
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+연결 지점에 스냅합니다.
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+그리드에 스냅합니다.
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+가이드에 스냅합니다.
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+교차점에 스냅합니다.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+아무것에도 스냅하지 않습니다.
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+눈금자 세분화에 스냅합니다.
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+선택 핸들에 스냅합니다.
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+도형 확장 옵션에 스냅합니다.
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+도형의 보이는 가장자리에 스냅합니다.
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+정점에 스냅합니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/solutionxml/_index.md
+++ b/korean/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Aspose.Diagram for Java API 참조
+description: 솔루션별로 특정된 잘 형성된 XML 데이터를 포함하며, 명시적인 네임스페이스가 접두사로 지정되고 문서와 함께 저장됩니다.
+type: docs
+weight: 381
+url: /ko/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | 생성자. |
+| [SolutionXML()](#SolutionXML--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | XML 데이터 세트를 식별하기 위한 고유한 이름입니다. |
+| [getXmlValue()](#getXmlValue--) | 명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/solutionxml\#getName--)을(를) 참조하십시오. |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | 이 속성에 대한 설명은 [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+XML 데이터 세트를 식별하기 위한 고유한 이름입니다.
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/solutionxml\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/korean/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Aspose.Diagram for Java API 참조
+description: SolutionXML 컬렉션.
+type: docs
+weight: 382
+url: /ko/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+SolutionXML 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | 컬렉션에 SolutionXML을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [get(String name)](#get-java.lang.String-) | 지정된 속성 Name의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | 컬렉션에서 SolutionXML을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+컬렉션에 SolutionXML을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+지정된 속성 Name의 요소를 가져옵니다. 요소가 존재하지 않으면 null을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+컬렉션에서 SolutionXML을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: SpinButton 컨트롤을 나타냅니다.
+type: docs
+weight: 383
+url: /ko/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+SpinButton 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMax()](#getMax--) | 허용되는 최대값. |
+| [getMin()](#getMin--) | 허용되는 최소값. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getOrientation()](#getOrientation--) | SpinButton 또는 ScrollBar가 수직으로 배치되는지 수평으로 배치되는지 여부. |
+| [getPosition()](#getPosition--) | 값. |
+| [getSmallChange()](#getSmallChange--) | Position 속성이 변경되는 양 |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMax(int value)](#setMax-int-) | 이 속성에 대한 설명은 [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)을(를) 참조하십시오. |
+| [setMin(int value)](#setMin-int-) | 이 속성에 대한 설명은 [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setOrientation(int value)](#setOrientation-int-) | 이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)을(를) 참조하십시오. |
+| [setPosition(int value)](#setPosition-int-) | 이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)을(를) 참조하십시오. |
+| [setSmallChange(int value)](#setSmallChange-int-) | 이 속성에 대한 설명은 [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+허용되는 최대값.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+허용되는 최소값.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+SpinButton 또는 ScrollBar가 수직으로 배치되는지 수평으로 배치되는지 여부.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+값.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+Position 속성이 변경되는 양
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+이 속성에 대한 설명은 [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+이 속성에 대한 설명은 [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+이 속성에 대한 설명은 [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+이 속성에 대한 설명은 [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/splineknot/_index.md
+++ b/korean/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Aspose.Diagram for Java API 참조
+description: 스플라인 제어점과 스플라인 매듭에 대한 x 및 y 좌표를 각각 X, Y 및 A 요소로 나타냅니다.
+type: docs
+weight: 384
+url: /ko/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+스플라인의 제어점 및 스플라인의 매듭에 대한 x 및 y 좌표를 포함하며, 각각 X, Y 및 A 요소로 표시됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | 다음 [SplineKnot](../../com.aspose.diagram/splineknot) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 스플라인의 매듭 중 하나(마지막 매듭이나 처음 두 매듭 제외). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 제어점의 x 좌표입니다. |
+| [getY()](#getY--) | 제어점의 y 좌표입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/splineknot\#getA--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/splineknot\#getDel--)을 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/splineknot\#getIX--)을 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/splineknot\#getX--)을 참조하십시오. |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/splineknot\#getY--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+다음 [SplineKnot](../../com.aspose.diagram/splineknot) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+스플라인의 매듭 중 하나(마지막 매듭이나 처음 두 매듭 제외).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+제어점의 x 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+제어점의 y 좌표입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/splineknot\#getA--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/splineknot\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/splineknot\#getIX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getX()](../../com.aspose.diagram/splineknot\#getX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getY()](../../com.aspose.diagram/splineknot\#getY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/korean/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Aspose.Diagram for Java API 참조
+description: SplineKnot 컬렉션.
+type: docs
+weight: 385
+url: /ko/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+SplineKnot 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/splinestart/_index.md
+++ b/korean/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Aspose.Diagram for Java API 참조
+description: 스플라인의 두 번째 제어점, 두 번째 매듭, 첫 번째 매듭, 마지막 매듭 및 스플라인 차수에 대한 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 386
+url: /ko/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+스플라인의 두 번째 제어점, 두 번째 매듭, 첫 번째 매듭, 마지막 매듭 및 스플라인 차수에 대한 x 및 y 좌표를 포함합니다. 이 정보는 각각 X, Y, A, B, C, D 요소에 포함됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | [SplineStart](../../com.aspose.diagram/splinestart) 클래스의 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | 스플라인의 두 번째 매듭. |
+| [getB()](#getB--) | 스플라인의 첫 번째 매듭. |
+| [getC()](#getC--) | 스플라인의 마지막 매듭. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | 스플라인의 차수(1에서 25 사이의 정수). |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getX()](#getX--) | 스플라인의 두 번째 제어점의 x 좌표. |
+| [getY()](#getY--) | 스플라인의 두 번째 제어점의 y 좌표. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/splinestart\#getA--)을(를) 참조하십시오. |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/splinestart\#getB--)을(를) 참조하십시오. |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/splinestart\#getC--)을(를) 참조하십시오. |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | 이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/splinestart\#getD--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/splinestart\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/splinestart\#getIX--)을(를) 참조하십시오. |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getX()](../../com.aspose.diagram/splinestart\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | For the description of this property, please see [getY()](../../com.aspose.diagram/splinestart\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+[SplineStart](../../com.aspose.diagram/splinestart) 클래스의 인스턴스를 생성합니다.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+스플라인의 두 번째 매듭.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+스플라인의 첫 번째 매듭.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+스플라인의 마지막 매듭.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+스플라인의 차수(1에서 25 사이의 정수).
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+스플라인의 두 번째 제어점의 x 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+스플라인의 두 번째 제어점의 y 좌표.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getA()](../../com.aspose.diagram/splinestart\#getA--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getB()](../../com.aspose.diagram/splinestart\#getB--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getC()](../../com.aspose.diagram/splinestart\#getC--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+이 속성에 대한 설명은 [getD()](../../com.aspose.diagram/splinestart\#getD--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/splinestart\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/splinestart\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+For the description of this property, please see [getX()](../../com.aspose.diagram/splinestart\#getX--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+For the description of this property, please see [getY()](../../com.aspose.diagram/splinestart\#getY--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/korean/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Aspose.Diagram for Java API 참조
+description: SplineStart 컬렉션.
+type: docs
+weight: 387
+url: /ko/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+SplineStart 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/str2value/_index.md
+++ b/korean/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Aspose.Diagram for Java API 참조
+description: 문자열 값.
+type: docs
+weight: 388
+url: /ko/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+문자열 값.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | 생성자. |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getUfev()](#getUfev--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 문자열 값. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)을(를) 참조하십시오. |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | 이 속성에 대한 설명은 [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)을(를) 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/strvalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+문자열 값.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+이 속성에 대한 설명은 [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/strvalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/korean/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 스트림 옵션을 나타냅니다.
+type: docs
+weight: 390
+url: /ko/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+스트림 옵션을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | 참조된 소스에 대해 생성된 HTML 파일에 저장되는 기본 경로(URL)입니다. |
+| [getStream()](#getStream--) | 저장된 데이터를 쓰기 위한 출력 스트림을 가져오거나 설정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | 참조된 소스에 대해 생성된 HTML 파일에 저장되는 사용자 지정 경로(URL)입니다. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | 이 속성에 대한 설명은 [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+참조된 소스에 대해 생성된 HTML 파일에 저장되는 기본 경로(URL)입니다. 예를 들어, 시트 데이터가 xxx\_files/sheet001.htm에 저장되는 경우, 메인 HTML 파일에서 사용되는 URL은 "src=\"xxx\_files/sheet001.htm\""와 같이 되어야 합니다.
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+저장된 데이터를 쓰기 위한 출력 스트림을 가져오거나 설정합니다.
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+참조된 소스에 대해 생성된 HTML 파일에 저장되는 사용자 지정 경로(URL)입니다. 사용자가 정의하지 않으면 DefaultPath가 사용됩니다. 예를 들어, 시트 데이터가 사용자가 d:/sheet001.htm에 저장하면, 메인 HTML 파일에서 사용되는 URL은 "d:/sheet001.htm" 또는 메인 HTML 파일에서 접근 가능한 다른 유효한 상대 경로가 되어야 합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+이 속성에 대한 설명은 [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/strvalue/_index.md
+++ b/korean/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Aspose.Diagram for Java API 참조
+description: 문자열 값
+type: docs
+weight: 389
+url: /ko/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+문자열 값
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | 생성자. |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | 생성자. |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성입니다. |
+| [getValue()](#getValue--) | 문자열 값. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)을(를) 참조하십시오. |
+| [setValue(String value)](#setValue-java.lang.String-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/strvalue\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+| 단위 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성입니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+문자열 값.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/strvalue\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/style/_index.md
+++ b/korean/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Style
+second_title: Aspose.Diagram for Java API 참조
+description: Specifies the character formatting applied to a range of text in the shapes text block.
+type: docs
+weight: 391
+url: /ko/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Style(int value)](#Style-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/styleprop/_index.md
+++ b/korean/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Aspose.Diagram for Java API 참조
+description: 스타일에 텍스트 라인 및 채우기 속성이 포함되는지와 같은 스타일 동작을 제어하는 요소를 포함합니다.
+type: docs
+weight: 392
+url: /ko/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+스타일에 텍스트, 선, 채우기 속성이 포함되는지와 같은 스타일 동작을 제어하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getEnableFillProps()](#getEnableFillProps--) | 스타일에 채우기 속성이 포함되는지 지정합니다. |
+| [getEnableLineProps()](#getEnableLineProps--) | 스타일에 선 속성이 포함되는지 지정합니다 |
+| [getEnableTextProps()](#getEnableTextProps--) | 스타일에 텍스트 속성이 포함되는지 지정합니다. |
+| [getHideForApply()](#getHideForApply--) | Microsoft Visio 사용자 인터페이스에서 스타일이 표시되는 위치를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/styleprop\#getDel--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+스타일에 채우기 속성이 포함되는지 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+스타일에 선 속성이 포함되는지 지정합니다
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+스타일에 텍스트 속성이 포함되는지 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Microsoft Visio 사용자 인터페이스에서 스타일이 표시되는 위치를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/styleprop\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/stylesheet/_index.md
+++ b/korean/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에 정의된 스타일을 나타냅니다.
+type: docs
+weight: 393
+url: /ko/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+문서에 정의된 스타일을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Char 요소의 컬렉션을 포함합니다. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | ConnectionABCD 요소의 컬렉션을 포함합니다. |
+| [getConnections()](#getConnections--) | Connection 요소의 컬렉션을 포함합니다. |
+| [getEvent()](#getEvent--) | 도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다. |
+| [getFill()](#getFill--) | 패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다. |
+| [getFillStyle()](#getFillStyle--) | 이 스타일이 채우기 서식을 상속받는 StyleSheet 요소입니다. |
+| [getForeign()](#getForeign--) | Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체 너비와 높이를 지정하는 요소를 포함합니다. |
+| [getForeignData()](#getForeignData--) | Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다. |
+| [getGroup()](#getGroup--) | 그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다. |
+| [getHelp()](#getHelp--) | Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getImage()](#getImage--) | 비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다. |
+| [getLayout()](#getLayout--) | 도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다. |
+| [getLine()](#getLine--) | 패턴, 두께 및 색상과 같은 도형의 선 속성을 제어하는 요소를 포함합니다. |
+| [getLineStyle()](#getLineStyle--) | 이 스타일이 선 서식을 상속받는 StyleSheet 요소입니다. |
+| [getMisc()](#getMisc--) | Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPageLayout()](#getPageLayout--) | 페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 Diagram을 포함합니다. 여기에는 페이지 내 모든 도형 사이의 간격, 모든 커넥터 사이의 간격, 그리고 모든 커넥터의 라우팅 스타일이 포함됩니다. |
+| [getParas()](#getParas--) | Para 요소의 컬렉션을 포함합니다. |
+| [getProtection()](#getProtection--) | 잠금은 도형에 대한 실수로 인한 변경을 방지하는 데 도움이 되지만 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. |
+| [getRulerGrid()](#getRulerGrid--) | 페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다. |
+| [getStyleProp()](#getStyleProp--) | 스타일에 텍스트, 선, 채우기 속성이 포함되는지와 같은 스타일 동작을 제어하는 요소를 포함합니다. |
+| [getTabsCollection()](#getTabsCollection--) | Tab 요소의 컬렉션을 포함합니다. |
+| [getTextBlock()](#getTextBlock--) | 도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다. |
+| [getTextStyle()](#getTextStyle--) | 이 스타일이 텍스트 서식을 상속받는 StyleSheet 요소입니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/stylesheet\#getID--)을(를) 참조하십시오. |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/stylesheet\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)을(를) 참조하십시오. |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | 이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Char 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+ConnectionABCD 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Connection 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+도형 이벤트를 제어하는 수식을 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+패턴, 전경색 및 배경색을 포함하여 도형 및 도형의 그림자에 대한 현재 채우기 서식 값을 포함합니다.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+이 스타일이 채우기 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Microsoft Visio 문서에서 사용되는 다른 프로그램의 객체의 너비와 높이를 지정하는 요소를 포함합니다. 또한 객체 이미지가 경계 내에서 오프셋되는 거리를 지정하는 요소도 포함합니다.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Windows 메타파일, 비트맵 또는 OLE 데이터와 같은 그림 데이터의 MIME(다목적 인터넷 메일 확장) 인코딩 BLOB을 포함합니다.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+그룹에 도형을 추가하고, 그룹 구성원을 이동하며, 그룹을 선택하는 방식을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+비트맵에 대한 감마, 밝기, 대비, 흐림, 선명화, 노이즈 제거 및 투명도 값을 포함합니다.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+도형 배치 및 커넥터 라우팅 설정을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+모양의 선 속성을 제어하는 요소들을 포함합니다. 예를 들어 패턴, 두께, 색상 등이 있습니다. 이러한 요소들은 선 끝이 형식화되는지 여부(예: 화살표 머리), 선 끝 형식의 크기, 선에 적용되는 둥근 원의 반경, 그리고 선 캡 스타일(둥근 또는 사각)을 결정합니다.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+이 스타일이 선 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Shape 요소의 도움말 파일 주제와 저작권 정보를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+페이지의 도형 및 커넥터에 대한 레이아웃 설정을 제어하는 Diagram을 포함합니다. 여기에는 페이지 내 모든 도형 사이의 간격, 모든 커넥터 사이의 간격, 그리고 모든 커넥터의 라우팅 스타일이 포함됩니다.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Para 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+잠금은 모양에 대한 의도치 않은 변경을 방지하는 데 도움이 되지만, 다른 상황에서 Microsoft Visio가 값을 재설정하는 것을 방지하지는 않습니다. 또한 ShapeSheet 창에서 이루어지는 변경으로부터 보호하지도 않습니다.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+페이지 눈금자와 격자 설정을 지정하는 요소를 포함합니다.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+스타일에 텍스트, 선, 채우기 속성이 포함되는지와 같은 스타일 동작을 제어하는 요소를 포함합니다.
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Tab 요소의 컬렉션을 포함합니다.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+이 스타일이 텍스트 서식을 상속받는 StyleSheet 요소입니다.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/stylesheet\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/stylesheet\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+이 속성에 대한 설명은 [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/korean/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Aspose.Diagram for Java API 참조
+description: StyleSheets 컬렉션.
+type: docs
+weight: 394
+url: /ko/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+StyleSheets 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | 컬렉션에 StyleSheet을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | Gets the element at the specified ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | 컬렉션에서 StyleSheet을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+컬렉션에 StyleSheet을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+컬렉션에서 StyleSheet을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/stylevalue/_index.md
+++ b/korean/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Aspose.Diagram for Java API 참조
+description: Specifies the character formatting applied to a range of text in the shapes text block.
+type: docs
+weight: 395
+url: /ko/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+도형 텍스트 블록의 텍스트 범위에 적용되는 문자 서식을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOLD](#BOLD) | Bold. |
+| [ITALIC](#ITALIC) | Italic. |
+| [SMALL_CAPS](#SMALL-CAPS) | Small caps. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [UNDERLINE](#UNDERLINE) | Underline. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Bold.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Italic.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Small caps.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Underline.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 SVG로 렌더링할 때 추가 옵션을 지정할 수 있도록 합니다.
+type: docs
+weight: 347
+url: /ko/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+다이어그램 페이지를 SVG로 렌더링할 때 추가 옵션을 지정할 수 있도록 합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | 이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | 이미지를 위한 생성된 SVG 파일에 저장된 사용자 지정 경로(URL)입니다. |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Emf 메타파일 렌더링 설정. |
+| [getEnlargePage()](#getEnlargePage--) | 페이지를 확대할지 여부를 지정합니다. |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | 사각형 요소를 rect 태그로 내보낼지 여부를 정의합니다. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | 가이드 도형을 내보낼지 여부를 정의합니다. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 숨겨진 페이지를 내보낼지 여부를 정의합니다. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 페이지의 0부터 시작하는 인덱스입니다. |
+| [getPageSize()](#getPageSize--) | 생성된 이미지의 페이지 크기. |
+| [getQuality()](#getQuality--) | 페이지를 JPEG 형식으로 저장할 때만 적용되는 생성된 이미지 품질을 결정하는 값입니다. |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | 이 속성이 true이면 생성된 SVG가 뷰포트에 맞게 조정됩니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다. |
+| [getShapes()](#getShapes--) | 렌더링할 도형. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | 주석을 내보낼지 여부를 정의합니다. |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | 행렬 형태로 스케일을 내보낼지 여부를 정의합니다. |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | 사용자 지정 선 패턴 저장 여부를 정의합니다. |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | 이미지를 별도로 저장할지 여부를 정의합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | 이 속성에 대한 설명은 [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)을(를) 참조하십시오. |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | 이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오. |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | 이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오. |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | 이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오. |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | 이 속성에 대한 설명은 [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)을(를) 참조하십시오. |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | 이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오. |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | 이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오. |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | 이 속성에 대한 설명은 [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)을(를) 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)을(를) 참조하십시오. |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | 이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오. |
+| [setQuality(int value)](#setQuality-int-) | 이 속성에 대한 설명은 [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)을(를) 참조하십시오. |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | 이 속성에 대한 설명은 [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | 이 속성에 대한 설명은 [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)을(를) 참조하십시오. |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | 이 속성에 대한 설명은 [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)을(를) 참조하십시오. |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | 이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+사용자가 지정한 경로(URL)가 이미지에 대한 생성된 SVG 파일에 저장됩니다. 사용자가 정의하지 않은 경우 현재 디렉터리가 사용됩니다.
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Emf 메타파일 렌더링을 위한 설정입니다. "EMF+ Dual" 로 식별되는 EMF 메타파일은 EMF+ 레코드와 EMF 레코드를 모두 포함할 수 있습니다. 두 종류의 레코드 중 하나를 사용하여 이미지를 렌더링하거나, EMF+ 레코드만, 혹은 EMF 레코드만 사용할 수 있습니다. EmfPlusPrefer가 설정되면 EMF+ 레코드가 파싱되고, 그렇지 않으면 EMF 레코드만 파싱됩니다. 기본값은 EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+페이지 확대 여부를 지정합니다. true이면 페이지를 확대하고, false이면 확대하지 않습니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+사각형 요소를 rect 태그로 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+가이드 도형을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+숨겨진 페이지를 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+생성된 이미지의 페이지 크기입니다. [PageSize](../../com.aspose.diagram/pagesize)이거나 null일 수 있습니다. 기본값은 null입니다. PageSize가 null이면 생성된 이미지의 페이지 크기는 소스 다이어그램에서 가져옵니다.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+JPEG 형식으로 페이지를 저장할 때만 적용되는 생성된 이미지의 품질을 결정하는 값입니다. 기본값은 100이며, JPEG로 저장할 때만 효과가 있습니다. 값은 0에서 100 사이여야 합니다. 기본값은 100입니다.
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+이 속성이 true이면 생성된 SVG가 뷰포트에 맞게 조정됩니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체가 사용될 경우 문서가 저장될 형식을 지정합니다.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+렌더링할 도형입니다. 기본 개수는 0입니다.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+주석을 내보낼지 여부를 정의합니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+행렬에 스케일을 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+사용자 지정 선 패턴 저장 여부를 정의합니다.
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+이미지를 별도로 저장할지 여부를 정의합니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+이 속성에 대한 설명은 [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+이 속성에 대한 설명은 [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+이 속성에 대한 설명은 [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+이 속성에 대한 설명은 [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+이 속성에 대한 설명은 [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/tab/_index.md
+++ b/korean/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Aspose.Diagram for Java API 참조
+description: Tab 요소의 컬렉션을 포함합니다.
+type: docs
+weight: 396
+url: /ko/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Tab 요소의 컬렉션을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | 탭 정렬을 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [getLeader()](#getLeader--) | 리더를 지정했습니다. |
+| [getPosition()](#getPosition--) | 탭 정지 위치를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | 이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/tab\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/tab\#getIX--)을(를) 참조하십시오. |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | 이 속성에 대한 설명은 [getLeader()](../../com.aspose.diagram/tab\#getLeader--)을(를) 참조하십시오. |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/tab\#getPosition--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+탭 정렬을 지정합니다.
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+리더를 지정했습니다.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+탭 정지 위치를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+이 속성에 대한 설명은 [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/tab\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/tab\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+이 속성에 대한 설명은 [getLeader()](../../com.aspose.diagram/tab\#getLeader--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getPosition()](../../com.aspose.diagram/tab\#getPosition--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/tabcollection/_index.md
+++ b/korean/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Aspose.Diagram for Java API 참조
+description: Tab 요소의 컬렉션을 포함합니다
+type: docs
+weight: 397
+url: /ko/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Tab 요소의 컬렉션을 포함합니다
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | 컬렉션에 Tab 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getIX()](#getIX--) | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | 컬렉션에서 Tab 객체를 제거합니다. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)을(를) 참조하십시오. |
+| [setIX(int value)](#setIX-int-) | 이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+컬렉션에 Tab 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+컬렉션에서 Tab 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+이 속성에 대한 설명은 [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/tabscollection/_index.md
+++ b/korean/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Aspose.Diagram for Java API 참조
+description: TabCollection 요소의 컬렉션을 포함합니다
+type: docs
+weight: 398
+url: /ko/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+TabCollection 요소의 컬렉션을 포함합니다
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | 컬렉션에 Tab 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | 컬렉션에서 Tab 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+컬렉션에 Tab 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+컬렉션에서 Tab 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/text/_index.md
+++ b/korean/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: 텍스트
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 텍스트를 포함합니다.
+type: docs
+weight: 399
+url: /ko/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+도형의 텍스트를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Text()](#Text--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | 도형의 텍스트를 포함하는 FormatTxt 컬렉션. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+도형의 텍스트를 포함하는 FormatTxt 컬렉션.
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textblock/_index.md
+++ b/korean/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Aspose.Diagram for Java API 참조
+description: 도형 텍스트 블록 내 텍스트의 정렬 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다.
+type: docs
+weight: 400
+url: /ko/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+도형 텍스트 블록의 텍스트 정렬, 여백 및 기본 탭 정지 위치를 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | 텍스트 블록의 하단 경계와 포함된 마지막 텍스트 행 사이의 거리를 결정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | 텍스트 블록 내 기본 탭 정지 간격을 지정합니다. |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getLeftMargin()](#getLeftMargin--) | 텍스트 블록의 왼쪽 경계와 포함된 텍스트 사이의 거리를 지정합니다. |
+| [getRightMargin()](#getRightMargin--) | 텍스트 블록의 오른쪽 경계와 포함된 텍스트 사이의 거리를 지정합니다. |
+| [getTextBkgnd()](#getTextBkgnd--) | 도형의 텍스트 배경 색상을 지정합니다. |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | 도형 텍스트 블록 배경 색상의 투명도 수준을 0(완전 불투명)부터 1(완전 투명)까지 지정합니다. |
+| [getTextDirection()](#getTextDirection--) | 텍스트 블록 내 문자 방향을 지정합니다. |
+| [getTopMargin()](#getTopMargin--) | 텍스트 블록의 상단 경계와 포함된 첫 번째 텍스트 행 사이의 거리를 지정합니다. |
+| [getVerticalAlign()](#getVerticalAlign--) | 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)을(를) 참조하십시오. |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/textblock\#getDel--)을(를) 참조하십시오. |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)을(를) 참조하십시오. |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)을(를) 참조하십시오. |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)을(를) 참조하십시오. |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)을(를) 참조하십시오. |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | 이 속성에 대한 설명은 [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)을(를) 참조하십시오. |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)을(를) 참조하십시오. |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | 이 속성에 대한 설명은 [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+텍스트 블록의 하단 경계와 포함된 마지막 텍스트 행 사이의 거리를 결정합니다. 기본값은 4pt입니다. 이 값은 도면의 축척에 영향을 받지 않습니다. 도면이 확대/축소되더라도 하단 여백은 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+텍스트 블록 내 기본 탭 정지 간격을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+텍스트 블록의 왼쪽 경계와 포함된 텍스트 사이의 거리를 지정합니다. 이 값은 도면의 축척에 영향을 받지 않습니다. 도면이 확대/축소되더라도 왼쪽 여백은 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+텍스트 블록의 오른쪽 경계와 포함된 텍스트 사이의 거리를 지정합니다. 이 값은 도면의 축척에 영향을 받지 않습니다. 도면이 확대/축소되더라도 오른쪽 여백은 동일하게 유지됩니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+도형의 텍스트 배경 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+도형 텍스트 블록 배경 색상의 투명도 수준을 0(완전 불투명)부터 1(완전 투명)까지 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+텍스트 블록 내 문자 방향을 지정합니다.
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+텍스트 블록의 상단 경계와 포함된 첫 번째 텍스트 행 사이의 거리를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/textblock\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+이 속성에 대한 설명은 [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+이 속성에 대한 설명은 [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 박스 ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 401
+url: /ko/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+텍스트 박스 ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getBorderOleColor()](#getBorderOleColor--) | the ole color of the background. |
+| [getBorderStyle()](#getBorderStyle--) | the type of border used by the control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Specifies the symbol displayed on the drop button |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Specifies selection behavior when entering the control. |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | ENTER 키의 동작을 지정합니다. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getHideSelection()](#getHideSelection--) | Indicates whether selected text in the control appears highlighted when the control does not have focus. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getIntegralHeight()](#getIntegralHeight--) | 컨트롤이 부분적인 줄을 표시하지 않고 전체 텍스트 줄만 표시할지 여부를 나타냅니다. |
+| [getMaxLength()](#getMaxLength--) | 최대 문자 수 |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPasswordChar()](#getPasswordChar--) | 입력된 문자 대신 표시될 문자입니다. |
+| [getScrollBars()](#getScrollBars--) | 컨트롤에 수직 스크롤 바, 수평 스크롤 바, 둘 다, 또는 전혀 없는지를 나타냅니다. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Specifies the symbol displayed on the drop button |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | 컨트롤 텍스트에서 탭 문자를 허용할지 여부를 나타냅니다. |
+| [getText()](#getText--) | 컨트롤의 텍스트. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isAutoTab()](#isAutoTab--) | 사용자가 최대 문자 수를 입력하면 포커스가 자동으로 다음 컨트롤로 이동하는지 여부를 나타냅니다. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | 선택을 확장하는 데 사용되는 기본 단위를 지정합니다. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | 컨트롤에 대해 끌어다 놓기가 활성화되어 있는지 여부를 나타냅니다. |
+| [isEditable()](#isEditable--) | 사용자가 컨트롤에 입력할 수 있는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isMultiLine()](#isMultiLine--) | 컨트롤이 한 줄 이상의 텍스트를 표시할 수 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isWordWrapped()](#isWordWrapped--) | 컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | 이 속성에 대한 설명은 [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)를 참조하십시오. |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | 이 속성에 대한 설명은 [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)를 참조하십시오. |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | 이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)를 참조하십시오. |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | 이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)를 참조하십시오. |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | 이 속성에 대한 설명은 [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)를 참조하십시오. |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | 이 속성에 대한 설명은 [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)를 참조하십시오. |
+| [setEditable(boolean value)](#setEditable-boolean-) | 이 속성에 대한 설명은 [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)를 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | 이 속성에 대한 설명은 [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)를 참조하십시오. |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | 이 속성에 대한 설명은 [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)를 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | 이 속성에 대한 설명은 [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)를 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | 이 속성에 대한 설명은 [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)를 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMaxLength(int value)](#setMaxLength-int-) | 이 속성에 대한 설명은 [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)를 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | 이 속성에 대한 설명은 [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)를 참조하십시오. |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | 이 속성에 대한 설명은 [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)를 참조하십시오. |
+| [setScrollBars(int value)](#setScrollBars-int-) | 이 속성에 대한 설명은 [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)를 참조하십시오. |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | 이 속성에 대한 설명은 [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)를 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)를 참조하십시오. |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | 이 속성에 대한 설명은 [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)를 참조하십시오. |
+| [setText(String value)](#setText-java.lang.String-) | 이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)를 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | 이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+the type of border used by the control.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Specifies the symbol displayed on the drop button
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+컨트롤에 진입할 때 선택 동작을 지정합니다. True는 선택이 마지막으로 컨트롤이 활성화되었을 때와 동일하게 유지됨을 지정하고, False는 컨트롤에 진입할 때 컨트롤 내 모든 텍스트가 선택됨을 지정합니다.
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+ENTER 키의 동작을 지정합니다. True는 ENTER를 누르면 새 줄이 생성된다는 것을 의미하고, False는 ENTER를 누르면 탭 순서에서 다음 객체로 포커스가 이동한다는 것을 의미합니다.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indicates whether selected text in the control appears highlighted when the control does not have focus.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+컨트롤이 부분적인 줄을 표시하지 않고 전체 텍스트 줄만 표시할지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+최대 문자 수
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+입력된 문자 대신 표시될 문자입니다.
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+컨트롤에 수직 스크롤 바, 수평 스크롤 바, 둘 다, 또는 전혀 없는지를 나타냅니다.
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Specifies the symbol displayed on the drop button
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+컨트롤 텍스트에서 탭 문자를 허용할지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+컨트롤의 텍스트.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+사용자가 최대 문자 수를 입력하면 포커스가 자동으로 다음 컨트롤로 이동하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+선택을 확장하는 데 사용되는 기본 단위를 지정합니다. True는 기본 단위가 단일 문자임을 지정하고, false는 기본 단위가 전체 단어임을 지정합니다.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+컨트롤에 대해 끌어다 놓기가 활성화되어 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+사용자가 컨트롤에 입력할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+컨트롤이 한 줄 이상의 텍스트를 표시할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+컨트롤 내용이 줄 끝에서 자동으로 줄 바꿈되는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+이 속성에 대한 설명은 [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+이 속성에 대한 설명은 [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+이 속성에 대한 설명은 [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+이 속성에 대한 설명은 [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textcollection/_index.md
+++ b/korean/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 텍스트를 포함합니다.
+type: docs
+weight: 402
+url: /ko/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+도형의 텍스트를 포함합니다. 각 항목은 문자, 단락 및 탭 속성을 가진 텍스트입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | 컬렉션에 Text 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | 컬렉션에서 Text 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+컬렉션에 Text 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+컬렉션에서 Text 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textdirection/_index.md
+++ b/korean/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 블록 내 문자 방향을 지정합니다.
+type: docs
+weight: 403
+url: /ko/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+텍스트 블록 내 문자 방향을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 텍스트 블록 내 문자 방향을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | For the description of this property, please see [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/textdirection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+텍스트 블록 내 문자 방향을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+For the description of this property, please see [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/textdirection\#getValue--)
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/korean/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 블록 내 문자 방향을 지정합니다.
+type: docs
+weight: 404
+url: /ko/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+텍스트 블록 내 문자 방향을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | 수평. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VERTICAL](#VERTICAL) | 수직. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+수평.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+수직.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/textxform/_index.md
+++ b/korean/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 텍스트 블록에 대한 위치 정보를 지정하는 요소를 포함합니다.
+type: docs
+weight: 405
+url: /ko/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+도형 텍스트 블록에 대한 위치 정보를 지정하는 요소를 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getTxtAngle()](#getTxtAngle--) | 도형의 x축에 대한 텍스트 블록의 현재 회전 각도를 지정합니다. |
+| [getTxtHeight()](#getTxtHeight--) | 텍스트 블록의 높이를 지정합니다. |
+| [getTxtLocPinX()](#getTxtLocPinX--) | 텍스트 블록 원점에 대한 텍스트 블록 회전 중심의 x좌표를 지정합니다. |
+| [getTxtLocPinY()](#getTxtLocPinY--) | 텍스트 블록 원점에 대한 텍스트 블록 회전 중심의 y좌표를 지정합니다. |
+| [getTxtPinX()](#getTxtPinX--) | 도형 원점에 대한 텍스트 블록 회전 중심의 x좌표를 지정합니다. |
+| [getTxtPinY()](#getTxtPinY--) | 도형 원점에 대한 텍스트 블록 회전 중심의 y좌표를 지정합니다. |
+| [getTxtWidth()](#getTxtWidth--) | 텍스트 블록의 너비를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/textxform\#getDel--)을(를) 참조하십시오. |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)을(를) 참조하십시오. |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)을(를) 참조하십시오. |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)을(를) 참조하십시오. |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)을(를) 참조하십시오. |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)을(를) 참조하십시오. |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)을(를) 참조하십시오. |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+도형의 x축에 대한 텍스트 블록의 현재 회전 각도를 지정합니다. 기본값은 0도입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+텍스트 블록의 높이를 지정합니다. 기본 수식은 도형의 높이와 동일하게 평가되는 F="Height\*1"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+텍스트 블록 원점에 대한 텍스트 블록 회전 중심의 x좌표를 지정합니다. 기본 수식은 텍스트 블록의 수평 중심으로 평가되는 F="TxtWidth\*0.5"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+텍스트 블록 원점에 대한 텍스트 블록 회전 중심의 y좌표를 지정합니다. 기본 수식은 텍스트 블록의 수직 중심으로 평가되는 F="TxtHeight\*0.5"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+도형 원점에 대한 텍스트 블록 회전 중심의 x좌표를 지정합니다. 기본 수식은 도형의 수평 중심으로 평가되는 F="Width\*0.5"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+도형 원점에 대한 텍스트 블록 회전 중심의 y좌표를 지정합니다. 기본 수식은 도형의 수직 중심으로 평가되는 F="Height\*0.5"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+텍스트 블록의 너비를 지정합니다. 기본 수식은 도형의 너비와 동일하게 평가되는 F="Width\*1"입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/textxform\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/threedformat/_index.md
+++ b/korean/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 3차원 서식을 나타냅니다.
+type: docs
+weight: 406
+url: /ko/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+도형의 3차원 서식을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | 3D 도형의 하단 베벨 높이를 지정합니다. |
+| [getBevelBottomType()](#getBevelBottomType--) | 3D 도형의 하단 베벨에 대한 사전 설정 베벨 유형을 지정합니다. |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | 3D 도형의 하단 베벨 너비를 지정합니다. |
+| [getBevelContourColor()](#getBevelContourColor--) | 3D 도형의 외곽선 색상을 지정합니다. |
+| [getBevelContourSize()](#getBevelContourSize--) | 3D 도형의 외곽선 두께를 지정합니다. |
+| [getBevelDepthColor()](#getBevelDepthColor--) | 3D 도형의 돌출 색상을 지정합니다. |
+| [getBevelDepthSize()](#getBevelDepthSize--) | 3D 도형의 돌출 깊이를 지정합니다. |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | 3D 도형의 조명 방향을 지정합니다. |
+| [getBevelLightingType()](#getBevelLightingType--) | 3D 도형의 조명 사전 설정 유형을 지정합니다. |
+| [getBevelMaterialType()](#getBevelMaterialType--) | 3D 도형의 표면 외관 사전 설정을 지정합니다. |
+| [getBevelTopHeight()](#getBevelTopHeight--) | 3D 도형의 상단 베벨 높이를 지정합니다. |
+| [getBevelTopType()](#getBevelTopType--) | 3D 도형의 상단 베벨에 대한 사전 설정 베벨 유형을 지정합니다. |
+| [getBevelTopWidth()](#getBevelTopWidth--) | 3D 도형의 상단 베벨 너비를 지정합니다. |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | 3D 회전 속성이 있는 도형의 거리를 지정합니다. |
+| [getKeepTextFlat()](#getKeepTextFlat--) | 3D 회전 속성이 도형의 텍스트에 적용되는지 여부를 지정합니다. |
+| [getPerspective()](#getPerspective--) | 3D 회전 속성이 있는 도형의 시야 각도를 지정합니다. |
+| [getRotationType()](#getRotationType--) | 도형의 효과 속성 투영 유형을 지정합니다. |
+| [getRotationXAngle()](#getRotationXAngle--) | 도형을 y축을 중심으로 반시계 방향 회전 각도를 지정합니다. |
+| [getRotationYAngle()](#getRotationYAngle--) | 도형을 x축을 중심으로 반시계 방향 회전 각도를 지정합니다. |
+| [getRotationZAngle()](#getRotationZAngle--) | 도형을 z축을 중심으로 반시계 방향 회전 각도를 지정합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)을(를) 참조하십시오. |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | 이 속성에 대한 설명은 [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)을(를) 참조하십시오. |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)을(를) 참조하십시오. |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)을(를) 참조하십시오. |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)을(를) 참조하십시오. |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | 이 속성에 대한 설명은 [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)을(를) 참조하십시오. |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)을(를) 참조하십시오. |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)을(를) 참조하십시오. |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | 이 속성에 대한 설명은 [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)을(를) 참조하십시오. |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | 이 속성에 대한 설명은 [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)을(를) 참조하십시오. |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)을(를) 참조하십시오. |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | 이 속성에 대한 설명은 [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)을(를) 참조하십시오. |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)을(를) 참조하십시오. |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)을(를) 참조하십시오. |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)을(를) 참조하십시오. |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)을(를) 참조하십시오. |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | 이 속성에 대한 설명은 [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)을(를) 참조하십시오. |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)을(를) 참조하십시오. |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)을(를) 참조하십시오. |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+3D 도형의 하단 베벨 높이를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+3D 도형의 하단 베벨에 대한 사전 설정 베벨 유형을 지정합니다.
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+3D 도형의 하단 베벨 너비를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+3D 도형의 외곽선 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+3D 도형의 외곽선 두께를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+3D 도형의 돌출 색상을 지정합니다.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+3D 도형의 돌출 깊이를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+3D 도형의 조명 방향을 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+3D 도형의 조명 사전 설정 유형을 지정합니다.
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+3D 도형의 표면 외관 사전 설정을 지정합니다.
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+3D 도형의 상단 베벨 높이를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+3D 도형의 상단 베벨에 대한 사전 설정 베벨 유형을 지정합니다.
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+3D 도형의 상단 베벨 너비를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+3D 회전 속성이 있는 도형의 거리를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+3D 회전 속성이 도형의 텍스트에 적용되는지 여부를 지정합니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+3D 회전 속성이 있는 도형의 시야 각도를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+도형의 효과 속성 투영 유형을 지정합니다.
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+도형을 y축을 중심으로 반시계 방향 회전 각도를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+도형을 x축을 중심으로 반시계 방향 회전 각도를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+도형을 z축을 중심으로 반시계 방향 회전 각도를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+이 속성에 대한 설명은 [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+이 속성에 대한 설명은 [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+이 속성에 대한 설명은 [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+이 속성에 대한 설명은 [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+이 속성에 대한 설명은 [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/korean/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Aspose.Diagram for Java API 참조
+description: 페이지를 TIFF 형식으로 저장할 때 적용할 압축 유형을 지정합니다.
+type: docs
+weight: 407
+url: /ko/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+페이지를 TIFF 형식으로 저장할 때 적용할 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | CCITT3 압축 방식을 지정합니다. |
+| [CCITT_4](#CCITT-4) | CCITT4 압축 방식을 지정합니다. |
+| [LZW](#LZW) | LZW 압축 방식을 지정합니다. |
+| [NONE](#NONE) | 압축을 사용하지 않음을 지정합니다. |
+| [RLE](#RLE) | RLE 압축 방식을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+CCITT3 압축 방식을 지정합니다.
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+CCITT4 압축 방식을 지정합니다.
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+LZW 압축 방식을 지정합니다.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+압축을 사용하지 않음을 지정합니다.
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+RLE 압축 방식을 지정합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/korean/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Aspose.Diagram for Java API 참조
+description: 타임라인 도형의 속성을 설정하기 위한 TimeLineHelper.
+type: docs
+weight: 408
+url: /ko/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+타임라인 도형의 속성을 설정하기 위한 TimeLineHelper.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | 날짜 및 시간을 double 값으로 변환합니다. |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | 타임라인 모양의 종료에 대한 기간 |
+| [getTimePeriodStart()](#getTimePeriodStart--) | 타임라인 모양의 시작에 대한 기간 |
+| [getTimeScale()](#getTimeScale--) | 타임라인 모양의 스케일 |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | 타임라인 모양의 시간을 새로 고칩니다 |
+| [setArrowHead(int value)](#setArrowHead-int-) | 타임라인 모양의 화살표 머리 |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | 타임라인에서 마커(마일스톤, 구간)를 이동할 때 데이터를 업데이트할지 여부 |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | 타임라인 모양의 시작 주 |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | 타임라인 모양의 시작 및 종료에 대한 날짜 형식 /// |
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | 타임라인 모양의 Intm에 대한 날짜 형식 /// |
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | 타임라인 모양의 시작 및 종료에 대한 날짜 형식 문자열 |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | 타임라인 모양의 Intm에 대한 날짜 형식 문자열 |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | 타임라인에 시작 및 종료 날짜를 표시할지 여부 |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | 타임라인에 중간 날짜/시간 틱을 표시할지 여부 |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | 중간 틱에 중간 날짜를 표시할지 여부 |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | 회계 연도의 첫 번째 날 |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | 타임라인 모양의 시작 주 |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+날짜 및 시간을 double 값으로 변환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | 날짜 및 시간. |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+타임라인 모양의 종료에 대한 기간
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+타임라인 모양의 시작에 대한 기간
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+타임라인 모양의 스케일
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| weekStart | int | (0일요일 1월요일 2 3 4 5 6) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+타임라인 모양의 시간을 새로 고칩니다
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+타임라인 모양의 화살표 머리
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+타임라인에서 마커(마일스톤, 구간)를 이동할 때 데이터를 업데이트할지 여부
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+타임라인 모양의 시작 주
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+타임라인 모양의 시작 및 종료에 대한 날짜 형식 ///
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+타임라인 모양의 Intm에 대한 날짜 형식 ///
+
+| ----------------------- | ------------------------------- |
+| **값**\u9286\u20ac | **형식 문자열**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+타임라인 모양의 시작 및 종료에 대한 날짜 형식 문자열
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+타임라인 모양의 Intm에 대한 날짜 형식 문자열
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+타임라인에 시작 및 종료 날짜를 표시할지 여부
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+타임라인에 중간 날짜/시간 틱을 표시할지 여부
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+중간 틱에 중간 날짜를 표시할지 여부
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+회계 연도의 첫 번째 날
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+타임라인 모양의 시작 주
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/korean/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Aspose.Diagram for Java API 참조
+description: ToggleButton ActiveX 컨트롤을 나타냅니다.
+type: docs
+weight: 410
+url: /ko/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+ToggleButton ActiveX 컨트롤을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | 컨트롤의 단축키입니다. |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getCaption()](#getCaption--) | 컨트롤에 표시되는 설명 텍스트입니다. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPicture()](#getPicture--) | 그림의 데이터입니다. |
+| [getPicturePosition()](#getPicturePosition--) | 컨트롤 캡션에 상대적인 그림의 위치. |
+| [getSpecialEffect()](#getSpecialEffect--) | 컨트롤의 특수 효과. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getValue()](#getValue--) | 컨트롤이 선택되었는지 여부를 나타냅니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [isTripleState()](#isTripleState--) | 지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | 이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)를 참조하십시오. |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setCaption(String value)](#setCaption-java.lang.String-) | 이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)를 참조하십시오. |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setPicture(byte[] value)](#setPicture-byte---) | 이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)를 참조하십시오. |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | 이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)를 참조하십시오. |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | 이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)를 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | 이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)를 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)를 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+컨트롤의 단축키입니다.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+컨트롤에 표시되는 설명 텍스트입니다.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+그림의 데이터입니다.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+컨트롤 캡션에 상대적인 그림의 위치.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+컨트롤의 특수 효과.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+컨트롤이 선택되었는지 여부를 나타냅니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+지정된 컨트롤이 Null 값을 표시하는 방식을 나타냅니다.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 설정 | 설명 |
+| True    | 컨트롤은 Yes, No 및 Null 값에 대한 상태를 순환합니다. Value 속성이 Null로 설정되면 컨트롤이 흐리게(회색) 표시됩니다. |
+| False   | (기본값) 컨트롤은 Yes와 No 값에 대한 상태를 순환합니다. Null 값은 No 값처럼 표시됩니다. |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+이 속성에 대한 설명은 [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+이 속성에 대한 설명은 [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+이 속성에 대한 설명은 [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+이 속성에 대한 설명은 [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/topartvalue/_index.md
+++ b/korean/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Aspose.Diagram for Java API 참조
+description: 연결이 이루어지는 도형의 부분.
+type: docs
+weight: 409
+url: /ko/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+연결이 이루어지는 도형의 부분.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | 연결 지점. |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | 가이드 교차점. |
+| [GUIDE_X](#GUIDE-X) | GuideX. |
+| [GUIDE_Y](#GUIDE-Y) | GuideY. |
+| [NONE](#NONE) | 없음. |
+| [TO_ANGLE](#TO-ANGLE) | 각도까지. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | 전체 도형. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+연결 지점.
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+가이드 교차점.
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuideX.
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuideY.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+없음.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+각도까지.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+전체 도형.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/tp/_index.md
+++ b/korean/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Aspose.Diagram for Java API 참조
+description: 탭 속성 실행의 시작을 지정합니다.
+type: docs
+weight: 411
+url: /ko/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+탭 속성 실행의 시작을 지정합니다. 실행은 텍스트 끝까지 또는 다음까지 정의됩니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | 생성자 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+생성자
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| IX | int | 부모 요소 내에서 해당 요소의 0부터 시작하는 인덱스. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/txt/_index.md
+++ b/korean/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Txt
+second_title: Aspose.Diagram for Java API 참조
+description: 도형의 텍스트
+type: docs
+weight: 412
+url: /ko/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+도형의 텍스트
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | 생성자 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | 도형의 텍스트를 포함합니다. |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | 이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/txt\#getText--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+생성자
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 도형의 텍스트. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+도형의 텍스트를 포함합니다.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+이 속성에 대한 설명은 [getText()](../../com.aspose.diagram/txt\#getText--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typeconnection/_index.md
+++ b/korean/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Aspose.Diagram for Java API 참조
+description: 포함된 요소를 기반으로 다양한 유형을 지정합니다.
+type: docs
+weight: 413
+url: /ko/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+포함된 요소에 따라 다양한 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 포함된 요소에 따라 다양한 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+포함된 요소에 따라 다양한 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/korean/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Aspose.Diagram for Java API 참조
+description: 포함된 요소를 기반으로 다양한 유형을 지정합니다.
+type: docs
+weight: 414
+url: /ko/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+포함된 요소에 따라 다양한 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [INWARD](#INWARD) | Inward. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Inward and outward. |
+| [OUTWARD](#OUTWARD) | Outward. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Inward.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Inward and outward.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Outward.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typefield/_index.md
+++ b/korean/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Aspose.Diagram for Java API 참조
+description: Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+type: docs
+weight: 415
+url: /ko/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | Type은 텍스트 필드 값의 데이터 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typefield\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typefield\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/korean/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Aspose.Diagram for Java API 참조
+description: Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+type: docs
+weight: 416
+url: /ko/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Type은 텍스트 필드 값의 데이터 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | 통화 값. |
+| [DATE_TIME](#DATE-TIME) | 날짜 또는 시간 값. |
+| [DURATION](#DURATION) | 기간 값. |
+| [NUMBER](#NUMBER) | 숫자. |
+| [STRING](#STRING) | 문자열. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+통화 값입니다. 시스템의 현재 지역 설정을 사용합니다.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+날짜 또는 시간 값. 일, 월, 연도 또는 초, 분, 시, 혹은 결합된 날짜와 시간 값을 표시합니다.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+기간 값. 경과 시간을 표시합니다.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+숫자. 날짜, 시간, 기간 및 통화 값과 스칼라, 차원, 각도를 포함합니다.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+문자열.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typeprop/_index.md
+++ b/korean/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Aspose.Diagram for Java API 참조
+description: Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+type: docs
+weight: 417
+url: /ko/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typeprop\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/typeprop\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/korean/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Aspose.Diagram for Java API 참조
+description: Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+type: docs
+weight: 418
+url: /ko/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Type은 사용자 지정 속성 값의 데이터 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | 불리언. |
+| [CURRENCY](#CURRENCY) | 통화 값. |
+| [DATE_TIME](#DATE-TIME) | 날짜 또는 시간 값. |
+| [DURATION](#DURATION) | 기간 값. |
+| [FIXED_LIST](#FIXED-LIST) | 고정 목록. |
+| [NUMBER](#NUMBER) | 숫자. |
+| [STRING](#STRING) | 문자열. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | 변수 목록. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Boolean. Visio 애플리케이션의 사용자 지정 속성 대화 상자에서 드롭다운 목록 상자에서 사용자가 선택할 수 있는 항목으로 FALSE와 TRUE를 표시합니다.
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+통화 값. 시스템의 현재 지역 설정을 사용합니다.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+날짜 또는 시간 값. 일, 월, 연도 또는 초, 분, 시, 혹은 결합된 날짜와 시간 값을 표시합니다.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+기간 값. 경과 시간을 표시합니다.
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+고정 목록. 사용자 지정 속성 대화 상자의 드롭다운 콤보 박스에 목록 항목을 표시합니다.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+숫자. 날짜, 시간, 기간 및 통화 값과 스칼라, 차원, 각도를 포함합니다.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+문자열. 이것이 기본값입니다.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+변수 목록. Visio의 사용자 지정 속성 대화 상자에서 드롭다운 콤보 박스에 목록 항목을 표시합니다. 사용자는 목록 항목을 선택하거나 새 항목을 입력하여 Format 요소의 현재 목록에 추가할 수 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/typevalue/_index.md
+++ b/korean/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: 선택적 열거형.
+type: docs
+weight: 419
+url: /ko/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+선택적 열거형. 도형의 유형입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | 외부. |
+| [GROUP](#GROUP) | 그룹. |
+| [GUIDE](#GUIDE) | 가이드. |
+| [SHAPE](#SHAPE) | 도형. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+외부.
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+그룹.
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+가이드.
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+도형.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/uivisibility/_index.md
+++ b/korean/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Aspose.Diagram for Java API 참조
+description: 탭 정렬을 지정합니다.
+type: docs
+weight: 420
+url: /ko/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+탭 정렬을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | uivisibility를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+uivisibility를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/korean/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Aspose.Diagram for Java API 참조
+description: 탭 정렬을 지정합니다.
+type: docs
+weight: 421
+url: /ko/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+탭 정렬을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | 숨김. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VISIBLE](#VISIBLE) | 보임 . |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+숨김.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+보임 .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/korean/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Aspose.Diagram for Java API 참조
+description: 요소의 속성을 지정합니다.
+type: docs
+weight: 422
+url: /ko/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+요소의 속성을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | 생성자. |
+| [UnitFormulaErr()](#UnitFormulaErr--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | 수식이 오류로 평가됨을 나타냅니다. |
+| [getF()](#getF--) | 요소의 수식을 나타냅니다. |
+| [getUnit()](#getUnit--) | 측정 단위. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | 이 속성에 대한 설명은 [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)을(를) 참조하십시오. |
+| [setF(String value)](#setF-java.lang.String-) | 이 속성에 대한 설명은 [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)을(를) 참조하십시오. |
+| [setUnit(int value)](#setUnit-int-) | 이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 단위 | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+수식이 오류로 평가됨을 나타냅니다.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+요소의 수식을 나타냅니다.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+측정 단위.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+이 속성에 대한 설명은 [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+이 속성에 대한 설명은 [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/korean/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Aspose.Diagram for Java API 참조
+description: 요소의 지정된 속성.
+type: docs
+weight: 423
+url: /ko/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+요소의 지정된 속성.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | 수식이 오류로 평가됨을 나타냅니다. |
+| [getF()](#getF--) | 요소의 수식을 나타냅니다. |
+| [getUnit()](#getUnit--) | 측정 단위. |
+| [getV()](#getV--) | 문자열 셀 값에 대한 null 문자열 조건을 나타냅니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | 이 속성에 대한 설명은 [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)을(를) 참조하십시오. |
+| [setF(String value)](#setF-java.lang.String-) | 이 속성에 대한 설명은 [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)을(를) 참조하십시오. |
+| [setUnit(int value)](#setUnit-int-) | 이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)을(를) 참조하십시오. |
+| [setV(String value)](#setV-java.lang.String-) | 이 속성에 대한 설명은 [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 단위 | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+수식이 오류로 평가됨을 나타냅니다.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+요소의 수식을 나타냅니다.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+측정 단위.
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+문자열 셀 값에 대한 null 문자열 조건을 나타냅니다. 경우에 따라 빈 문자열 셀 null과 null 문자열 셀 값을 구분하는 것이 도움이 될 수 있습니다. 이 속성은 이러한 빈 값 형태를 구분하는 데 사용됩니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+이 속성에 대한 설명은 [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+이 속성에 대한 설명은 [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+이 속성에 대한 설명은 [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+이 속성에 대한 설명은 [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/korean/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Aspose.Diagram for Java API 참조
+description: 알 수 없는 컨트롤.
+type: docs
+weight: 424
+url: /ko/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+알 수 없는 컨트롤.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | the ole color of the background. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | the binary data of the control. |
+| [getForeOleColor()](#getForeOleColor--) | the ole color of the foreground. |
+| [getHeight()](#getHeight--) | the height of the control in unit of points. |
+| [getIMEMode()](#getIMEMode--) | the default run-time mode of the Input Method Editor for the control as it receives focus. |
+| [getMouseIcon()](#getMouseIcon--) | 컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘. |
+| [getMousePointer()](#getMousePointer--) | 컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형. |
+| [getPersistenceType()](#getPersistenceType--) | ActiveX 컨트롤을 지속시키기 위한 지속성 방법을 가져옵니다. |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | 관계 데이터를 가져옵니다. |
+| [getType()](#getType--) | ActiveX 컨트롤의 유형을 가져옵니다. |
+| [getWidth()](#getWidth--) | 포인트 단위의 컨트롤 너비. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | 컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다. |
+| [isEnabled()](#isEnabled--) | 컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다. |
+| [isLocked()](#isLocked--) | 컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다. |
+| [isTransparent()](#isTransparent--) | 컨트롤이 투명한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | 이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오 |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | 이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오 |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | 이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오. |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | 이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오. |
+| [setHeight(double value)](#setHeight-double-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오. |
+| [setIMEMode(int value)](#setIMEMode-int-) | 이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오. |
+| [setLocked(boolean value)](#setLocked-boolean-) | 이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오. |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | 이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오. |
+| [setMousePointer(int value)](#setMousePointer-int-) | 이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오. |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | 이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오. |
+| [setWidth(double value)](#setWidth-double-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+the ole color of the background.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+the binary data of the control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+전경의 OLE 색상입니다. Image 컨트롤에는 적용되지 않습니다.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+the height of the control in unit of points.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+the default run-time mode of the Input Method Editor for the control as it receives focus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시할 사용자 지정 아이콘.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+컨트롤에 대한 마우스 포인터로 표시되는 아이콘 유형.
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+ActiveX 컨트롤을 지속시키기 위한 지속성 방법을 가져옵니다.
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+관계 데이터를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| relId | java.lang.String | 관계 ID입니다. |
+
+**Returns:**
+byte[] - 관계 데이터를 반환합니다.
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+ActiveX 컨트롤의 유형을 가져옵니다.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+포인트 단위의 컨트롤 너비.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+컨트롤이 전체 내용을 표시하도록 자동으로 크기를 조정하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+컨트롤이 포커스를 받을 수 있고 사용자 생성 이벤트에 응답할 수 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+컨트롤의 데이터가 편집을 위해 잠겨 있는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+컨트롤이 투명한지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)을 참조하십시오
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+이 속성에 대한 설명은 [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+이 속성에 대한 설명은 [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+이 속성에 대한 설명은 [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+이 속성에 대한 설명은 [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+이 속성에 대한 설명은 [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/user/_index.md
+++ b/korean/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: User
+second_title: Aspose.Diagram for Java API 참조
+description: 다른 요소와 추가 도구에서 참조하는 사용자 지정 요소에 수식을 입력하기 위한 작업 영역을 포함합니다.
+type: docs
+weight: 425
+url: /ko/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+다른 요소와 추가 도구에서 참조하는 사용자 지정 요소에 수식을 입력하기 위한 작업 영역을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [User()](#User--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getName()](#getName--) | 요소의 이름입니다. |
+| [getNameU()](#getNameU--) | 요소의 보편적인 이름입니다. |
+| [getPrompt()](#getPrompt--) | 사용자 정의 요소에 대한 설명 프롬프트 또는 주석을 지정합니다. |
+| [getValue()](#getValue--) | 명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/user\#getDel--)을(를) 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/user\#getID--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/user\#getName--)을(를) 참조하십시오. |
+| [setNameU(String value)](#setNameU-java.lang.String-) | 이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/user\#getNameU--)을(를) 참조하십시오. |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | 이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)을(를) 참조하십시오. |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/user\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+생성자.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소의 이름입니다.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+요소의 보편적인 이름입니다.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+사용자 정의 요소에 대한 설명 프롬프트 또는 주석을 지정합니다.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/user\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/user\#getID--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/user\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+이 속성에 대한 설명은 [getNameU()](../../com.aspose.diagram/user\#getNameU--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+이 속성에 대한 설명은 [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/user\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/usercollection/_index.md
+++ b/korean/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 사용자 컬렉션.
+type: docs
+weight: 426
+url: /ko/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+사용자 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | 컬렉션에 User 객체를 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [getUser(int ID)](#getUser-int-) | Gets the element at the specified ID. |
+| [getUser(String name)](#getUser-java.lang.String-) | Gets the element at the specified ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | 컬렉션에서 User 객체를 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+컬렉션에 User 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+Gets the element at the specified ID.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+컬렉션에서 User 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/validation/_index.md
+++ b/korean/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: Validation
+second_title: Aspose.Diagram for Java API 참조
+description: 문서에 대한 다이어그램 검증 정보를 저장합니다.
+type: docs
+weight: 427
+url: /ko/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+문서에 대한 다이어그램 검증 정보를 저장합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | Contains all the Issue elements for the document. |
+| [getRuleSets()](#getRuleSets--) | Includes a RuleSet element for each validation rule set in the document. |
+| [getValidationProperties()](#getValidationProperties--) | 문서 검증과 관련된 속성을 캡슐화합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+Contains all the Issue elements for the document.
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+Includes a RuleSet element for each validation rule set in the document.
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+문서 검증과 관련된 속성을 캡슐화합니다.
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/validationproperties/_index.md
+++ b/korean/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Aspose.Diagram for Java API 참조
+description: 문서 검증과 관련된 속성을 캡슐화합니다.
+type: docs
+weight: 428
+url: /ko/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+문서 검증과 관련된 속성을 캡슐화합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | 문서가 마지막으로 검증된 날짜와 시간 |
+| [getShowIgnored()](#getShowIgnored--) | Issues 창에 무시된 검증 문제를 표시할지 여부. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | 이 속성에 대한 설명은 [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)을(를) 참조하십시오. |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | 이 속성에 대한 설명은 [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+문서가 마지막으로 검증된 날짜와 시간
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Issues 창에 무시된 검증 문제를 표시할지 여부.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+이 속성에 대한 설명은 [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/value/_index.md
+++ b/korean/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: Value
+second_title: Aspose.Diagram for Java API 참조
+description: 값.
+type: docs
+weight: 429
+url: /ko/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+값.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | 명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다. |
+| [getUfev()](#getUfev--) | 요소의 지정된 속성. |
+| [getVal()](#getVal--) | 텍스트 값 |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | 이 속성에 대한 설명은 [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)을(를) 참조하십시오. |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | 이 속성에 대한 설명은 [getUfev()](../../com.aspose.diagram/value\#getUfev--)을(를) 참조하십시오. |
+| [setVal(String value)](#setVal-java.lang.String-) | 이 속성에 대한 설명은 [getVal()](../../com.aspose.diagram/value\#getVal--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+명시적 네임스페이스에 접두사가 붙은 솔루션별 잘 형성된 XML 데이터를 포함하며 문서와 함께 저장됩니다.
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+요소의 지정된 속성.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+텍스트 값
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+이 속성에 대한 설명은 [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+이 속성에 대한 설명은 [getUfev()](../../com.aspose.diagram/value\#getUfev--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+이 속성에 대한 설명은 [getVal()](../../com.aspose.diagram/value\#getVal--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbamodule/_index.md
+++ b/korean/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 프로젝트에 포함된 모듈을 나타냅니다.
+type: docs
+weight: 430
+url: /ko/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+VBA 프로젝트에 포함된 모듈을 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | 모듈의 코드. |
+| [getName()](#getName--) | 모듈의 이름. |
+| [getType()](#getType--) | 모듈의 유형을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | 이 속성에 대한 설명은 [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbamodule\#getName--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+모듈의 코드.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+모듈의 이름.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+모듈의 유형을 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+이 속성에 대한 설명은 [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbamodule\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/korean/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 다음 목록을 나타냅니다.
+type: docs
+weight: 431
+url: /ko/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+다음 목록을 나타냅니다: [VbaModule](../../com.aspose.diagram/vbamodule)
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | 페이지용 모듈을 추가합니다. |
+| [add(int type, String name)](#add-int-java.lang.String-) | 모듈을 추가합니다. |
+| [add(Object o)](#add-java.lang.Object-) | CollectionBase 인스턴스에 항목을 추가합니다. |
+| [clear()](#clear--) | CollectionBase 인스턴스에서 모든 객체를 제거합니다. |
+| [contains(Object o)](#contains-java.lang.Object-) | 인스턴스가 이 객체를 포함하는지 여부를 반환합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 인덱스로 목록에서 [VbaModule](../../com.aspose.diagram/vbamodule)을 가져옵니다. |
+| [get(String name)](#get-java.lang.String-) | 이름으로 목록에서 [VbaModule](../../com.aspose.diagram/vbamodule)을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+| [iterator()](#iterator--) | CollectionBase 인스턴스를 순회하는 열거자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | 페이지의 모듈을 제거합니다. |
+| [remove(String name)](#remove-java.lang.String-) | 이름으로 모듈을 제거합니다 |
+| [removeAt(int index)](#removeAt-int-) | 지정된 인덱스에 있는 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+페이지용 모듈을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | 페이지 |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+모듈을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 유형 | int | 모듈의 유형입니다. |
+| name | java.lang.String | 모듈의 이름입니다. |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+CollectionBase 인스턴스에 항목을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에 추가할 객체입니다. |
+
+**Returns:**
+int - 새 요소가 삽입된 위치입니다.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+CollectionBase 인스턴스에서 모든 객체를 제거합니다.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+인스턴스가 이 객체를 포함하는지 여부를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | 테스트 객체 |
+
+**Returns:**
+boolean - 인스턴스가 이 객체를 포함하는지 여부
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+인덱스로 목록에서 [VbaModule](../../com.aspose.diagram/vbamodule)을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 인덱스. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+이름으로 목록에서 [VbaModule](../../com.aspose.diagram/vbamodule)을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String | 모듈의 이름입니다. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int - CollectionBase 인스턴스에 포함된 요소 수.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+
+**Returns:**
+int - 리스트에서 값을 찾은 경우 해당 인덱스; 찾지 못하면 -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+CollectionBase 인스턴스를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+java.util.Iterator - CollectionBase 인스턴스용 반복자.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+페이지의 모듈을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | 페이지 |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+이름으로 모듈을 제거합니다
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+지정된 인덱스에 있는 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 제거할 항목의 0부터 시작하는 인덱스. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/korean/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 모듈 유형을 나타냅니다.
+type: docs
+weight: 432
+url: /ko/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+VBA 모듈 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CLASS](#CLASS) | 클래스 모듈을 나타냅니다. |
+| [DESIGNER](#DESIGNER) | 디자이너 모듈을 나타냅니다. |
+| [DOCUMENT](#DOCUMENT) | 문서 모듈을 나타냅니다. |
+| [PROCEDURAL](#PROCEDURAL) | 절차적 모듈을 나타냅니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+클래스 모듈을 나타냅니다.
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+디자이너 모듈을 나타냅니다.
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+문서 모듈을 나타냅니다.
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+절차적 모듈을 나타냅니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbaproject/_index.md
+++ b/korean/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 프로젝트를 나타냅니다.
+type: docs
+weight: 433
+url: /ko/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+VBA 프로젝트를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | 모든 [VbaModule](../../com.aspose.diagram/vbamodule) 객체를 가져옵니다. |
+| [getName()](#getName--) | VBA 프로젝트의 이름. |
+| [getReferences()](#getReferences--) | VBA 프로젝트의 모든 참조를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | VBAcode가 서명되었는지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbaproject\#getName--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+모든 [VbaModule](../../com.aspose.diagram/vbamodule) 객체를 가져옵니다.
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+VBA 프로젝트의 이름.
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+VBA 프로젝트의 모든 참조를 가져옵니다.
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+VBAcode가 서명되었는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbaproject\#getName--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/korean/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 프로젝트의 참조를 나타냅니다.
+type: docs
+weight: 434
+url: /ko/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+VBA 프로젝트의 참조를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | 참조의 확장된 Libid. |
+| [getLibid()](#getLibid--) | 참조의 Libid. |
+| [getName()](#getName--) | 참조의 이름. |
+| [getRelativeLibid()](#getRelativeLibid--) | 상대 경로가 있는 참조된 VBA 프로젝트\\u9225\\u6a9a 식별자. |
+| [getTwiddledlibid()](#getTwiddledlibid--) | 참조의 변형된 Libid. |
+| [getType()](#getType--) | 이 참조의 유형을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | 이 속성에 대한 설명은 [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)을(를) 참조하십시오. |
+| [setLibid(String value)](#setLibid-java.lang.String-) | 이 속성에 대한 설명은 [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)을(를) 참조하십시오. |
+| [setName(String value)](#setName-java.lang.String-) | 이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)을(를) 참조하십시오. |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | 이 속성에 대한 설명은 [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)을(를) 참조하십시오. |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | 이 속성에 대한 설명은 [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+참조의 확장된 Libid. 제어 참조에만 해당됩니다.
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+참조의 Libid.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+참조의 이름.
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+상대 경로가 있는 참조된 VBA 프로젝트\\u9225\\u6a9a 식별자. 프로젝트 참조에만 해당됩니다.
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+참조의 변형된 Libid. 제어 참조에만 해당됩니다.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+이 참조의 유형을 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+이 속성에 대한 설명은 [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+이 속성에 대한 설명은 [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+이 속성에 대한 설명은 [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+이 속성에 대한 설명은 [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+이 속성에 대한 설명은 [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/korean/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 프로젝트의 모든 참조를 나타냅니다.
+type: docs
+weight: 435
+url: /ko/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+VBA 프로젝트의 모든 참조를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | CollectionBase 인스턴스에 항목을 추가합니다. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | twiddled 타입 라이브러리와 해당 확장 타입 라이브러리에 대한 참조를 추가합니다. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | 외부 VBA 프로젝트에 대한 참조를 추가합니다. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Automation 타입 라이브러리에 대한 참조를 추가합니다. |
+| [clear()](#clear--) | CollectionBase 인스턴스에서 모든 객체를 제거합니다. |
+| [contains(Object o)](#contains-java.lang.Object-) | 인스턴스가 이 객체를 포함하는지 여부를 반환합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스로 목록에서 참조를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+| [iterator()](#iterator--) | CollectionBase 인스턴스를 순회하는 열거자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | 지정된 인덱스에 있는 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+CollectionBase 인스턴스에 항목을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에 추가할 객체입니다. |
+
+**Returns:**
+int - 새 요소가 삽입된 위치입니다.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+twiddled 타입 라이브러리와 해당 확장 타입 라이브러리에 대한 참조를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String | 참조의 이름. |
+| libid | java.lang.String | Automation 타입 라이브러리의 식별자. |
+| twiddledlibid | java.lang.String | twiddled 타입 라이브러리의 식별자 |
+| extendedLibid | java.lang.String | 확장된 타입 라이브러리의 식별자 |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+외부 VBA 프로젝트에 대한 참조를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String | 참조의 이름. |
+| absoluteLibid | java.lang.String | 절대 경로를 가진 참조된 VBA 프로젝트\u9225\u6a9a 식별자. |
+| relativeLibid | java.lang.String | 상대 경로를 가진 참조된 VBA 프로젝트\u9225\u6a9a 식별자. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Automation 타입 라이브러리에 대한 참조를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| name | java.lang.String | 참조의 이름. |
+| libid | java.lang.String | Automation 타입 라이브러리의 식별자. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+CollectionBase 인스턴스에서 모든 객체를 제거합니다.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+인스턴스가 이 객체를 포함하는지 여부를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | 테스트 객체 |
+
+**Returns:**
+boolean - 인스턴스가 이 객체를 포함하는지 여부
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+인덱스로 목록에서 참조를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| i | int | 인덱스. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+CollectionBase 인스턴스에 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int - CollectionBase 인스턴스에 포함된 요소 수.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| o | java.lang.Object | CollectionBase 인스턴스에서 특정 항목의 인덱스를 결정합니다. |
+
+**Returns:**
+int - 리스트에서 값을 찾은 경우 해당 인덱스; 찾지 못하면 -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+CollectionBase 인스턴스를 순회하는 열거자를 반환합니다.
+
+**Returns:**
+java.util.Iterator - CollectionBase 인스턴스용 반복자.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+지정된 인덱스에 있는 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 제거할 항목의 0부터 시작하는 인덱스. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/korean/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Aspose.Diagram for Java API 참조
+description: VBA 프로젝트 참조 유형을 나타냅니다.
+type: docs
+weight: 436
+url: /ko/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+VBA 프로젝트 참조 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CONTROL](#CONTROL) | twiddled 타입 라이브러리와 해당 확장 타입 라이브러리에 대한 참조를 지정합니다. |
+| [PROJECT](#PROJECT) | 외부 VBA 프로젝트에 대한 참조를 지정합니다. |
+| [REGISTERED](#REGISTERED) | Automation 타입 라이브러리에 대한 참조를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+twiddled 타입 라이브러리와 해당 확장 타입 라이브러리에 대한 참조를 지정합니다.
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+외부 VBA 프로젝트에 대한 참조를 지정합니다.
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Automation 타입 라이브러리에 대한 참조를 지정합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/verticalalign/_index.md
+++ b/korean/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+type: docs
+weight: 437
+url: /ko/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | 이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)을(를) 참조하십시오. |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+이 속성에 대한 설명은 [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/korean/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Aspose.Diagram for Java API 참조
+description: 텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+type: docs
+weight: 438
+url: /ko/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+텍스트 블록 내 텍스트의 수직 정렬을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | 아래. |
+| [MIDDLE](#MIDDLE) | 가운데. |
+| [TOP](#TOP) | 상단. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+아래.
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+가운데.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+상단.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/korean/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Aspose.Diagram for Java API 참조
+description: ValidationRule.TargetType 속성에 전달되고 반환되는 검증 규칙의 대상을 정의하는 내용을 지정합니다.
+type: docs
+weight: 439
+url: /ko/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+검증 규칙의 대상을 정의하는 내용을 지정합니다; ValidationRule.TargetType 속성에 전달되고 반환됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | 이 규칙은 문서의 도형에 적용됩니다. |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | 이 규칙은 문서의 페이지에 적용됩니다. |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | 이 규칙은 문서 자체에 적용됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+이 규칙은 문서의 도형에 적용됩니다.
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+이 규칙은 문서의 페이지에 적용됩니다.
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+이 규칙은 문서 자체에 적용됩니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/walkpreference/_index.md
+++ b/korean/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Aspose.Diagram for Java API 참조
+description: 도형이 모호한 위치로 이동될 때 동적 접착을 사용하여 도형에 붙어 있는 수평 또는 수직 연결점으로 1차원 도형의 끝점이 이동하는지를 지정합니다.
+type: docs
+weight: 440
+url: /ko/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | 동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/korean/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Aspose.Diagram for Java API 참조
+description: 도형이 모호한 위치로 이동될 때 동적 접착을 사용하여 도형에 붙어 있는 수평 또는 수직 연결점으로 1차원 도형의 끝점이 이동하는지를 지정합니다.
+type: docs
+weight: 441
+url: /ko/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+동적 접착을 사용하여 도형이 모호한 위치로 이동할 때 1차원 도형의 끝점이 붙어 있는 도형의 수평 또는 수직 연결 지점으로 이동하는지를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | 기본값. |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | 1차원 도형의 시작점이 수평 연결 지점으로 이동하고, 끝점은 수직 연결 지점으로 이동합니다(측면-위쪽 또는 측면-아래쪽 연결). |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | 1차원 도형의 양쪽 끝점이 수직 연결 지점으로 이동합니다(위쪽-아래쪽 연결). |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | 1차원 도형의 시작점이 수직 연결 지점으로 이동하고, 끝점은 수평 연결 지점으로 이동합니다(위쪽-측면 또는 아래쪽-측면 연결). |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+기본값. 1차원 도형의 양쪽 끝점이 수평 연결 지점으로 이동합니다(측면-측면 연결).
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+1차원 도형의 시작점이 수평 연결 지점으로 이동하고, 끝점은 수직 연결 지점으로 이동합니다(측면-위쪽 또는 측면-아래쪽 연결).
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+1차원 도형의 양쪽 끝점이 수직 연결 지점으로 이동합니다(위쪽-아래쪽 연결).
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+1차원 도형의 시작점이 수직 연결 지점으로 이동하고, 끝점은 수평 연결 지점으로 이동합니다(위쪽-측면 또는 아래쪽-측면 연결).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/warninginfo/_index.md
+++ b/korean/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Aspose.Diagram for Java API 참조
+description: 경고 정보
+type: docs
+weight: 442
+url: /ko/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+경고 정보
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | 경고 정보를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | 경고 정보의 설명을 가져옵니다. |
+| [getWarningType()](#getWarningType--) | 경고 유형을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+경고 정보를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| warningType | int | 경고 유형 |
+| 설명 | java.lang.String | 경고 설명 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+경고 정보의 설명을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+경고 유형을 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/warningtype/_index.md
+++ b/korean/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: WarningType
+second_title: Aspose.Diagram for Java API 참조
+description: WarningType
+type: docs
+weight: 443
+url: /ko/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+WarningType
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | 폰트를 찾을 수 없을 때 발생하는 폰트 대체 경고 유형이며, 이 경고 유형을 가져올 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+폰트를 찾을 수 없을 때 발생하는 폰트 대체 경고 유형이며, 이 경고 유형을 가져올 수 있습니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/window/_index.md
+++ b/korean/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: 창
+second_title: Aspose.Diagram for Java API 참조
+description: Microsoft Visio 인스턴스에서 열린 창을 나타냅니다.
+type: docs
+weight: 444
+url: /ko/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Microsoft Visio 인스턴스에서 열려 있는 창을 나타냅니다. 이 요소는 DatadiagramML 파일이 Visio에 처음 열릴 때 애플리케이션 작업 영역에 사용자 인터페이스 창을 정확히 재생성하는 데 필요한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Window()](#Window--) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | 컨테이너 ID: 페이지, 시트 또는 마스터. |
+| [getContainerType()](#getContainerType--) | 다음 값 중 하나일 수 있습니다: Document, Page, 또는 Master. |
+| [getDocument()](#getDocument--) | 이 창에 표시되는 문서의 파일 경로. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | 문서 또는 창에 대해 동적 그리드 기능이 활성화되어 있는지 지정합니다. |
+| [getGlueSettings()](#getGlueSettings--) | 문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다. |
+| [getID()](#getID--) | 부모 요소 내에서 해당 요소의 고유 ID입니다. |
+| [getMaster()](#getMaster--) | 이 창이 마스터를 표시하는 경우 마스터 ID. |
+| [getPage()](#getPage--) | 이 창이 페이지를 표시하는 경우 페이지 ID. |
+| [getParentWindow()](#getParentWindow--) | 이 스텐실 창이 포함된 창의 ID. |
+| [getReadOnly()](#getReadOnly--) | 이 스텐실이 문서 스텐실이 아닌 경우 읽기 전용 플래그. |
+| [getSheet()](#getSheet--) | 컨테이너 내 시트 ID. |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | 창에 연결 지점이 표시되는지 여부를 지정합니다. |
+| [getShowGrid()](#getShowGrid--) | 그리기 창에 격자가 표시되는지 여부를 지정합니다. |
+| [getShowGuides()](#getShowGuides--) | 그리기 창에 가이드가 표시되는지 여부를 지정합니다. |
+| [getShowPageBreaks()](#getShowPageBreaks--) | 창에 페이지 구분이 표시되는지 여부를 지정합니다. |
+| [getShowRulers()](#getShowRulers--) | 그리기 창에 눈금자가 표시되는지 여부를 지정합니다. |
+| [getSnapAngles()](#getSnapAngles--) | SnapAngle 요소들의 컬렉션을 포함합니다. |
+| [getSnapExtensions()](#getSnapExtensions--) | 활성 창에 대해 특정 스냅 확장 설정이 활성화되었는지 비활성화되었는지 지정합니다. |
+| [getSnapSettings()](#getSnapSettings--) | 창에서 스냅이 활성화될 때 도형이 스냅되는 객체를 지정합니다. |
+| [getStencilGroup()](#getStencilGroup--) | 창이 속한 병합된 스텐실 창 그룹을 지정합니다. |
+| [getStencilGroupPos()](#getStencilGroupPos--) | 창 내 그룹에서 스텐실의 상대 위치를 지정하는 정수를 포함합니다. |
+| [getTabSplitterPos()](#getTabSplitterPos--) | 그리기 창의 페이지 탭 컨트롤 너비를 지정합니다(그리기 창 전체 너비에 대한 비율). |
+| [getViewCenterX()](#getViewCenterX--) | 선택적 double. |
+| [getViewCenterY()](#getViewCenterY--) | 선택적 double. |
+| [getViewScale()](#getViewScale--) | 선택적 double. |
+| [getWindowHeight()](#getWindowHeight--) | 창 사각형의 높이. |
+| [getWindowLeft()](#getWindowLeft--) | 창 사각형의 왼쪽 좌표. |
+| [getWindowState()](#getWindowState--) | 이 속성은 다음 값들의 합계가 될 수 있습니다. |
+| [getWindowTop()](#getWindowTop--) | 창 사각형의 상단 좌표. |
+| [getWindowType()](#getWindowType--) | 다음 중 하나일 수 있는 열거형 값: Drawing, Sheet, Stencil 또는 Icon. WindowType='Stencil'인 Window 요소는 부모 그리기 창(WindowType='Drawing') 뒤에, 다른 그리기 창 요소들 앞에 나타나야 합니다. |
+| [getWindowWidth()](#getWindowWidth--) | 창 사각형의 너비. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | 이 속성에 대한 설명은 [getContainer()](../../com.aspose.diagram/window\#getContainer--)을(를) 참조하십시오. |
+| [setContainerType(int value)](#setContainerType-int-) | 이 속성에 대한 설명은 [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)을(를) 참조하십시오. |
+| [setDocument(String value)](#setDocument-java.lang.String-) | 이 속성에 대한 설명은 [getDocument()](../../com.aspose.diagram/window\#getDocument--) 를 참조하십시오. |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | 이 속성에 대한 설명은 [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) 를 참조하십시오. |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | 이 속성에 대한 설명은 [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) 를 참조하십시오. |
+| [setID(int value)](#setID-int-) | 이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/window\#getID--) 를 참조하십시오. |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | 이 속성에 대한 설명은 [getMaster()](../../com.aspose.diagram/window\#getMaster--) 를 참조하십시오. |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | 이 속성에 대한 설명은 [getPage()](../../com.aspose.diagram/window\#getPage--) 를 참조하십시오. |
+| [setParentWindow(int value)](#setParentWindow-int-) | 이 속성에 대한 설명은 [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) 를 참조하십시오. |
+| [setReadOnly(int value)](#setReadOnly-int-) | 이 속성에 대한 설명은 [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) 를 참조하십시오. |
+| [setSheet(int value)](#setSheet-int-) | 이 속성에 대한 설명은 [getSheet()](../../com.aspose.diagram/window\#getSheet--) 를 참조하십시오. |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | 이 속성에 대한 설명은 [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) 를 참조하십시오. |
+| [setShowGrid(int value)](#setShowGrid-int-) | 이 속성에 대한 설명은 [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) 를 참조하십시오. |
+| [setShowGuides(int value)](#setShowGuides-int-) | 이 속성에 대한 설명은 [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) 를 참조하십시오. |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | 이 속성에 대한 설명은 [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) 를 참조하십시오. |
+| [setShowRulers(int value)](#setShowRulers-int-) | 이 속성에 대한 설명은 [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) 를 참조하십시오. |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | 이 속성에 대한 설명은 [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) 를 참조하십시오. |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | 이 속성에 대한 설명은 [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) 를 참조하십시오. |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | 이 속성에 대한 설명은 [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) 를 참조하십시오. |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | 이 속성에 대한 설명은 [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) 를 참조하십시오. |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | 이 속성에 대한 설명은 [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) 를 참조하십시오. |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | 이 속성에 대한 설명은 [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) 를 참조하십시오. |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | 이 속성에 대한 설명은 [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) 를 참조하십시오. |
+| [setViewScale(double value)](#setViewScale-double-) | 이 속성에 대한 설명은 [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) 를 참조하십시오. |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | 이 속성에 대한 설명은 [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) 를 참조하십시오. |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | 이 속성에 대한 설명은 [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) 를 참조하십시오. |
+| [setWindowState(int value)](#setWindowState-int-) | 이 속성에 대한 설명은 [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) 를 참조하십시오. |
+| [setWindowTop(int value)](#setWindowTop-int-) | 이 속성에 대한 설명은 [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)을(를) 참조하십시오. |
+| [setWindowType(int value)](#setWindowType-int-) | 이 속성에 대한 설명은 [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)을(를) 참조하십시오. |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | 이 속성에 대한 설명은 [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+생성자.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+컨테이너 ID: 페이지, 시트 또는 마스터. ContainerType이 지정된 경우에만 관련 있고 필요합니다.
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+다음 값 중 하나일 수 있습니다: Document, Page, 또는 Master. WindowType이 Drawing 또는 Sheet로 지정된 경우에만 해당됩니다.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+이 창에 표시되는 문서의 파일 경로입니다. 이 속성은 WindowType이 Stencil으로 지정된 창에 해당합니다.
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+문서 또는 창에 대해 동적 그리드 기능이 활성화되어 있는지 지정합니다.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+문서에서 접착이 활성화된 경우 도형이 접착되는 객체를 지정합니다.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+부모 요소 내에서 해당 요소의 고유 ID입니다.
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+이 창이 마스터를 표시하는 경우 마스터 ID.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+창이 페이지를 표시하는 경우 페이지 ID입니다. WindowType이 Drawing으로, ContainerType이 Page로 지정된 경우에만 해당합니다.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+이 스텐실 창이 포함된 창의 ID입니다. WindowType이 Stencil으로 지정된 경우에만 해당합니다.
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+이 스텐실이 문서 스텐실이 아닌 경우 읽기 전용 플래그.
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+컨테이너에 있는 시트의 ID입니다. Container가 Sheet로 지정된 경우에만 해당합니다.
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+창에 연결 지점이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+그리기 창에 격자가 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+그리기 창에 가이드가 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+창에 페이지 구분이 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+그리기 창에 눈금자가 표시되는지 여부를 지정합니다.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+SnapAngle 요소들의 컬렉션을 포함합니다.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+특정 스냅 확장 설정이 활성 창에 대해 활성화되었는지 비활성화되었는지를 지정합니다. 값은 다음 표에 있는 값들의 합이 될 수 있습니다.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+창에서 스냅이 활성화된 경우 도형이 맞추는 객체를 지정합니다. 값은 다음 표에 있는 값들의 합일 수 있습니다.
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+창이 속한 병합된 스텐실 창 그룹을 지정합니다. 이 속성은 WindowType 속성이 Stencil인 Window 요소에만 해당하며, 스텐실 창이 병합된 스텐실 창 그룹의 일부인 경우에만 적용됩니다. 동일한 병합 그룹에 속한 모든 스텐실 창은 동일한 StencilGroup 요소 값을 가집니다.
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+창 내 그룹에서 스텐실의 상대 위치를 지정하는 정수를 포함합니다.
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+그리기 창의 페이지 탭 컨트롤 너비를 지정합니다(그리기 창 전체 너비에 대한 비율).
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+선택적 double.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+선택적 double.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+선택적 double.
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+창 사각형의 높이.
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+창 사각형의 왼쪽 좌표.
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+이 속성은 다음 값들의 합계가 될 수 있습니다.
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+창 사각형의 상단 좌표.
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+다음 중 하나일 수 있는 열거형 값: Drawing, Sheet, Stencil 또는 Icon. WindowType='Stencil'인 Window 요소는 부모 그리기 창(WindowType='Drawing') 뒤에, 다른 그리기 창 요소들 앞에 나타나야 합니다.
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+창 사각형의 너비.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+이 속성에 대한 설명은 [getContainer()](../../com.aspose.diagram/window\#getContainer--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+이 속성에 대한 설명은 [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+이 속성에 대한 설명은 [getDocument()](../../com.aspose.diagram/window\#getDocument--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+이 속성에 대한 설명은 [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+이 속성에 대한 설명은 [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+이 속성에 대한 설명은 [getID()](../../com.aspose.diagram/window\#getID--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+이 속성에 대한 설명은 [getMaster()](../../com.aspose.diagram/window\#getMaster--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+이 속성에 대한 설명은 [getPage()](../../com.aspose.diagram/window\#getPage--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+이 속성에 대한 설명은 [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+이 속성에 대한 설명은 [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+이 속성에 대한 설명은 [getSheet()](../../com.aspose.diagram/window\#getSheet--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+이 속성에 대한 설명은 [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+이 속성에 대한 설명은 [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+이 속성에 대한 설명은 [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+이 속성에 대한 설명은 [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+이 속성에 대한 설명은 [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+이 속성에 대한 설명은 [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+이 속성에 대한 설명은 [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+이 속성에 대한 설명은 [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+이 속성에 대한 설명은 [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+이 속성에 대한 설명은 [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+이 속성에 대한 설명은 [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+이 속성에 대한 설명은 [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+이 속성에 대한 설명은 [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/windowcollection/_index.md
+++ b/korean/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Aspose.Diagram for Java API 참조
+description: 창 컬렉션.
+type: docs
+weight: 445
+url: /ko/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+창 컬렉션.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | 컬렉션에 창을 추가합니다. |
+| [clear()](#clear--) | 컬렉션에서 모든 요소를 제거합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | 지정된 인덱스의 요소를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | 선택적 int. |
+| [getClientWidth()](#getClientWidth--) | 선택적 int. |
+| [getCount()](#getCount--) | 컬렉션에 실제로 포함된 요소 수를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | 컬렉션에 항목이 존재합니다. |
+| [iterator()](#iterator--) | 비제네릭 컬렉션에 대한 간단한 반복을 지원합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | 컬렉션에서 창을 제거합니다. |
+| [setClientHeight(int value)](#setClientHeight-int-) | 이 속성에 대한 설명은 [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)을(를) 참조하십시오. |
+| [setClientWidth(int value)](#setClientWidth-int-) | 이 속성에 대한 설명은 [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+컬렉션에 창을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+컬렉션에서 모든 요소를 제거합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+지정된 인덱스의 요소를 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+선택적 int.
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+선택적 int.
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+컬렉션에 실제로 포함된 요소 수를 가져옵니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+컬렉션에 항목이 존재합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소의 인덱스. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+비제네릭 컬렉션에 대한 간단한 반복을 지원합니다.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+컬렉션에서 창을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+이 속성에 대한 설명은 [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+이 속성에 대한 설명은 [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/korean/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Aspose.Diagram for Java API 참조
+description: 비트 플래그를 지정하는 정수.
+type: docs
+weight: 446
+url: /ko/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+비트 플래그를 지정하는 정수입니다. 이 속성은 다음 값들의 합일 수 있습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | 활성화됨. |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | 아래쪽 고정. |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | 왼쪽 고정. |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | 병합된 앵커. |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | 오른쪽 고정. |
+| [ANCHOR_TOP](#ANCHOR-TOP) | 위쪽 고정. |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | 아래쪽 도킹. |
+| [DOCKED_LEFT](#DOCKED-LEFT) | 왼쪽 도킹. |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | 오른쪽 도킹. |
+| [DOCKED_TOP](#DOCKED-TOP) | 위쪽 도킹. |
+| [DOUBLEING](#DOUBLEING) | 두 배로 늘리기. |
+| [MAXIMIZED](#MAXIMIZED) | 최대화됨. |
+| [MINIMIZED](#MINIMIZED) | 최소화됨. |
+| [RESTORED](#RESTORED) | 복원됨. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+활성화됨.
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+아래쪽 고정.
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+왼쪽 고정.
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+병합된 앵커.
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+오른쪽 고정.
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+위쪽 고정.
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+아래쪽 도킹.
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+왼쪽 도킹.
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+오른쪽 도킹.
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+위쪽 도킹.
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+두 배로 늘리기.
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+최대화됨.
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+최소화됨.
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+복원됨.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/korean/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Aspose.Diagram for Java API 참조
+description: An enumerated value that may be one of the following Drawing Sheet Stencil or Icon.
+type: docs
+weight: 447
+url: /ko/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+An enumerated value that may be one of the following: Drawing, Sheet, Stencil, or Icon. A Window element of WindowType='Stencil' must appear after its parent drawing window (WindowType='Drawing') and before any other drawing window elements.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DRAWING](#DRAWING) | Drawing |
+| [ICON](#ICON) | Icon. |
+| [SHEET](#SHEET) | Sheet |
+| [STENCIL](#STENCIL) | Stencil. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Drawing
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Icon.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Sheet
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Stencil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 XAML로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+type: docs
+weight: 448
+url: /ko/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+다이어그램 페이지를 XAML로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | 이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getPageCount()](#getPageCount--) | XAML에서 렌더링할 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 첫 번째 페이지의 0 기반 인덱스. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 모든 페이지를 이미지로 저장할지, 전경만 저장할지 여부를 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. |
+| [getStreamProvider()](#getStreamProvider--) | 객체를 내보내기 위한 IStreamProvider. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)을(를) 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)을(를) 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)을(를) 참조하십시오. |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | 이 속성에 대한 설명은 [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)을(를) 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+XAML에서 렌더링할 페이지 수입니다. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 첫 번째 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+이미지에 모든 페이지를 저장할지 아니면 전경만 저장할지 지정합니다. true인 경우 전경 페이지만 렌더링됩니다(배경이 있으면 포함). false인 경우 전경 페이지가 렌더링된 뒤 빈 배경 페이지가 렌더링됩니다. PageCount가 1보다 클 때만 true를 반환할 수 있습니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat만 사용할 수 있습니다.
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+객체를 내보내기 위한 IStreamProvider.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+이 속성에 대한 설명은 [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xform/_index.md
+++ b/korean/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Aspose.Diagram for Java API 참조
+description: 패턴 두께 및 색상과 같은 도형의 선 속성을 제어하는 요소를 포함합니다.
+type: docs
+weight: 449
+url: /ko/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+모양의 선 속성을 제어하는 요소들을 포함합니다. 예를 들어 패턴, 두께, 색상 등이 있습니다. 이러한 요소들은 선 끝이 형식화되는지 여부(예: 화살표 머리), 선 끝 형식의 크기, 선에 적용되는 둥근 원의 반경, 그리고 선 캡 스타일(둥근 또는 사각)을 결정합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | 도형이 부모에 대해 현재 회전 각도를 나타냅니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getFlipX()](#getFlipX--) | 도형이 수평으로 뒤집혔는지 여부를 나타냅니다 |
+| [getFlipY()](#getFlipY--) | 도형이 수직으로 뒤집혔는지 여부를 나타냅니다. |
+| [getHeight()](#getHeight--) | 도형의 높이를 그리기 단위로 지정합니다. |
+| [getLocPinX()](#getLocPinX--) | 도형의 원점에 대한 도형 핀(회전 중심)의 x좌표를 지정합니다. |
+| [getLocPinY()](#getLocPinY--) | 도형의 원점에 대한 도형 핀(회전 중심)의 y좌표를 지정합니다. |
+| [getPinPos()](#getPinPos--) | 도형의 핀 위치를 지정합니다 |
+| [getPinX()](#getPinX--) | 부모의 원점에 대한 도형 핀(회전 중심)의 x좌표를 지정합니다. |
+| [getPinY()](#getPinY--) | 부모의 원점에 대한 도형 핀(회전 중심)의 y좌표를 지정합니다. |
+| [getResizeMode()](#getResizeMode--) | 그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다. |
+| [getWidth()](#getWidth--) | 연관된 도형의 너비를 그리기 단위로 포함합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getAngle()](../../com.aspose.diagram/xform\#getAngle--)을 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/xform\#getDel--)을 참조하십시오. |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)을 참조하십시오. |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | 이 속성에 대한 설명은 [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)을 참조하십시오. |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/xform\#getHeight--)을 참조하십시오. |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)을 참조하십시오. |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)을 참조하십시오. |
+| [setPinPos(int value)](#setPinPos-int-) | 이 속성에 대한 설명은 [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)을 참조하십시오. |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getPinX()](../../com.aspose.diagram/xform\#getPinX--)을 참조하십시오. |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getPinY()](../../com.aspose.diagram/xform\#getPinY--)을 참조하십시오. |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | 이 속성에 대한 설명은 [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)을 참조하십시오. |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/xform\#getWidth--)을 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+도형이 부모에 대해 현재 회전 각도를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+도형이 수평으로 뒤집혔는지 여부를 나타냅니다
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+도형이 수직으로 뒤집혔는지 여부를 나타냅니다.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+도형의 높이를 그리기 단위로 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+도형의 원점에 대한 도형 핀(회전 중심)의 x좌표를 지정합니다. LocPinX를 결정하는 기본 수식은: F='Width\* 0.5'입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+도형의 원점에 대한 도형 핀(회전 중심)의 y좌표를 지정합니다. LocPinY를 결정하는 기본 수식은: F='Height \* 0.5'입니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+도형의 핀 위치를 지정합니다
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+부모의 원점에 대한 도형 핀(회전 중심)의 x좌표를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+부모의 원점에 대한 도형 핀(회전 중심)의 y좌표를 지정합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+그룹에 포함된 경우 도형에 대한 현재 크기 조정 동작 설정을 지정합니다.
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+연관된 도형의 너비를 그리기 단위로 포함합니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getAngle()](../../com.aspose.diagram/xform\#getAngle--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/xform\#getDel--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+이 속성에 대한 설명은 [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getHeight()](../../com.aspose.diagram/xform\#getHeight--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+이 속성에 대한 설명은 [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getPinX()](../../com.aspose.diagram/xform\#getPinX--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getPinY()](../../com.aspose.diagram/xform\#getPinY--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+이 속성에 대한 설명은 [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getWidth()](../../com.aspose.diagram/xform\#getWidth--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xform1d/_index.md
+++ b/korean/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Aspose.Diagram for Java API 참조
+description: 1차원 도형의 시작점과 끝점의 x 및 y 좌표를 포함합니다.
+type: docs
+weight: 450
+url: /ko/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+1-D 도형의 시작점과 끝점의 x 및 y 좌표를 포함합니다. 이 요소는 1-D 도형에만 나타납니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 인스턴스의 깊은 복사본을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | 부모의 원점을 기준으로 1-D 도형 시작점의 x 좌표를 나타냅니다. |
+| [getBeginY()](#getBeginY--) | 부모의 원점을 기준으로 1-D 도형 시작점의 y 좌표를 나타냅니다. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | 요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그. |
+| [getEndX()](#getEndX--) | 부모의 원점을 기준으로 1-D 도형 끝점의 x 좌표를 나타냅니다. |
+| [getEndY()](#getEndY--) | 부모의 원점에 대한 1차원 도형 끝점의 y좌표를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)을(를) 참조하십시오. |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)을(를) 참조하십시오. |
+| [setDel(int value)](#setDel-int-) | 이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/xform1d\#getDel--)을(를) 참조하십시오. |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)을(를) 참조하십시오. |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | 이 속성에 대한 설명은 [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+이 인스턴스의 깊은 복사본을 생성합니다.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+부모의 원점을 기준으로 1-D 도형 시작점의 x 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+부모의 원점을 기준으로 1-D 도형 시작점의 y 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+요소가 로컬에서 삭제되었는지 여부를 나타내는 플래그입니다. 값 1은 요소가 로컬에서 삭제되었음을 나타냅니다.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+부모의 원점을 기준으로 1-D 도형 끝점의 x 좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+부모의 원점에 대한 1차원 도형 끝점의 y좌표를 나타냅니다.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+이 속성에 대한 설명은 [getDel()](../../com.aspose.diagram/xform1d\#getDel--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+이 속성에 대한 설명은 [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xjustify/_index.md
+++ b/korean/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Aspose.Diagram for Java API 참조
+description: X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+type: docs
+weight: 451
+url: /ko/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/xjustify\#getValue--)을(를) 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/xjustify\#getValue--)을(를) 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/korean/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Aspose.Diagram for Java API 참조
+description: X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+type: docs
+weight: 452
+url: /ko/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 x 오프셋입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CENTERED](#CENTERED) | 가운데. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | 왼쪽 정렬 (기본값). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | 오른쪽 정렬. |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+가운데.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+왼쪽 정렬 (기본값).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+오른쪽 정렬.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/korean/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Aspose.Diagram for Java API 참조
+description: 다이어그램 페이지를 XPS로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+type: docs
+weight: 453
+url: /ko/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+다이어그램 페이지를 XPS로 렌더링할 때 추가 옵션을 지정할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | 이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | 지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | 다이어그램의 문자가 유니코드이고 올바른 글꼴 값이 설정되지 않았거나 로컬에 글꼴이 설치되지 않은 경우, pdf, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | 숨겨진 페이지를 내보낼지 여부를 정의합니다. |
+| [getPageCount()](#getPageCount--) | XPS에서 렌더링할 페이지 수. |
+| [getPageIndex()](#getPageIndex--) | 렌더링할 첫 번째 페이지의 0 기반 인덱스. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | 모든 페이지를 이미지로 저장할지, 전경만 저장할지 여부를 지정합니다. |
+| [getSaveFormat()](#getSaveFormat--) | 이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. |
+| [getWarningCallback()](#getWarningCallback--) | 경고 콜백. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | 이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오. |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | 이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)을 참조하십시오. |
+| [setPageCount(int value)](#setPageCount-int-) | 이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)을 참조하십시오. |
+| [setPageIndex(int value)](#setPageIndex-int-) | 이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)을 참조하십시오. |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | 이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)을 참조하십시오. |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | 이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)을 참조하십시오. |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+이 클래스를 새 인스턴스로 초기화하여 Aspose.Diagram.SaveFileFormat 형식으로 문서를 저장할 수 있습니다.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+지정된 저장 형식에 적합한 클래스의 저장 옵션 객체를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| saveFormat | int | 저장 옵션 객체를 만들기 위한 Aspose.Diagram.SaveFileFormat입니다. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+다이어그램의 문자가 유니코드이며 올바른 글꼴 값이 설정되지 않았거나 글꼴이 로컬에 설치되지 않은 경우, PDF, 이미지 또는 XPS에서 블록으로 표시될 수 있습니다. MingLiu 또는 MS Gothic과 같은 DefaultFont를 설정하여 이러한 문자를 표시하십시오.
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+숨겨진 페이지를 내보낼지 여부를 정의합니다. 기본값은 true입니다.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+XPS에서 렌더링할 페이지 수. 기본값은 MaxValue이며, 이는 다이어그램의 모든 페이지가 렌더링됨을 의미합니다.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+렌더링할 첫 번째 페이지의 0부터 시작하는 인덱스입니다. 기본값은 0입니다.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+이미지에 모든 페이지를 저장할지 아니면 전경만 저장할지 지정합니다. true인 경우 전경 페이지만 렌더링됩니다(배경이 있으면 포함). false인 경우 전경 페이지가 렌더링된 뒤 빈 배경 페이지가 렌더링됩니다. PageCount가 1보다 클 때만 true를 반환할 수 있습니다. 기본값은 false입니다.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+이 저장 옵션 객체를 사용할 경우 렌더링된 다이어그램 페이지가 저장될 형식을 지정합니다. Aspose.Diagram.SaveFileFormat만 사용할 수 있습니다.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+경고 콜백.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+이 속성에 대한 설명은 [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+이 속성에 대한 설명은 [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+이 속성에 대한 설명은 [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+이 속성에 대한 설명은 [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)을 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/yjustify/_index.md
+++ b/korean/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Aspose.Diagram for Java API 참조
+description: X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+type: docs
+weight: 454
+url: /ko/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | 생성자. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | 객체가 같은지 여부를 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | 요소의 속성을 지정합니다. |
+| [getValue()](#getValue--) | X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다. |
+| [hashCode()](#hashCode--) | 특정 유형에 대한 해시 함수 역할을 합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | 이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/yjustify\#getValue--) 를 참조하십시오. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+생성자.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+객체가 같은지 여부를 확인합니다.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+요소의 속성을 지정합니다.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+특정 유형에 대한 해시 함수 역할을 합니다.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+이 속성에 대한 설명은 [getValue()](../../com.aspose.diagram/yjustify\#getValue--) 를 참조하십시오.
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| 값 | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/korean/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Aspose.Diagram for Java API 참조
+description: X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+type: docs
+weight: 455
+url: /ko/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+X 및 Y 요소로 정의된 점을 기준으로 스마트 태그 버튼의 y 오프셋을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | 아래쪽 정렬. |
+| [CENTERED](#CENTERED) | 가운데. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | 위쪽 정렬 (기본값). |
+| [UNDEFINED](#UNDEFINED) | 정의되지 않음. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+아래쪽 정렬.
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+가운데.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+위쪽 정렬 (기본값).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+정의되지 않음.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 형식 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `korean/java`

🤖 Generated by RDA