### PR TITLE
[auto] Translate JAVA API Reference to Spanish

### DIFF
--- a/spanish/java/_index.md
+++ b/spanish/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram para Java
+type: docs
+weight: 11
+url: /es/java/
+description: Las referencias de API de Aspose.Diagram para Java contienen ejemplos, fragmentos de código y documentación de API. Proporciona paquetes, clases, interfaces y otros detalles de la API.
+is_root: true
+---
+
+## Packages
+| Paquete | Descripción |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | El paquete com.aspose.diagram proporciona clases para generar, convertir, modificar, renderizar e imprimir documentos de Microsoft Visio sin utilizar Microsoft Visio. |

--- a/spanish/java/com.aspose.diagram/_index.md
+++ b/spanish/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El paquete com.aspose.diagram proporciona clases para generar, convertir, modificar, renderizar e imprimir documentos de Microsoft Visio sin utilizar Microsoft Visio.
+type: docs
+weight: 10
+url: /es/java/com.aspose.diagram/
+---
+
+
+El paquete com.aspose.diagram proporciona clases para generar, convertir, modificar, renderizar e imprimir documentos de Microsoft Visio sin utilizar Microsoft Visio.
+
+
+## Clases
+
+| Clase | Descripción |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | Monitor para solicitudes de interrupción en todas las operaciones que consumen mucho tiempo. |
+| [Act](../com.aspose.diagram/act) | Define nombres de comandos personalizados que aparecen en el menú contextual de un objeto y especifica las acciones que realizan los comandos. |
+| [ActCollection](../com.aspose.diagram/actcollection) | Colección Act. |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | Representa el control ActiveX. |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | Representa el control ActiveX. |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | Representa el método de persistencia para conservar un control ActiveX. |
+| [Align](../com.aspose.diagram/align) | Indica la alineación de una forma con respecto a la guía o punto de guía al que la forma está adherida. |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | Entero opcional. |
+| [Alignment](../com.aspose.diagram/alignment) | Especifica la alineación de la pestaña. |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | Especifica la alineación de la pestaña. |
+| [Annotation](../com.aspose.diagram/annotation) | Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento. |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Colección de anotaciones. |
+| [ArcTo](../com.aspose.diagram/arcto) | Contiene las coordenadas x e y y la curvatura de un arco circular representados respectivamente por los elementos X, Y y A. |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | Colección ArcTo. |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | Especifica el tamaño de la punta de flecha de la línea. |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | Especifica el tamaño de la punta de flecha de la línea. |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | Es su propia versión de la clase .NET PrintDocument que puede pasarse a un formulario PrintPreviewDialog para imprimir y previsualizar un diagrama. |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | Define una regla que compara una columna en el elemento DataRecordset padre con un elemento de datos de forma de la última acción de enlace automático exitosa realizada en la interfaz de usuario. |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | Representa opciones de autoespaciado. |
+| [BOOL](../com.aspose.diagram/bool) | Booleano. |
+| [Bevel](../com.aspose.diagram/bevel) | Representa un bisel de una forma |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | Especifica el tipo de sombra para una forma. |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | Representa una luz preestablecida derecha que se puede aplicar a una forma |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | Especifica el tipo de sombra para una forma. |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | Describe la apariencia superficial de una forma. |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D. |
+| [BevelType](../com.aspose.diagram/beveltype) | Especifica el tipo de sombra para una forma. |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D. |
+| [BoolValue](../com.aspose.diagram/boolvalue) | Valor booleano. |
+| [Bullet](../com.aspose.diagram/bullet) | Determina el estilo de viñeta. |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | Determina el estilo de viñeta. |
+| [Calendar](../com.aspose.diagram/calendar) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [Case](../com.aspose.diagram/case) | Determina la capitalización del texto de una forma. |
+| [CaseValue](../com.aspose.diagram/casevalue) | Determina la capitalización del texto de una forma. |
+| [Char](../com.aspose.diagram/char) | Contiene los atributos de formato para el texto de la forma, como fuente, color, estilo de texto, capitalización, posición relativa a la línea base y tamaño de punto. |
+| [CharCollection](../com.aspose.diagram/charcollection) | Colección de caracteres. |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | Representa un control ActiveX CheckBox. |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | Representa el tipo de valor de verificación del check box. |
+| [Collection](../com.aspose.diagram/collection) | Es la clase base para colecciones. |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | Proporciona la clase base abstracta para una colección fuertemente tipada. |
+| [Color](../com.aspose.diagram/color) | Representa un color ARGB (alfa, rojo, verde, azul). |
+| [ColorEntry](../com.aspose.diagram/colorentry) | Contiene una entrada de tabla de colores. |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | Contiene la tabla de colores del documento. |
+| [ColorValue](../com.aspose.diagram/colorvalue) | Representa un valor de color |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | Representa un control ActiveX ComboBox. |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | Representa un botón de comando. |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | Especifica el nivel de calidad a usar durante la composición. |
+| [CompoundType](../com.aspose.diagram/compoundtype) | Especifica el tamaño de la punta de flecha de la línea. |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | Representa el estilo de dibujo de líneas. |
+| [CompressionType](../com.aspose.diagram/compressiontype) | Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | Determina cuándo se redirige un conector. |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | Determina cuándo se redirige un conector. |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | Determina si un conector salta cuando dos conectores se cruzan. |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | Determina si un conector salta cuando dos conectores se cruzan. |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico. |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico. |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico. |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico. |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | Determina el estilo de salto de línea para saltos de línea en un conector dinámico. |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | Determina el estilo de salto de línea para saltos de línea en un conector dinámico. |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | Determina la apariencia de un conector. |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | Determina la apariencia de un conector. |
+| [ConType](../com.aspose.diagram/contype) | Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango. |
+| [ConValue](../com.aspose.diagram/convalue) | Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango. |
+| [Connect](../com.aspose.diagram/connect) | Representa una conexión entre dos formas en un dibujo, como una línea y un cuadro en un organigrama. |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Colección Connect. |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | Filtra la matriz de IDs de forma devueltos por la direccionalidad de los conectores. |
+| [Connection](../com.aspose.diagram/connection) | Contiene elementos para un punto de conexión definido para la forma. |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | El elemento ConnectionABCD es una versión obsoleta del elemento Connection y solo existe para compatibilidad hacia atrás. |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | Colección ConnectionABCD. |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Colección Connection. |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | Especifica la ubicación en la forma donde se conectará el conector. |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | Representa la regla de conector entre dos formas con un conector, incluyendo qué punto de conexión de qué forma inicia, la forma final y su punto de conexión. |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | Puede ser uno de los siguientes valores: RightAngle, StraightLines, o CurvedLines. |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | Puede ser uno de los siguientes valores: Document, Page, o Master. |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | Especifica las propiedades del grupo o forma a usar para la comparación. |
+| [Control](../com.aspose.diagram/control) | Contiene elementos para las coordenadas x e y de cada mango de control definido para una forma, y elementos que especifican la forma en que el mango de control debe comportarse. |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | Representa el tipo de borde del control ActiveX. |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | Representa la posición del Caption relativo al control. |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Colección Control. |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | Representa la apariencia visual de la lista en un ListBox o ComboBox. |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | Representa cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe. |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | Representa el tipo de ícono que se muestra como puntero del ratón para el control. |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Representa la alineación de la imagen dentro del Formulario o Imagen. |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | Representa la ubicación de la imagen del control en relación con su título. |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | Representa cómo mostrar la imagen. |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | Representa el tipo de barra de desplazamiento. |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | Representa el tipo de orientación del desplazamiento |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | Representa el tipo de efecto especial. |
+| [ControlType](../com.aspose.diagram/controltype) | Representa todos los tipos de control ActiveX. |
+| [Coordinate](../com.aspose.diagram/coordinate) | Clase abstracta para las coordenadas x e y. |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | Colección de coordenadas. |
+| [CountryCode](../com.aspose.diagram/countrycode) | Representa los identificadores de país del diagrama. |
+| [Cp](../com.aspose.diagram/cp) | Marca el inicio de una secuencia de propiedades de carácter que se formatea según el elemento Char correspondiente. |
+| [CustomProp](../com.aspose.diagram/customprop) | Estructura CustomProp. |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | Colección CustomProps. |
+| [CustomValue](../com.aspose.diagram/customvalue) | Valor de la propiedad. |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Define cómo aparece una columna de datos en la ventana de Datos externos en la interfaz de usuario de Visio y califica los datos en la columna definiendo su tipo de datos y formato. |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | Colección DataColumn. |
+| [DataConnection](../com.aspose.diagram/dataconnection) | Abstrae la comunicación entre uno o más elementos DataRecordset y una fuente de datos no XML. |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | Colección DataConnection. |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | Permite configurar opciones para las conexiones a la base de datos. |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Almacena, formatea, actualiza y expone datos consultados de una base de datos en Microsoft Visio. |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | Colección DataRecordSet. |
+| [DateTime](../com.aspose.diagram/datetime) | Representa un instante en el tiempo, típicamente expresado como una fecha y hora del día. |
+| [DateValue](../com.aspose.diagram/datevalue) | Valor de fecha y hora. |
+| [Diagram](../com.aspose.diagram/diagram) | Elemento raíz de la jerarquía de objetos de Visio. |
+| [DiagramException](../com.aspose.diagram/diagramexception) | Clase base para todas las excepciones de Aspose.Diagram |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Puede usarse para especificar opciones adicionales al guardar un diagrama en formato Visio (VDX\VSX). |
+| [DisplayMode](../com.aspose.diagram/displaymode) | Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo. |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo. |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. |
+| [DocProps](../com.aspose.diagram/docprops) | Contiene elementos que controlan la calidad de vista previa del documento, el alcance y el formato de salida. |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | Contiene elementos de propiedades del documento, como el título del documento, el autor, etc. |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | Contiene elementos que especifican la configuración del documento. |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | Especifica la estructura ShapeSheet de un documento. |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Valor doble |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama. |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama. |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | Especifica el tipo de escala de dibujo a usar para una página. |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | Especifica el tipo de escala de dibujo a usar para una página. |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | Especifica el tamaño de dibujo de una página. |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | Especifica el tamaño de dibujo de una página. |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | Representa el símbolo mostrado en el botón desplegable. |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. |
+| [Ellipse](../com.aspose.diagram/ellipse) | Contiene elementos que especifican las coordenadas x e y del punto central de la elipse y dos puntos en la elipse. |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | Colección de elipses. |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | Contiene elementos que especifican información sobre un arco elíptico. |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | Colección EllipticalArcTo. |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Configuración para renderizar metarchivo Emf. |
+| [Encoding](../com.aspose.diagram/encoding) | Representa una codificación de caracteres. |
+| [Event](../com.aspose.diagram/event) | Contiene elementos que especifican fórmulas que controlan eventos de forma. |
+| [EventItem](../com.aspose.diagram/eventitem) | Encapsula un código de evento. |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | Colección EventItem. |
+| [Field](../com.aspose.diagram/field) | Contiene elementos que especifican funciones y fórmulas insertadas en el texto de la forma. |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | Colección de campos. |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | Representa el único archivo de fuente TrueType almacenado en el sistema de archivos. |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | Contiene datos devueltos por los métodos de detección de formato de archivo de [FileFormatUtil](../com.aspose.diagram/fileformatutil). |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | Enumera los tipos de formato de archivo de hoja de cálculo |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | Proporciona métodos utilitarios para convertir enumeraciones de formato de archivo a cadenas o extensiones de archivo y viceversa. |
+| [Fill](../com.aspose.diagram/fill) | Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo. |
+| [FillType](../com.aspose.diagram/filltype) | Tipo de formato de relleno. |
+| [Fld](../com.aspose.diagram/fld) | Indica un punto de inserción de campo de texto para el elemento Field correspondiente. |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | Contiene una colección de números de puntos de duplicación |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | Representa la carpeta que contiene archivos de fuentes TrueType. |
+| [Font](../com.aspose.diagram/font) | Contiene información sobre una fuente. |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Contiene una colección de elementos Font. |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | Especifica la configuración de la fuente |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | Esta es una clase base abstracta para las clases que permiten al usuario especificar varios orígenes de fuentes |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | Especifica el tipo de un origen de fuente. |
+| [Foreign](../com.aspose.diagram/foreign) | Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio. |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [ForeignType](../com.aspose.diagram/foreigntype) | Tipo de datos. |
+| [FormatTxt](../com.aspose.diagram/formattxt) | Clase abstracta para el formato de texto |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | Colección FormatTxt que contiene el texto de una forma. |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | La parte de una forma desde la cual se origina una conexión. |
+| [Geom](../com.aspose.diagram/geom) | Contiene elementos que especifican las coordenadas de los vértices de las líneas y arcos que forman la forma. |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Colección Geom. |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | Esta clase especifica un efecto de resplandor, en el que se agrega un contorno difuminado de color fuera de los bordes del objeto. |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | Los valores de bits indican que una configuración de pegamento específica está activada o desactivada. |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento. |
+| [GlueType](../com.aspose.diagram/gluetype) | Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma. |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma. |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | Especifica constantes que identifican qué formas devolver, basándose en la dimensionalidad y direccionalidad de los puntos de conexión que están pegados a una forma particular; se pasan al método Shape.GluedShapes. |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | Representa todos los tipos de dirección del degradado. |
+| [GradientFill](../com.aspose.diagram/gradientfill) | Representa el relleno de degradado. |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | Especifica el tipo de degradado de color de relleno de una forma |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | Representa todos los tipos de relleno de degradado. |
+| [GradientStop](../com.aspose.diagram/gradientstop) | Representa el punto de parada del degradado. |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | Representa la colección de puntos de parada del degradado. |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | Representa el estilo de sombreado del degradado. |
+| [GridDensity](../com.aspose.diagram/griddensity) | Especifica el tipo de cuadrícula horizontal/vertical a usar para una página. |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | Especifica el tipo de cuadrícula horizontal/vertical a usar para una página. |
+| [Group](../com.aspose.diagram/group) | Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos. |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagramas a HTML. |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | Contiene elementos para el encabezado y pie de página de un documento. |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | Especifica la fuente utilizada para el texto del encabezado y pie de página. |
+| [Help](../com.aspose.diagram/help) | Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor. |
+| [HorzAlign](../com.aspose.diagram/horzalign) | Especifica la alineación horizontal del texto en el bloque de texto de la forma. |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | Especifica la alineación horizontal del texto en el bloque de texto de la forma. |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | Contiene elementos para crear múltiples saltos entre una forma o página de dibujo y otra página de dibujo, otro archivo o un sitio web. |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | Colección de hipervínculos. |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | Entero opcional. |
+| [Image](../com.aspose.diagram/image) | Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits. |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | Representa el control de imagen. |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | Especifica el modo de color para las imágenes generadas de las páginas del documento. |
+| [ImageFormat](../com.aspose.diagram/imageformat) | Especifica el formato de archivo de la imagen. |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagramas a imágenes. |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | Configuraciones de fuente para cada objeto [Diagram](../com.aspose.diagram/diagram). |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | Contiene elementos que especifican las coordenadas x e y de dos puntos en una línea infinita. |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | Colección InfiniteLine. |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | Representa el modo de ejecución predeterminado del Editor de Métodos de Entrada. |
+| [IntValue](../com.aspose.diagram/intvalue) | Valor entero |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | La enumeración InterpolationMode especifica el algoritmo que se utiliza cuando las imágenes se escalan o rotan. |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | Representa todos los operadores sobre la interrupción. |
+| [Issue](../com.aspose.diagram/issue) | Representa un único problema de validación en el documento. |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Colección de problemas. |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | Según el objetivo del problema de validación principal, especifica ya sea la página, o tanto la página como la forma, con la que está asociado el problema de validación principal. |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | Representa el control ActiveX de etiqueta. |
+| [Layer](../com.aspose.diagram/layer) | Contiene elementos que definen una única capa y sus propiedades para una página. |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Colección de capas. |
+| [LayerMem](../com.aspose.diagram/layermem) | Contiene el elemento LayerMember, que especifica cada capa a la que se asigna la forma. |
+| [Layout](../com.aspose.diagram/layout) | Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores. |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | Se utiliza para establecer la dirección del diseño. |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | Se utiliza para especificar el estilo y opciones adicionales del diseño de formas para realizar el Re-Diseño de la(s) página(s). |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | Se utiliza para especificar el estilo del diseño. |
+| [License](../com.aspose.diagram/license) | Proporciona métodos para licenciar el componente. |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | Representa el tipo de dirección del rig de luz. |
+| [Line](../com.aspose.diagram/line) | Contiene elementos que especifican información general de posicionamiento sobre una forma. |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | Especifica qué conectores dinámicos separar si se enrutan uno sobre otro. |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | Especifica qué conectores dinámicos separar si se enrutan uno sobre otro. |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos. |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos. |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | Determina los conectores dinámicos a los que desea agregar saltos. |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | Determina los conectores dinámicos a los que desea agregar saltos. |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local. |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local. |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | Especifica la apariencia predeterminada para todos los conectores en una página. |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | Especifica la apariencia predeterminada para todos los conectores en una página. |
+| [LineTo](../com.aspose.diagram/lineto) | Contiene las coordenadas x e y del vértice final de un segmento de línea recta. |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | Colección LineTo. |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | Representa un control ActiveX ListBox. |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | Enumeración para la selección del formato de carga del diagrama. |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | Permite especificar opciones adicionales al cargar un diagrama en un objeto Diagram. |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | Especifica si el texto de la forma debe localizarse (traducirse a otro idioma). |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | Especifica si el texto de la forma debe localizarse (traducirse a otro idioma). |
+| [Margin](../com.aspose.diagram/margin) | Especifica el margen. |
+| [Master](../com.aspose.diagram/master) | Contiene elementos que definen una plantilla maestra para el documento. |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | Colección Master. |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | Especifica un acceso directo maestro definido en el documento. |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | Colección MasterShortcut. |
+| [MeasureConst](../com.aspose.diagram/measureconst) | Unidades de\\ medida. |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | Representa el único archivo de fuente TrueType almacenado en memoria. |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | MilestoneHelper para establecer la propiedad de la forma de hito. |
+| [Misc](../com.aspose.diagram/misc) | Contiene varios elementos de formas y grupos, como los que controlan el resaltado de selección y la visibilidad. |
+| [MoveTo](../com.aspose.diagram/moveto) | Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | Colección MoveTo. |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | Contiene las coordenadas x e y, la posición del penúltimo nudo, la posición del último peso, la posición del primer nudo, la posición del primer peso y la fórmula de una B-spline racional no uniforme (NURBS). |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | Colección NURBSTo. |
+| [ObjType](../com.aspose.diagram/objtype) | Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo. |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo. |
+| [ObjectKind](../com.aspose.diagram/objectkind) | Indica el tipo de campo de texto. |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | Indica el tipo de campo de texto. |
+| [ObjectType](../com.aspose.diagram/objecttype) | Si el atributo ForeignType es "Object", el elemento ForeignData también debe tener un atributo ObjectType. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | Entero sin signo opcional. |
+| [OutputFormat](../com.aspose.diagram/outputformat) | Especifica el formato de salida para un dibujo. |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | Especifica el formato de salida para un dibujo. |
+| [Page](../com.aspose.diagram/page) | Contiene elementos que definen una página en el documento. |
+| [PageCollection](../com.aspose.diagram/pagecollection) | Colección de páginas. |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | Información para una página finaliza el proceso de guardado. |
+| [PageLayout](../com.aspose.diagram/pagelayout) | Contiene celdas que controlan la configuración del diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página. |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [PageProps](../com.aspose.diagram/pageprops) | Contiene celdas que controlan los atributos de la página, como el ancho, la altura y la escala de la página. |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | Información para un proceso de guardado de página. |
+| [PageSheet](../com.aspose.diagram/pagesheet) | Contiene elementos que definen la hoja de página para un elemento Página o Maestro. |
+| [PageSize](../com.aspose.diagram/pagesize) | Contiene información sobre el tamaño de página para las imágenes generadas. |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | Información para una página inicia el proceso de guardado. |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | Enumeración para la selección del formato de tamaño de papel al guardar. |
+| [Para](../com.aspose.diagram/para) | Contiene los elementos de formato de párrafo para el texto de la forma, como sangrías, interlineado, viñetas y alineación horizontal de los párrafos. |
+| [ParaCollection](../com.aspose.diagram/paracollection) | Colección de párrafos. |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | Especifica el nivel de cumplimiento PDF para el archivo de salida. |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | Especifica el algoritmo de hash digital utilizado por la firma digital. |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | Especifica el algoritmo de cifrado a usar para encriptar un documento PDF. |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | Contiene detalles para un cifrado PDF. |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | Especifica los permisos de usuario para el documento PDF. |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagramas a PDF. |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | Especifica un tipo de compresión aplicado a todo el contenido del archivo PDF, excepto a las imágenes. |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | Especifica la posición del pin para la forma. |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | Especifica cómo se desplazan los píxeles durante el renderizado. |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño. |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño. |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio. |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio. |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma). |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma). |
+| [PolylineTo](../com.aspose.diagram/polylineto) | Contiene las coordenadas x e y del último punto de una polilínea y la fórmula de la polilínea. |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | Colección PolylineTo. |
+| [Pos](../com.aspose.diagram/pos) | Especifica la posición del texto de la forma respecto a la línea base. |
+| [PosValue](../com.aspose.diagram/posvalue) | Especifica la posición del texto de la forma respecto a la línea base. |
+| [Pp](../com.aspose.diagram/pp) | Especifica el comienzo de una ejecución de propiedades de párrafo. |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | Representa diferentes métodos algorítmicos para establecer todas las propiedades de la cámara, incluida la posición. |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Se utiliza para establecer la propiedad de color del estilo de tema de Shape. |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | Especifica el valor del estilo rápido del tema. |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | Representa el tipo de sombra predefinido. |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Se utiliza para establecer la propiedad de estilo de tema de Shape. |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | Especifica el valor del tema. |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | Especifica el valor de la variante del tema. |
+| [PreviewScope](../com.aspose.diagram/previewscope) | Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento. |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento. |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | Determina si la página se imprime en orientación vertical u horizontal. |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | Determina si la página se imprime en orientación vertical u horizontal. |
+| [PrintProps](../com.aspose.diagram/printprops) | Contiene elementos que controlan cómo se formatea (aparece) la página de dibujo en la página de la impresora. |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | Permite especificar opciones adicionales al imprimir el diagrama. |
+| [Prop](../com.aspose.diagram/prop) | Contiene elementos para definir propiedades personalizadas y elementos para asociar datos con una forma. |
+| [PropCollection](../com.aspose.diagram/propcollection) | Colección Prop. |
+| [PropType](../com.aspose.diagram/proptype) | Tipo de propiedad. |
+| [Protection](../com.aspose.diagram/protection) | El bloqueo ayuda a prevenir cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | Representa un control ActiveX RadioButton. |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | Representa cómo posicionar dos rectángulos entre sí. |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | Contiene las coordenadas x e y de los puntos de un RelCubBezTo. |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | Colección RelCubBezTo. |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | Contiene elementos que especifican información sobre un arco elíptico. Las coordenadas se especifican como coordenadas relativas. |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | Colección RelEllipticalArcTo. |
+| [RelLineTo](../com.aspose.diagram/rellineto) | Contiene las coordenadas x e y del vértice final de un segmento de línea recta. |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | Colección RelLineTo. |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. Las coordenadas se especifican como coordenadas relativas. |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | Colección RelMoveTo. |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | Contiene coordenadas x e y para los puntos de un RelQuadBezTo. |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | Colección RelQuadBezTo. |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | Especifica la eliminación de información oculta para el diagrama. |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular. |
+| [ResizeMode](../com.aspose.diagram/resizemode) | Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo. |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo. |
+| [Reviewer](../com.aspose.diagram/reviewer) | Contiene elementos que incluyen información de identificación sobre un revisor de documentos. |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | Colección Reviewer. |
+| [RotationType](../com.aspose.diagram/rotationtype) | Especifica el tipo de sombra para una forma. |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | Especifica el tipo de proyección de las propiedades de efecto de una forma |
+| [RouteStyle](../com.aspose.diagram/routestyle) | Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local. |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local. |
+| [Row](../com.aspose.diagram/row) | Indica una fila en el conjunto de registros de datos. |
+| [RowCollection](../com.aspose.diagram/rowcollection) | Colección Row. |
+| [Rule](../com.aspose.diagram/rule) | Representa una regla de validación única en un conjunto de reglas de validación de diagramas. |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | Colección Rule. |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | Especifica información sobre la regla de validación a la que se refiere el problema de validación principal. |
+| [RuleSet](../com.aspose.diagram/ruleset) | Representa un conjunto de reglas de validación de diagramas. |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | Colección RuleSet. |
+| [RuleValue](../com.aspose.diagram/rulevalue) | Valor de regla. |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | Especifica las subdivisiones horizontales en la regla para la página. |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | Especifica las subdivisiones horizontales en la regla para la página. |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página. |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagramas a SVG. |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | Enumeración para la selección del formato de guardado del diagrama. |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular. |
+| [Scratch](../com.aspose.diagram/scratch) | Contiene un área de trabajo para ingresar y probar fórmulas a las que hacen referencia otros elementos. |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | Colección de Scratch. |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | Representa el control ScrollBar. |
+| [SelectMode](../com.aspose.diagram/selectmode) | Especifica cómo el usuario selecciona una forma de grupo y sus miembros. |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | Especifica cómo el usuario selecciona una forma de grupo y sus miembros. |
+| [Shape](../com.aspose.diagram/shape) | Contiene elementos que definen una forma en un Master, una Página o un elemento de forma de grupo. |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | Colección de Formas. |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | Especifica el comportamiento de colocación para una forma colocable. |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | Especifica el comportamiento de colocación para una forma colocable. |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes). |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes). |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | Determina el estilo de colocación para los hijos. |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | Determina el estilo de colocación para los hijos. |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo. |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo. |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo. |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo. |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | Especifica el tipo de sombra para una forma. |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | Especifica el tipo de sombra para una forma. |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | Especifica el tipo de sombra para una forma. |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | Especifica el tipo de sombra para una forma. |
+| [ShdwType](../com.aspose.diagram/shdwtype) | Indica el tipo de sombra predeterminado para una página. |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | Indica el tipo de sombra predeterminado para una página. |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | Especifica cuándo mostrar el botón de despliegue |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | Contiene elementos que incluyen información para cada etiqueta inteligente definida para una forma o página. |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | Colección SmartTagDef. |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | Especifica si el suavizado (antialiasing) se aplica a líneas y curvas y a los bordes de áreas rellenas. |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa. |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa. |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana. |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento. |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | Colección SolutionXML. |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | Representa el control SpinButton. |
+| [SplineKnot](../com.aspose.diagram/splineknot) | Contiene coordenadas x e y para el punto de control de una spline y el nudo de una spline, representados por los elementos X, Y y A, respectivamente. |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | Colección SplineKnot. |
+| [SplineStart](../com.aspose.diagram/splinestart) | Contiene coordenadas x e y para el segundo punto de control de una spline, su segundo nudo, su primer nudo, el último nudo y el grado de la spline. |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | Colección SplineStart. |
+| [Str2Value](../com.aspose.diagram/str2value) | Valor de cadena. |
+| [StrValue](../com.aspose.diagram/strvalue) | Valor de cadena |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | Representa las opciones de flujo. |
+| [Style](../com.aspose.diagram/style) | Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma. |
+| [StyleProp](../com.aspose.diagram/styleprop) | Contiene elementos que controlan el comportamiento del estilo, como si un estilo incluye atributos de texto, línea y relleno. |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | Representa un estilo definido en un documento. |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | Colección de hojas de estilo. |
+| [StyleValue](../com.aspose.diagram/stylevalue) | Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma. |
+| [Tab](../com.aspose.diagram/tab) | Contiene una colección de elementos Tab. |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Contiene una colección de elementos Tab. |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | Contiene una colección de elementos TabCollection. |
+| [Text](../com.aspose.diagram/text) | Contiene el texto de una forma. |
+| [TextBlock](../com.aspose.diagram/textblock) | Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma. |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | Representa un control ActiveX de cuadro de texto. |
+| [TextCollection](../com.aspose.diagram/textcollection) | Contiene el texto de una forma. |
+| [TextDirection](../com.aspose.diagram/textdirection) | Especifica la dirección de los caracteres en un bloque de texto. |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | Especifica la dirección de los caracteres en un bloque de texto. |
+| [TextXForm](../com.aspose.diagram/textxform) | Contiene elementos que especifican información de posicionamiento sobre el bloque de texto de una forma. |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | Representa el formato tridimensional de una forma. |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | Especifica qué tipo de compresión aplicar al guardar páginas en formato TIFF. |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | TimeLineHelper para establecer la propiedad de la forma de línea de tiempo. |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | La parte de una forma a la que se hace una conexión. |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | Representa un control ActiveX de botón de alternancia. |
+| [Tp](../com.aspose.diagram/tp) | Especifica el comienzo de una ejecución de propiedades de tabulaciones. |
+| [Txt](../com.aspose.diagram/txt) | Texto de la forma |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | Especifica varios tipos, según el elemento en el que está contenido. |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | Especifica varios tipos, según el elemento en el que está contenido. |
+| [TypeField](../com.aspose.diagram/typefield) | Tipo especifica un tipo de datos para el valor del campo de texto. |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Tipo especifica un tipo de datos para el valor del campo de texto. |
+| [TypeProp](../com.aspose.diagram/typeprop) | Tipo especifica un tipo de datos para el valor de la propiedad personalizada. |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Tipo especifica un tipo de datos para el valor de la propiedad personalizada. |
+| [TypeValue](../com.aspose.diagram/typevalue) | Enumeración opcional. |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | Especifica la alineación de la pestaña. |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | Especifica la alineación de la pestaña. |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | Especifica los atributos de un elemento. |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | Atributos especificados de un elemento. |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | Control desconocido. |
+| [User](../com.aspose.diagram/user) | Contiene un área de trabajo para ingresar fórmulas en elementos específicos del usuario que son referenciados por otros elementos y herramientas complementarias. |
+| [UserCollection](../com.aspose.diagram/usercollection) | Colección de usuarios. |
+| [Validation](../com.aspose.diagram/validation) | Almacena información sobre la validación del diagrama para el documento. |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | Encapsula propiedades relacionadas con la validación del documento. |
+| [Value](../com.aspose.diagram/value) | Valor. |
+| [VbaModule](../com.aspose.diagram/vbamodule) | Representa el módulo que está contenido en el proyecto VBA. |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | Representa la lista de [VbaModule](../com.aspose.diagram/vbamodule) |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | Representa el tipo de módulo VBA. |
+| [VbaProject](../com.aspose.diagram/vbaproject) | Representa el proyecto VBA. |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | Representa la referencia del proyecto VBA. |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | Representa todas las referencias del proyecto VBA. |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | Representa el tipo de referencia del proyecto VBA. |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | Especifica la alineación vertical del texto dentro del bloque de texto. |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | Especifica la alineación vertical del texto dentro del bloque de texto. |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | Especifica el contenido que define el objetivo de la regla de validación; se pasa y se devuelve mediante la propiedad ValidationRule.TargetType. |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua. |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua. |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | Información de advertencia |
+| [WarningType](../com.aspose.diagram/warningtype) | WarningType |
+| [Window](../com.aspose.diagram/window) | Representa una ventana abierta en una instancia de Microsoft Visio. |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | Colección de ventanas. |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | Un entero que especifica banderas de bits. |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | Un valor enumerado que puede ser uno de los siguientes: Drawing, Sheet, Stencil o Icon. |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagrama a XAML. |
+| [XForm](../com.aspose.diagram/xform) | Contiene elementos que controlan los atributos de línea de una forma, como patrón, grosor y color. |
+| [XForm1D](../com.aspose.diagram/xform1d) | Contiene las coordenadas x e y del punto inicial y del punto final de una forma 1-D. |
+| [XJustify](../com.aspose.diagram/xjustify) | El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | Permite especificar opciones adicionales al renderizar páginas de diagrama a XPS. |
+| [YJustify](../com.aspose.diagram/yjustify) | Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+
+## Interfaces
+
+| Interfaz | Descripción |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | Controlar/Indicar el progreso del proceso de guardado de la página. |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | Representa el proveedor de flujo exportado. |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | Interfaz de devolución de llamada de advertencia. |

--- a/spanish/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/spanish/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Monitor para solicitudes de interrupción en todas las operaciones que consumen mucho tiempo.
+type: docs
+weight: 10
+url: /es/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+Monitor para solicitudes de interrupción en todas las operaciones que consumen mucho tiempo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Indica si se solicita interrupción para la operación actual. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+Indica si se solicita interrupción para la operación actual. Si es verdadero, la operación actual será interrumpida.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/act/_index.md
+++ b/spanish/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Define nombres de comandos personalizados que aparecen en el menú contextual de un objeto y especifica las acciones que realizan los comandos.
+type: docs
+weight: 11
+url: /es/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+Define nombres de comandos personalizados que aparecen en el menú contextual de un objeto y especifica las acciones que realizan los comandos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Act()](#Act--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Contiene la fórmula que se ejecuta cuando un usuario hace clic en el nombre del comando definido en el elemento Menu correspondiente. |
+| [getBeginGroup()](#getBeginGroup--) | Indica si se inserta un separador en el menú encima de esta acción. |
+| [getButtonFace()](#getButtonFace--) | Identifica el ícono que aparece junto a un elemento en un menú contextual. |
+| [getChecked()](#getChecked--) | Determina si se muestra una marca de verificación junto al nombre del comando en el menú contextual de una forma. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDisabled()](#getDisabled--) | El elemento Disabled determina si el nombre del comando se muestra en el menú contextual. |
+| [getFlyoutChild()](#getFlyoutChild--) | Determina si la fila de acción es un submenú desplegable hijo de la última fila anterior que no es un hijo desplegable. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getInvisible()](#getInvisible--) | El elemento Invisible indica si la acción es visible en la etiqueta inteligente o en el menú contextual. |
+| [getMenu()](#getMenu--) | Especifica el nombre del comando que aparece en el menú contextual de una forma o página. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getReadOnly()](#getReadOnly--) | Determina si la acción en una etiqueta inteligente o menú contextual es de solo lectura. |
+| [getSortKey()](#getSortKey--) | Especifica un número que determina el orden de las acciones que aparecen en un menú contextual o de etiqueta inteligente. |
+| [getTagName()](#getTagName--) | Contiene el nombre de la etiqueta inteligente con la que está asociada la acción. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/act\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/act\#getID--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/act\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/act\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/act\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+Contiene la fórmula que se ejecuta cuando un usuario hace clic en el nombre del comando definido en el elemento Menu correspondiente.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+Indica si se inserta un separador en el menú encima de esta acción.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Identifica el ícono que aparece junto a un elemento en un menú contextual.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+Determina si se muestra una marca de verificación junto al nombre del comando en el menú contextual de una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+El elemento Disabled determina si el nombre del comando se muestra en el menú contextual.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+Determina si la fila de acción es un submenú desplegable hijo de la última fila anterior que no es un hijo desplegable.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+El elemento Invisible indica si la acción es visible en la etiqueta inteligente o en el menú contextual.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+Especifica el nombre del comando que aparece en el menú contextual de una forma o página.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+Determina si la acción en una etiqueta inteligente o menú contextual es de solo lectura.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Especifica un número que determina el orden de las acciones que aparecen en un menú contextual o de etiqueta inteligente.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Contiene el nombre de la etiqueta inteligente con la que está asociada la acción.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/act\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/act\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/act\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/act\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/act\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/actcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Act.
+type: docs
+weight: 12
+url: /es/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Colección Act.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | Agregue el objeto Act a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getAct(int ID)](#getAct-int-) | Obtiene el elemento con el ID especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | Elimine el objeto Act de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+Agregue el objeto Act a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+Elimine el objeto Act de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control ActiveX.
+type: docs
+weight: 13
+url: /es/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+Representa el control ActiveX.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/spanish/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control ActiveX.
+type: docs
+weight: 14
+url: /es/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+Representa el control ActiveX.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/spanish/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el método de persistencia para conservar un control ActiveX.
+type: docs
+weight: 15
+url: /es/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+Representa el método de persistencia para conservar un control ActiveX.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | Los datos se almacenan como datos XML. |
+| [STORAGE](#STORAGE) | Los datos se almacenan como datos binarios de almacenamiento. |
+| [STREAM](#STREAM) | Los datos se almacenan como datos binarios de flujo. |
+| [STREAM_INIT](#STREAM-INIT) | Los datos se almacenan como datos binarios de streaminit. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+Los datos se almacenan como datos XML.
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+Los datos se almacenan como datos binarios de almacenamiento.
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+Los datos se almacenan como datos binarios de flujo.
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+Los datos se almacenan como datos binarios de streaminit.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/align/_index.md
+++ b/spanish/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica la alineación de una forma con respecto a la guía o punto de guía al que la forma está adherida.
+type: docs
+weight: 16
+url: /es/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+Indica la alineación de una forma con respecto a la guía o punto de guía al que la forma está pegada. El elemento Align aparece solo para formas que están pegadas a guías o puntos de guía.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | Determina la posición vertical, relativa al origen de su padre, de una guía horizontal o punto de guía al que está alineado el borde inferior de la forma. |
+| [getAlignCenter()](#getAlignCenter--) | Determina la posición horizontal, relativa al origen de su padre, de una guía vertical o punto de guía al que está alineado el centro horizontal de la forma. |
+| [getAlignLeft()](#getAlignLeft--) | Determina la posición horizontal, relativa al origen de su padre, de una guía vertical o punto de guía al que está alineado el borde izquierdo de la forma. |
+| [getAlignMiddle()](#getAlignMiddle--) | Determina la posición vertical, relativa al origen de su elemento padre, de una guía horizontal o punto de guía al que se alinea el centro vertical de la forma. |
+| [getAlignRight()](#getAlignRight--) | Determina la posición horizontal, relativa al origen de su elemento padre, de una guía vertical o punto de guía al que se alinea el borde derecho de la forma. |
+| [getAlignTop()](#getAlignTop--) | Determina la posición vertical, relativa al origen de su elemento padre, de una guía horizontal o punto de guía al que se alinea el borde superior de la forma. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/align\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+Determina la posición vertical, relativa al origen de su padre, de una guía horizontal o punto de guía al que está alineado el borde inferior de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+Determina la posición horizontal, relativa al origen de su padre, de una guía vertical o punto de guía al que está alineado el centro horizontal de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+Determina la posición horizontal, relativa al origen de su padre, de una guía vertical o punto de guía al que está alineado el borde izquierdo de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+Determina la posición vertical, relativa al origen de su elemento padre, de una guía horizontal o punto de guía al que se alinea el centro vertical de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+Determina la posición horizontal, relativa al origen de su elemento padre, de una guía vertical o punto de guía al que se alinea el borde derecho de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+Determina la posición vertical, relativa al origen de su elemento padre, de una guía horizontal o punto de guía al que se alinea el borde superior de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/align\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/alignment/_index.md
+++ b/spanish/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Alignment
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación de la pestaña.
+type: docs
+weight: 18
+url: /es/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+Especifica la alineación de la pestaña.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la alineación de la pestaña. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/alignment\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la alineación de la pestaña.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/alignment\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación de la pestaña.
+type: docs
+weight: 19
+url: /es/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+Especifica la alineación de la pestaña.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CENTER](#CENTER) | Centro. |
+| [DECIMAL](#DECIMAL) | Decimal. |
+| [LEFT](#LEFT) | Izquierda. |
+| [RIGHT](#RIGHT) | Derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro.
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+Decimal.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Entero opcional.
+type: docs
+weight: 17
+url: /es/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+Entero opcional. Especifica si el texto del maestro en la ventana de plantilla está alineado a la izquierda, a la derecha o al centro.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | Alinear texto al centro. |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | Alinear texto a la izquierda. |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | Alinear texto a la derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+Alinear texto al centro.
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+Alinear texto a la izquierda.
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+Alinear texto a la derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/annotation/_index.md
+++ b/spanish/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: Anotación
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento.
+type: docs
+weight: 20
+url: /es/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Contiene el texto del comentario en formato de cadena para una forma. |
+| [getDate()](#getDate--) | especifica cuándo se creó un comentario |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getEditDate()](#getEditDate--) | Especifica cuándo se modificó por última vez un comentario |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getLangID()](#getLangID--) | Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario. |
+| [getMarkerIndex()](#getMarkerIndex--) | Especifica el número de índice asignado a un marcador de comentario. |
+| [getReviewerID()](#getReviewerID--) | Contiene el número de ID del revisor que agrega marcas al documento. |
+| [getShapeID()](#getShapeID--) | El ID de forma del comentario. |
+| [getX()](#getX--) | La coordenada x del marcador de comentario en coordenadas de página. |
+| [getY()](#getY--) | La coordenada y del marcador de comentario en coordenadas de página. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/annotation\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/annotation\#getIX--) |
+| [setShapeID(int value)](#setShapeID-int-) | Para la descripción de esta propiedad, consulte [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Contiene el texto del comentario en formato de cadena para una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+especifica cuándo se creó un comentario
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+Especifica cuándo se modificó por última vez un comentario
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+Especifica el número de índice asignado a un marcador de comentario.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Contiene el número de ID del revisor que agrega marcas al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+El ID de forma del comentario.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del marcador de comentario en coordenadas de página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del marcador de comentario en coordenadas de página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/annotation\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/annotation\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de anotaciones.
+type: docs
+weight: 21
+url: /es/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Colección de anotaciones.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | Agrega el objeto Annotation en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | Elimina el objeto Annotation de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+Agrega el objeto Annotation en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+Elimina el objeto Annotation de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/arcto/_index.md
+++ b/spanish/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y y la curvatura de un arco circular representados respectivamente por los elementos X Y y A.
+type: docs
+weight: 22
+url: /es/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+Contiene las coordenadas x e y y la curvatura de un arco circular representados respectivamente por los elementos X, Y y A.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | Crea una instancia de la clase [ArcTo](../../com.aspose.diagram/arcto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La distancia desde el punto medio del arco hasta el punto medio de su cuerda. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de un arco. |
+| [getY()](#getY--) | La coordenada y del vértice final de un arco. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/arcto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/arcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/arcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/arcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/arcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+Crea una instancia de la clase [ArcTo](../../com.aspose.diagram/arcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La distancia desde el punto medio del arco hasta el punto medio de su cuerda.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/arcto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/arcto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/arcto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/arcto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/arcto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/arctocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección ArcTo.
+type: docs
+weight: 23
+url: /es/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+Colección ArcTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/arrowsize/_index.md
+++ b/spanish/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tamaño de la punta de flecha de la línea.
+type: docs
+weight: 24
+url: /es/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+Especifica el tamaño de la punta de flecha de la línea.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tamaño de la punta de flecha de la línea. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/arrowsize\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tamaño de la punta de flecha de la línea.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tamaño de la punta de flecha de la línea.
+type: docs
+weight: 25
+url: /es/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+Especifica el tamaño de la punta de flecha de la línea.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | Colosal. |
+| [EXTRA_LARGE](#EXTRA-LARGE) | ExtraGrande. |
+| [JUMBO](#JUMBO) | Jumbo. |
+| [LARGE](#LARGE) | Grande. |
+| [MEDIUM](#MEDIUM) | Medio. |
+| [SMALL](#SMALL) | Pequeño. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VERY_SMALL](#VERY-SMALL) | MuyPequeño. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+Colosal.
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+ExtraGrande.
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+Jumbo.
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+Grande.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Medio.
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+Pequeño.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+MuyPequeño.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/spanish/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Su propia versión de la clase .NET PrintDocument que puede pasarse a un formulario PrintPreviewDialog para imprimir y previsualizar un diagrama.
+type: docs
+weight: 26
+url: /es/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+Es su propia versión de la clase .NET PrintDocument que puede pasarse a un formulario PrintPreviewDialog para imprimir y previsualizar un diagrama.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | Inicializa una nueva instancia de esta clase que puede pasarse a un formulario PrintPreviewDialog para imprimir y previsualizar un diagrama. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+Inicializa una nueva instancia de esta clase que puede pasarse a un formulario PrintPreviewDialog para imprimir y previsualizar un diagrama.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/spanish/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Define una regla que compara una columna en el elemento DataRecordset padre con un elemento de datos de forma de la última acción de enlace automático exitosa realizada en la interfaz de usuario.
+type: docs
+weight: 27
+url: /es/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+Define una regla que compara una columna en el elemento DataRecordset padre con un elemento de datos de forma de la última acción de enlace automático exitosa realizada en la interfaz de usuario.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | Corresponde a un nombre de columna en el conjunto de registros ADO. |
+| [getContextType()](#getContextType--) | Especifica las propiedades del grupo o forma a usar para la comparación. |
+| [getContextTypeLabel()](#getContextTypeLabel--) | Si el valor de ContextType es 2 o 3, este atributo es necesario para definir una comparación. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) |
+| [setContextType(int value)](#setContextType-int-) | Para la descripción de esta propiedad, consulte [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | Para la descripción de esta propiedad, consulte [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+Corresponde a un nombre de columna en el conjunto de registros ADO.
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+Especifica las propiedades del grupo o forma que se usarán para la comparación. Los valores posibles se muestran en la tabla siguiente.
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+Si el valor de ContextType es 2 o 3, este atributo es necesario para definir una comparación. Para ContextType = 2, ContextTypeLabel debe ser la etiqueta del elemento de datos de forma, y si ContextType = 3, ContextTypeLabel debe ser el nombre de fila local.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa opciones de autoespaciado.
+type: docs
+weight: 28
+url: /es/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+Representa opciones de autoespaciado.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | Define la distancia entre las formas en dirección horizontal en pulgadas. |
+| [getDistanceInVertical()](#getDistanceInVertical--) | Define la distancia entre las formas en dirección vertical en pulgadas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | Para la descripción de esta propiedad, consulte [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | Para la descripción de esta propiedad, consulte [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+Define la distancia entre las formas en dirección horizontal en pulgadas. Valor predeterminado 0,375 pulgada.
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+Define la distancia entre las formas en dirección vertical en pulgadas. Valor predeterminado 0,375 pulgada.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevel/_index.md
+++ b/spanish/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un bisel de una forma
+type: docs
+weight: 30
+url: /es/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+Representa un bisel de una forma
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | la altura del bisel, o qué tan por encima de la forma se aplica. |
+| [getWidth()](#getWidth--) | la anchura del bisel, o qué tan dentro de la forma se aplica. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/bevel\#getHeight--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/bevel\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+la altura del bisel, o qué tan por encima de la forma se aplica. En unidades de puntos.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+la anchura del bisel, o qué tan dentro de la forma se aplica.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/spanish/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 31
+url: /es/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de bisel. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de bisel.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa una luz preestablecida derecha que se puede aplicar a una forma
+type: docs
+weight: 32
+url: /es/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+Representa una luz preestablecida derecha que se puede aplicar a una forma
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BALANCED](#BALANCED) | Equilibrado |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Sala brillante |
+| [CHILLY](#CHILLY) | Frío |
+| [CONTRASTING](#CONTRASTING) | Contrastante |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Inundación |
+| [FREEZING](#FREEZING) | Congelante |
+| [GLOW](#GLOW) | Resplandor |
+| [HARSH](#HARSH) | Áspero |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Mañana |
+| [SOFT](#SOFT) | Suave |
+| [SUNRISE](#SUNRISE) | Amanecer |
+| [SUNSET](#SUNSET) | Atardecer |
+| [THREE_POINT](#THREE-POINT) | Tres puntos |
+| [TWO_POINT](#TWO-POINT) | Dos puntos |
+| [UNDEFINED](#UNDEFINED) | Sin bastidor de luz. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Equilibrado
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Sala brillante
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Frío
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Contrastante
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Inundación
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Congelante
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Resplandor
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Áspero
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Mañana
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+Suave
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+Amanecer
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+Atardecer
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+Tres puntos
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+Dos puntos
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Sin bastidor de luz.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/spanish/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 33
+url: /es/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de bisel. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de bisel.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Describe la apariencia superficial de una forma.
+type: docs
+weight: 34
+url: /es/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+Describe la apariencia superficial de una forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CLEAR](#CLEAR) | Borrar |
+| [DARK_EDGE](#DARK-EDGE) | Borde oscuro |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | Mate legado |
+| [LEGACY_METAL](#LEGACY-METAL) | Metal legado |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | Plástico legado |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | Wireframe legado |
+| [MATTE](#MATTE) | Mate |
+| [METAL](#METAL) | Metal |
+| [PLASTIC](#PLASTIC) | Plástico |
+| [POWDER](#POWDER) | Polvo |
+| [SOFT_EDGE](#SOFT-EDGE) | Borde suave |
+| [SOFT_METAL](#SOFT-METAL) | Metal blando |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | Polvo translúcido |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | Mate cálido |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+Borrar
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+Borde oscuro
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+Mate legado
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+Metal legado
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+Plástico legado
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+Wireframe legado
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+Mate
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+Metal
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+Plástico
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+Polvo
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+Borde suave
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+Metal blando
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+Polvo translúcido
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+Mate cálido
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/spanish/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D.
+type: docs
+weight: 35
+url: /es/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ANGLE](#ANGLE) | Ángulo |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Círculo |
+| [CONVEX](#CONVEX) | Convexo |
+| [COOL_SLANT](#COOL-SLANT) | Inclinación fresca |
+| [CROSS](#CROSS) | Cruz |
+| [DIVOT](#DIVOT) | Hueco |
+| [HARD_EDGE](#HARD-EDGE) | Borde duro |
+| [NONE](#NONE) | Sin bisel |
+| [RELAXED_INSET](#RELAXED-INSET) | Inserción relajada |
+| [RIBLET](#RIBLET) | Estría |
+| [SLOPE](#SLOPE) | Pendiente |
+| [SOFT_ROUND](#SOFT-ROUND) | Redondeado suave |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Ángulo
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Círculo
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Convexo
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Inclinación fresca
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cruz
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Hueco
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Borde duro
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Sin bisel
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Inserción relajada
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Estría
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Pendiente
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Redondeado suave
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/beveltype/_index.md
+++ b/spanish/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 36
+url: /es/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de bisel. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/beveltype\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de bisel.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/beveltype\\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D.
+type: docs
+weight: 37
+url: /es/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+Representa un preajuste para un tipo de bisel que se puede aplicar a una forma en 3D.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ANGLE](#ANGLE) | Ángulo |
+| [ART_DECO](#ART-DECO) | Art déco |
+| [CIRCLE](#CIRCLE) | Círculo |
+| [CONVEX](#CONVEX) | Convexo |
+| [COOL_SLANT](#COOL-SLANT) | Inclinación fresca |
+| [CROSS](#CROSS) | Cruz |
+| [DIVOT](#DIVOT) | Hueco |
+| [HARD_EDGE](#HARD-EDGE) | Borde duro |
+| [NONE](#NONE) | Sin bisel |
+| [RELAXED_INSET](#RELAXED-INSET) | Inserción relajada |
+| [RIBLET](#RIBLET) | Estría |
+| [SLOPE](#SLOPE) | Pendiente |
+| [SOFT_ROUND](#SOFT-ROUND) | Redondeado suave |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Ángulo
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art déco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Círculo
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Convexo
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Inclinación fresca
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Cruz
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Hueco
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Borde duro
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Sin bisel
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Inserción relajada
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Estría
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Pendiente
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Redondeado suave
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bool/_index.md
+++ b/spanish/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Booleano.
+type: docs
+weight: 29
+url: /es/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+Booleano.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FALSE](#FALSE) | Falso. |
+| [TRUE](#TRUE) | Verdadero. |
+| [UNDEFINED](#UNDEFINED) | Estado indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+Falso.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+Verdadero.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Estado indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/boolvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor booleano.
+type: docs
+weight: 38
+url: /es/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+Valor booleano.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor booleano |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/boolvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+| unidad | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Valor booleano
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bullet/_index.md
+++ b/spanish/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de viñeta.
+type: docs
+weight: 39
+url: /es/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+Determina el estilo de viñeta.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina el estilo de viñeta. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bullet\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina el estilo de viñeta.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/bullet\\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de viñeta.
+type: docs
+weight: 40
+url: /es/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+Determina el estilo de viñeta.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NONE](#NONE) | Ninguno. |
+| [STYLE_1](#STYLE-1) | Punto. |
+| [STYLE_2](#STYLE-2) | Rombo. |
+| [STYLE_3](#STYLE-3) | Cuadrado. |
+| [STYLE_4](#STYLE-4) | Cuadrado grande. |
+| [STYLE_5](#STYLE-5) | Rombos. |
+| [STYLE_6](#STYLE-6) | Flecha. |
+| [STYLE_7](#STYLE-7) | Marca. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ninguno.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Punto.
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Rombo.
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Cuadrado.
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Cuadrado grande.
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Rombos.
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Flecha.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+Marca.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/calendar/_index.md
+++ b/spanish/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el calendario que se utiliza para los campos de texto de propiedades personalizadas y las fórmulas de los elementos.
+type: docs
+weight: 41
+url: /es/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/calendar\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/calendar\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/calendar\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ValorCalendario
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el calendario que se utiliza para los campos de texto de propiedades personalizadas y las fórmulas de los elementos.
+type: docs
+weight: 42
+url: /es/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Árabe hijri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | Inglés transliterado. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | Francés transliterado. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebreo lunar. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Reinado del Emperador japonés. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Koreano Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Era Saka. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Calendario taiwanés. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Budista tailandés. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [WESTERN](#WESTERN) | Occidental. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Árabe hijri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+Inglés transliterado.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+Francés transliterado.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebreo lunar.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Reinado del Emperador japonés.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Koreano Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Era Saka.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Calendario taiwanés.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Budista tailandés.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Occidental.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/case/_index.md
+++ b/spanish/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el caso del texto de una forma.
+type: docs
+weight: 43
+url: /es/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+Determina la capitalización del texto de una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Case(int value)](#Case-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina la capitalización del texto de una forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/case\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/case\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la capitalización del texto de una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/case\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/case\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/casevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el caso del texto de una forma.
+type: docs
+weight: 44
+url: /es/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+Determina el caso del texto de una forma. Todas las letras mayúsculas (uppercase) (1) y las letras iniciales mayúsculas (2) no cambian la apariencia del texto que se ingresó en mayúsculas. El texto debe ingresarse en minúsculas para que estas opciones tengan efecto.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | Todas las letras en mayúsculas (uppercase). |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | Solo letras iniciales en mayúscula. |
+| [NORMAL_CASE](#NORMAL-CASE) | Caso normal. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+Todas las letras en mayúsculas (uppercase).
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+Solo letras iniciales en mayúscula.
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+Caso normal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/char/_index.md
+++ b/spanish/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene los atributos de formato para el texto de las formas, como el color de fuente, estilo de texto, mayúsculas/minúsculas, posición relativa a la línea base y tamaño del punto.
+type: docs
+weight: 45
+url: /es/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+Contiene los atributos de formato para el texto de la forma, como fuente, color, estilo de texto, capitalización, posición relativa a la línea base y tamaño de punto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Char()](#Char--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | Especifica el número de ID de la fuente utilizada para formatear texto que contiene caracteres asiáticos. |
+| [getAsianFontName()](#getAsianFontName--) | Especifica el nombre de la fuente asiática de la fuente utilizada para formatear el texto. Se usa para Visio 2013. |
+| [getCase()](#getCase--) | Determina la capitalización del texto de una forma. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Cuando está contenido en un elemento Char, el elemento Color. |
+| [getColorTrans()](#getColorTrans--) | Determina el grado de transparencia del color del texto de una capa o forma, de 0 (completamente opaco) a 1 (completamente transparente). |
+| [getComplexScriptFont()](#getComplexScriptFont--) | Contiene el número de la fuente utilizada para formatear texto compuesto por caracteres de escritura compleja. |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | Especifica el nombre de la fuente ComplexScript de la fuente utilizada para formatear el texto. Se usa para Visio 2013. |
+| [getComplexScriptSize()](#getComplexScriptSize--) | El tamaño de la fuente utilizada para formatear texto compuesto por caracteres de escritura compleja. |
+| [getDblUnderline()](#getDblUnderline--) | Especifica si el rango de texto tiene un subrayado doble debajo. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | Determina si el texto está formateado como doble tachado. |
+| [getFont()](#getFont--) | Especifica el número de ID de la fuente utilizada para formatear el texto. |
+| [getFontName()](#getFontName--) | Especifica el nombre de la fuente utilizada para formatear el texto. Se usa para Visio 2013 |
+| [getFontScale()](#getFontScale--) | Especifica el ancho de la fuente. |
+| [getHighlight()](#getHighlight--) | Especifica el resaltado. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getLangID()](#getLangID--) | Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario. |
+| [getLetterspace()](#getLetterspace--) | Especifica la cantidad de espacio entre dos o más caracteres. |
+| [getLocale()](#getLocale--) | Especifica la configuración regional del segmento de texto para fines de corrección ortográfica. |
+| [getLocalizeFont()](#getLocalizeFont--) | Especifica si el texto de la forma debe localizarse (traducirse a otro idioma). |
+| [getOverline()](#getOverline--) | Especifica si el texto tiene una línea encima. |
+| [getPerpendicular()](#getPerpendicular--) | Especifica si un campo de texto aparece perpendicular al otro texto en un bloque de texto. |
+| [getPos()](#getPos--) | Especifica la posición del texto de la forma respecto a la línea base. |
+| [getRTLText()](#getRTLText--) | Determina si la dirección del texto del segmento de caracteres actual es de izquierda a derecha o de derecha a izquierda. |
+| [getSize()](#getSize--) | Especifica el tamaño del texto en el bloque de texto de la forma. |
+| [getStrikethru()](#getStrikethru--) | Especifica si el texto está formateado como tachado. |
+| [getStyle()](#getStyle--) | Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma. |
+| [getUseVertical()](#getUseVertical--) | Determina si el segmento de caracteres es vertical u horizontal. |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | Indica si la fuente está en negrita. |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | Indica si la fuente tiene doble tachado. |
+| [isDoubleUnderline()](#isDoubleUnderline--) | Indica si la fuente tiene doble subrayado. |
+| [isItalic()](#isItalic--) | Indica si la fuente está en cursiva. |
+| [isStrikethrough()](#isStrikethrough--) | Indica si la fuente está tachada. |
+| [isSubscript()](#isSubscript--) | Indica si la fuente está en subíndice. |
+| [isSuperscript()](#isSuperscript--) | Indica si la fuente está en superíndice. |
+| [isUnderline()](#isUnderline--) | Indica si la fuente está subrayada. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | Para la descripción de esta propiedad, consulte [getCase()](../../com.aspose.diagram/char\#getCase--) |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/char\#getColor--) |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--) |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--) |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--) |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--) |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/char\#getDel--) |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--) |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getFont()](../../com.aspose.diagram/char\#getFont--) |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getFontName()](../../com.aspose.diagram/char\#getFontName--) |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getFontScale()](../../com.aspose.diagram/char\#getFontScale--) |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getHighlight()](../../com.aspose.diagram/char\#getHighlight--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/char\#getIX--) |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getLangID()](../../com.aspose.diagram/char\#getLangID--) |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--) |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getLocale()](../../com.aspose.diagram/char\#getLocale--) |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | Para la descripción de esta propiedad, consulte [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--) |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getOverline()](../../com.aspose.diagram/char\#getOverline--) |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--) |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | Para la descripción de esta propiedad, consulte [getPos()](../../com.aspose.diagram/char\#getPos--) |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getRTLText()](../../com.aspose.diagram/char\#getRTLText--) |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getSize()](../../com.aspose.diagram/char\#getSize--) |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--) |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | Para la descripción de esta propiedad, consulte [getStyle()](../../com.aspose.diagram/char\#getStyle--) |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+Especifica el número de ID de la fuente utilizada para formatear texto que contiene caracteres asiáticos.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+Especifica el nombre de la fuente asiática de la fuente utilizada para formatear el texto. Se usa para Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+Determina la capitalización del texto de una forma.
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Cuando está contenido en un elemento Char, el elemento Color.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Determina el grado de transparencia del color del texto de una capa o forma, de 0 (completamente opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+Contiene el número de la fuente utilizada para formatear texto compuesto por caracteres de escritura compleja. Las escrituras complejas son lenguajes cuyos caracteres requieren ligadura o conformación, como los idiomas de derecha a izquierda (árabe, persa, hebreo y urdu) y varios idiomas del sur de Asia.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+Especifica el nombre de la fuente ComplexScript de la fuente utilizada para formatear el texto. Se usa para Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+El tamaño de la fuente utilizada para formatear texto compuesto por caracteres de scripts complejos. Los scripts complejos son lenguajes cuyos caracteres requieren ligadura o conformación, como los idiomas de derecha a izquierda (árabe, persa, hebreo y urdu) y varios idiomas del sur de Asia.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+Especifica si el rango de texto tiene un subrayado doble debajo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+Determina si el texto está formateado como doble tachado.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+Especifica el número de ID de la fuente utilizada para formatear el texto.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+Especifica el nombre de la fuente utilizada para formatear el texto. Se usa para Visio 2013
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+Especifica el ancho de la fuente.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+Especifica el resaltado.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de celda, el texto, la propiedad personalizada o el comentario. Para obtener una lista de los idiomas compatibles con las aplicaciones de Microsoft Office y sus correspondientes IDs de idioma, consulte el elemento DocLangID.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+Especifica la cantidad de espacio entre dos o más caracteres. El espacio puede añadirse o restarse en incrementos de 1/20 de punto.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+Especifica la configuración regional del segmento de texto para fines de corrección ortográfica.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+Especifica si el texto de la forma debe localizarse (traducirse a otro idioma).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+Especifica si el texto tiene una línea encima.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+Especifica si un campo de texto aparece perpendicular al otro texto en un bloque de texto.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+Especifica la posición del texto de la forma respecto a la línea base.
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+Determina si la dirección del texto del segmento de caracteres actual es de izquierda a derecha o de derecha a izquierda.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+Especifica el tamaño del texto en el bloque de texto de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+Especifica si el texto está formateado como tachado.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma.
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+Determina si el segmento de caracteres es vertical u horizontal.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+Indica si la fuente está en negrita.
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+Indica si la fuente tiene doble tachado.
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+Indica si la fuente tiene doble subrayado.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+Indica si la fuente está en cursiva.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+Indica si la fuente está tachada.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+Indica si la fuente está en subíndice.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+Indica si la fuente está en superíndice.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+Indica si la fuente está subrayada.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCase()](../../com.aspose.diagram/char\#getCase--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/char\#getColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/char\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFont()](../../com.aspose.diagram/char\#getFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFontName()](../../com.aspose.diagram/char\#getFontName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/char\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLangID()](../../com.aspose.diagram/char\#getLangID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocale()](../../com.aspose.diagram/char\#getLocale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOverline()](../../com.aspose.diagram/char\#getOverline--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPos()](../../com.aspose.diagram/char\#getPos--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSize()](../../com.aspose.diagram/char\#getSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStyle()](../../com.aspose.diagram/char\#getStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/charcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de caracteres.
+type: docs
+weight: 46
+url: /es/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+Colección de caracteres.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | Agregue el objeto Char en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getChar(int IX)](#getChar-int-) | Obtiene el elemento en el IX especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | Elimine el objeto Char de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+Agregue el objeto Char en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+Obtiene el elemento en el IX especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int | intEl índice basado en cero del elemento dentro de su elemento padre. |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+Elimine el objeto Char de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX CheckBox.
+type: docs
+weight: 47
+url: /es/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+Representa un control ActiveX CheckBox.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | la tecla de acceso rápido para el control. |
+| [getAlignment()](#getAlignment--) | la posición del Caption relativa al control. |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getCaption()](#getCaption--) | el texto descriptivo que aparece en un control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getGroupName()](#getGroupName--) | el nombre del grupo. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPicturePosition()](#getPicturePosition--) | la ubicación de la imagen del control relativa a su leyenda. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getValue()](#getValue--) | Indica si el control está marcado o no. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isChecked()](#isChecked--) | Indica si la casilla está marcada. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isTripleState()](#isTripleState--) | Indica cómo el control especificado mostrará los valores Null. |
+| [isWordWrapped()](#isWordWrapped--) | Indica si el contenido del control se ajusta automáticamente al final de una línea. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) |
+| [setChecked(boolean value)](#setChecked-boolean-) | Para la descripción de esta propiedad, consulte [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+la tecla de acceso rápido para el control.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+la posición del Caption relativa al control.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+el texto descriptivo que aparece en un control.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+el nombre del grupo.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la ubicación de la imagen del control relativa a su leyenda.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica si el control está marcado o no.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+Indica si la casilla está marcada.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica cómo el control especificado mostrará los valores Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Configuración | Descripción                                                                                                                                     |
+| True    | El control ciclará a través de los estados para los valores Sí, No y Null. El control aparece atenuado (gris) cuando su propiedad Value está establecida en Null. |
+| False   | (Predeterminado) El control ciclará a través de los estados para los valores Sí y No. Los valores Null se muestran como si fueran valores No.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica si el contenido del control se ajusta automáticamente al final de una línea.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/spanish/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de valor de verificación del check box.
+type: docs
+weight: 48
+url: /es/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+Representa el tipo de valor de verificación del check box.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CHECKED](#CHECKED) | Marcado |
+| [MIXED](#MIXED) | Mixto |
+| [UN_CHECKED](#UN-CHECKED) | Desmarcado |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+Marcado
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+Mixto
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+Desmarcado
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/collection/_index.md
+++ b/spanish/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: Colección
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Es la clase base para colecciones.
+type: docs
+weight: 49
+url: /es/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+Es la clase base para colecciones.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Collection()](#Collection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+Constructor.
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/collectionbase/_index.md
+++ b/spanish/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Proporciona la clase base abstracta para una colección fuertemente tipada.
+type: docs
+weight: 50
+url: /es/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+Proporciona la clase base abstracta para una colección fuertemente tipada.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | Inicializa una nueva instancia de la clase CollectionBase con la capacidad inicial predeterminada. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | Inicializa una nueva instancia de la clase CollectionBase con la capacidad especificada. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Agrega un elemento a la instancia de CollectionBase. |
+| [clear()](#clear--) | Elimina todos los objetos de la instancia de CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Devuelve si la instancia contiene este objeto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene un elemento en la posición especificada. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos contenidos en la instancia de CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+| [iterator()](#iterator--) | Devuelve un enumerador que recorre la instancia de CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Elimina el elemento en el índice especificado. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+Inicializa una nueva instancia de la clase CollectionBase con la capacidad inicial predeterminada.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+Inicializa una nueva instancia de la clase CollectionBase con la capacidad especificada.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| capacidad | int | El número de elementos que la nueva lista puede almacenar inicialmente. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Agrega un elemento a la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | El objeto a agregar a la instancia de CollectionBase. |
+
+**Returns:**
+int - La posición en la que se insertó el nuevo elemento.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los objetos de la instancia de CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Devuelve si la instancia contiene este objeto
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | objeto de prueba |
+
+**Returns:**
+boolean - Indica si la instancia contiene este objeto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+Obtiene un elemento en la posición especificada.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de posición especificado. |
+
+**Returns:**
+java.lang.Object - El elemento en la posición especificada.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos contenidos en la instancia de CollectionBase.
+
+**Returns:**
+int - El número de elementos contenidos en la instancia de CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina el índice de un elemento específico en la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+
+**Returns:**
+int - El índice del valor si se encuentra en la lista; de lo contrario, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Devuelve un enumerador que recorre la instancia de CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iterador para la instancia de CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Elimina el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | El índice basado en cero del elemento a eliminar. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/color/_index.md
+++ b/spanish/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un color ARGB alfa rojo verde azul.
+type: docs
+weight: 51
+url: /es/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+Representa un color ARGB (alfa, rojo, verde, azul).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Color()](#Color--) | función constructora |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Comprueba si el objeto especificado es un objeto Color y es equivalente a este objeto. |
+| [fromArgb(int argb)](#fromArgb-int-) | Crea un objeto Color a partir de un valor ARGB de 32 bits. |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | Crea un objeto Color a partir de los valores de color de 8 bits especificados (rojo, verde y azul). |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | Crea un objeto Color a partir de los cuatro valores de componentes ARGB (alfa, rojo, verde y azul). |
+| [getA()](#getA--) | Obtiene el valor del componente alfa de este objeto Color. |
+| [getAliceBlue()](#getAliceBlue--) | Obtenga un color definido por el sistema. |
+| [getAntiqueWhite()](#getAntiqueWhite--) | Obtenga un color definido por el sistema. |
+| [getAqua()](#getAqua--) | Obtenga un color definido por el sistema. |
+| [getAquamarine()](#getAquamarine--) | Obtenga un color definido por el sistema. |
+| [getAzure()](#getAzure--) | Obtenga un color definido por el sistema. |
+| [getB()](#getB--) | Obtiene el valor del componente azul de este objeto Color. |
+| [getBeige()](#getBeige--) | Obtenga un color definido por el sistema. |
+| [getBisque()](#getBisque--) | Obtenga un color definido por el sistema. |
+| [getBlack()](#getBlack--) | Obtenga un color definido por el sistema. |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | Obtenga un color definido por el sistema. |
+| [getBlue()](#getBlue--) | Obtenga un color definido por el sistema. |
+| [getBlueViolet()](#getBlueViolet--) | Obtenga un color definido por el sistema. |
+| [getBrown()](#getBrown--) | Obtenga un color definido por el sistema. |
+| [getBurlyWood()](#getBurlyWood--) | Obtenga un color definido por el sistema. |
+| [getCadetBlue()](#getCadetBlue--) | Obtenga un color definido por el sistema. |
+| [getChartreuse()](#getChartreuse--) | Obtenga un color definido por el sistema. |
+| [getChocolate()](#getChocolate--) | Obtenga un color definido por el sistema. |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | Obtenga un color definido por el sistema. |
+| [getCornflowerBlue()](#getCornflowerBlue--) | Obtenga un color definido por el sistema. |
+| [getCornsilk()](#getCornsilk--) | Obtenga un color definido por el sistema. |
+| [getCrimson()](#getCrimson--) | Obtenga un color definido por el sistema. |
+| [getCyan()](#getCyan--) | Obtenga un color definido por el sistema. |
+| [getDarkBlue()](#getDarkBlue--) | Obtenga un color definido por el sistema. |
+| [getDarkCyan()](#getDarkCyan--) | Obtenga un color definido por el sistema. |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | Obtenga un color definido por el sistema. |
+| [getDarkGray()](#getDarkGray--) | Obtenga un color definido por el sistema. |
+| [getDarkGreen()](#getDarkGreen--) | Obtenga un color definido por el sistema. |
+| [getDarkKhaki()](#getDarkKhaki--) | Obtenga un color definido por el sistema. |
+| [getDarkMagenta()](#getDarkMagenta--) | Obtenga un color definido por el sistema. |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | Obtenga un color definido por el sistema. |
+| [getDarkOrange()](#getDarkOrange--) | Obtenga un color definido por el sistema. |
+| [getDarkOrchid()](#getDarkOrchid--) | Obtenga un color definido por el sistema. |
+| [getDarkRed()](#getDarkRed--) | Obtenga un color definido por el sistema. |
+| [getDarkSalmon()](#getDarkSalmon--) | Obtenga un color definido por el sistema. |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | Obtenga un color definido por el sistema. |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | Obtenga un color definido por el sistema. |
+| [getDarkSlateGray()](#getDarkSlateGray--) | Obtenga un color definido por el sistema. |
+| [getDarkTurquoise()](#getDarkTurquoise--) | Obtenga un color definido por el sistema. |
+| [getDarkViolet()](#getDarkViolet--) | Obtenga un color definido por el sistema. |
+| [getDeepPink()](#getDeepPink--) | Obtenga un color definido por el sistema. |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | Obtenga un color definido por el sistema. |
+| [getDimGray()](#getDimGray--) | Obtenga un color definido por el sistema. |
+| [getDodgerBlue()](#getDodgerBlue--) | Obtenga un color definido por el sistema. |
+| [getEmpty()](#getEmpty--) | Obtenga un color vacío definido por el sistema. |
+| [getFirebrick()](#getFirebrick--) | Obtenga un color definido por el sistema. |
+| [getFloralWhite()](#getFloralWhite--) | Obtenga un color definido por el sistema. |
+| [getForestGreen()](#getForestGreen--) | Obtenga un color definido por el sistema. |
+| [getFuchsia()](#getFuchsia--) | Obtenga un color definido por el sistema. |
+| [getG()](#getG--) | Obtiene el valor del componente verde de este objeto Color. |
+| [getGainsboro()](#getGainsboro--) | Obtenga un color definido por el sistema. |
+| [getGhostWhite()](#getGhostWhite--) | Obtenga un color definido por el sistema. |
+| [getGold()](#getGold--) | Obtenga un color definido por el sistema. |
+| [getGoldenrod()](#getGoldenrod--) | Obtenga un color definido por el sistema. |
+| [getGray()](#getGray--) | Obtenga un color definido por el sistema. |
+| [getGreen()](#getGreen--) | Obtenga un color definido por el sistema. |
+| [getGreenYellow()](#getGreenYellow--) | Obtenga un color definido por el sistema. |
+| [getHoneydew()](#getHoneydew--) | Obtenga un color definido por el sistema. |
+| [getHotPink()](#getHotPink--) | Obtenga un color definido por el sistema. |
+| [getIndianRed()](#getIndianRed--) | Obtenga un color definido por el sistema. |
+| [getIndigo()](#getIndigo--) | Obtenga un color definido por el sistema. |
+| [getIvory()](#getIvory--) | Obtenga un color definido por el sistema. |
+| [getKhaki()](#getKhaki--) | Obtenga un color definido por el sistema. |
+| [getLavender()](#getLavender--) | Obtenga un color definido por el sistema. |
+| [getLavenderBlush()](#getLavenderBlush--) | Obtenga un color definido por el sistema. |
+| [getLawnGreen()](#getLawnGreen--) | Obtenga un color definido por el sistema. |
+| [getLemonChiffon()](#getLemonChiffon--) | Obtenga un color definido por el sistema. |
+| [getLightBlue()](#getLightBlue--) | Obtenga un color definido por el sistema. |
+| [getLightCoral()](#getLightCoral--) | Obtenga un color definido por el sistema. |
+| [getLightCyan()](#getLightCyan--) | Obtenga un color definido por el sistema. |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | Obtenga un color definido por el sistema. |
+| [getLightGray()](#getLightGray--) | Obtenga un color definido por el sistema. |
+| [getLightGreen()](#getLightGreen--) | Obtenga un color definido por el sistema. |
+| [getLightPink()](#getLightPink--) | Obtenga un color definido por el sistema. |
+| [getLightSalmon()](#getLightSalmon--) | Obtenga un color definido por el sistema. |
+| [getLightSeaGreen()](#getLightSeaGreen--) | Obtenga un color definido por el sistema. |
+| [getLightSkyBlue()](#getLightSkyBlue--) | Obtenga un color definido por el sistema. |
+| [getLightSlateGray()](#getLightSlateGray--) | Obtenga un color definido por el sistema. |
+| [getLightSteelBlue()](#getLightSteelBlue--) | Obtenga un color definido por el sistema. |
+| [getLightYellow()](#getLightYellow--) | Obtenga un color definido por el sistema. |
+| [getLime()](#getLime--) | Obtenga un color definido por el sistema. |
+| [getLimeGreen()](#getLimeGreen--) | Obtenga un color definido por el sistema. |
+| [getLinen()](#getLinen--) | Obtenga un color definido por el sistema. |
+| [getMagenta()](#getMagenta--) | Obtenga un color definido por el sistema. |
+| [getMaroon()](#getMaroon--) | Obtenga un color definido por el sistema. |
+| [getMediumAquamarine()](#getMediumAquamarine--) | Obtenga un color definido por el sistema. |
+| [getMediumBlue()](#getMediumBlue--) | Obtenga un color definido por el sistema. |
+| [getMediumOrchid()](#getMediumOrchid--) | Obtenga un color definido por el sistema. |
+| [getMediumPurple()](#getMediumPurple--) | Obtenga un color definido por el sistema. |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | Obtenga un color definido por el sistema. |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | Obtenga un color definido por el sistema. |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | Obtenga un color definido por el sistema. |
+| [getMediumTurquoise()](#getMediumTurquoise--) | Obtenga un color definido por el sistema. |
+| [getMediumVioletRed()](#getMediumVioletRed--) | Obtenga un color definido por el sistema. |
+| [getMidnightBlue()](#getMidnightBlue--) | Obtenga un color definido por el sistema. |
+| [getMintCream()](#getMintCream--) | Obtenga un color definido por el sistema. |
+| [getMistyRose()](#getMistyRose--) | Obtenga un color definido por el sistema. |
+| [getMoccasin()](#getMoccasin--) | Obtenga un color definido por el sistema. |
+| [getNavajoWhite()](#getNavajoWhite--) | Obtenga un color definido por el sistema. |
+| [getNavy()](#getNavy--) | Obtenga un color definido por el sistema. |
+| [getOldLace()](#getOldLace--) | Obtenga un color definido por el sistema. |
+| [getOlive()](#getOlive--) | Obtenga un color definido por el sistema. |
+| [getOliveDrab()](#getOliveDrab--) | Obtenga un color definido por el sistema. |
+| [getOrange()](#getOrange--) | Obtenga un color definido por el sistema. |
+| [getOrangeRed()](#getOrangeRed--) | Obtenga un color definido por el sistema. |
+| [getOrchid()](#getOrchid--) | Obtenga un color definido por el sistema. |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | Obtenga un color definido por el sistema. |
+| [getPaleGreen()](#getPaleGreen--) | Obtenga un color definido por el sistema. |
+| [getPaleTurquoise()](#getPaleTurquoise--) | Obtenga un color definido por el sistema. |
+| [getPaleVioletRed()](#getPaleVioletRed--) | Obtenga un color definido por el sistema. |
+| [getPapayaWhip()](#getPapayaWhip--) | Obtenga un color definido por el sistema. |
+| [getPeachPuff()](#getPeachPuff--) | Obtenga un color definido por el sistema. |
+| [getPeru()](#getPeru--) | Obtenga un color definido por el sistema. |
+| [getPink()](#getPink--) | Obtenga un color definido por el sistema. |
+| [getPlum()](#getPlum--) | Obtenga un color definido por el sistema. |
+| [getPowderBlue()](#getPowderBlue--) | Obtenga un color definido por el sistema. |
+| [getPurple()](#getPurple--) | Obtenga un color definido por el sistema. |
+| [getR()](#getR--) | Obtiene el valor del componente rojo de este objeto Color. |
+| [getRed()](#getRed--) | Obtenga un color definido por el sistema. |
+| [getRosyBrown()](#getRosyBrown--) | Obtenga un color definido por el sistema. |
+| [getRoyalBlue()](#getRoyalBlue--) | Obtenga un color definido por el sistema. |
+| [getSaddleBrown()](#getSaddleBrown--) | Obtenga un color definido por el sistema. |
+| [getSalmon()](#getSalmon--) | Obtenga un color definido por el sistema. |
+| [getSandyBrown()](#getSandyBrown--) | Obtenga un color definido por el sistema. |
+| [getSeaGreen()](#getSeaGreen--) | Obtenga un color definido por el sistema. |
+| [getSeaShell()](#getSeaShell--) | Obtenga un color definido por el sistema. |
+| [getSienna()](#getSienna--) | Obtenga un color definido por el sistema. |
+| [getSilver()](#getSilver--) | Obtenga un color definido por el sistema. |
+| [getSkyBlue()](#getSkyBlue--) | Obtenga un color definido por el sistema. |
+| [getSlateBlue()](#getSlateBlue--) | Obtenga un color definido por el sistema. |
+| [getSlateGray()](#getSlateGray--) | Obtenga un color definido por el sistema. |
+| [getSnow()](#getSnow--) | Obtenga un color definido por el sistema. |
+| [getSpringGreen()](#getSpringGreen--) | Obtenga un color definido por el sistema. |
+| [getSteelBlue()](#getSteelBlue--) | Obtenga un color definido por el sistema. |
+| [getTan()](#getTan--) | Obtenga un color definido por el sistema. |
+| [getTeal()](#getTeal--) | Obtenga un color definido por el sistema. |
+| [getThistle()](#getThistle--) | Obtenga un color definido por el sistema. |
+| [getTomato()](#getTomato--) | Obtenga un color definido por el sistema. |
+| [getTransparent()](#getTransparent--) | Obtenga un color definido por el sistema. |
+| [getTurquoise()](#getTurquoise--) | Obtenga un color definido por el sistema. |
+| [getViolet()](#getViolet--) | Obtenga un color definido por el sistema. |
+| [getWheat()](#getWheat--) | Obtenga un color definido por el sistema. |
+| [getWhite()](#getWhite--) | Obtenga un color definido por el sistema. |
+| [getWhiteSmoke()](#getWhiteSmoke--) | Obtenga un color definido por el sistema. |
+| [getYellow()](#getYellow--) | Obtenga un color definido por el sistema. |
+| [getYellowGreen()](#getYellowGreen--) | Obtenga un color definido por el sistema. |
+| [hashCode()](#hashCode--) | Devuelve un código hash para este objeto Color. |
+| [isEmpty()](#isEmpty--) | Especifica si este objeto Color no está inicializado. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | Obtiene el valor ARGB de 32 bits de este objeto Color. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+función constructora
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Comprueba si el objeto especificado es un objeto Color y es equivalente a este objeto.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object | El objeto a probar. |
+
+**Returns:**
+boolean - verdadero si obj es un objeto Color y es equivalente a este objeto Color; de lo contrario, falso.
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+Crea un objeto Color a partir de un valor ARGB de 32 bits.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| argb | int | Un valor que especifica el valor ARGB de 32 bits. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+Crea un objeto Color a partir de los valores de color de 8 bits especificados (rojo, verde y azul). El valor alfa es implícitamente 255 (totalmente opaco). Aunque este método permite pasar un valor de 32 bits para cada componente de color, el valor de cada componente está limitado a 8 bits.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| red | int | El valor del componente rojo para el nuevo objeto Color. Los valores válidos son de 0 a 255. |
+| verde | int | El valor del componente verde para el nuevo objeto Color. Los valores válidos están entre 0 y 255. |
+| azul | int | El valor del componente azul para el nuevo objeto Color. Los valores válidos están entre 0 y 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+Crea un objeto Color a partir de los cuatro valores de componentes ARGB (alfa, rojo, verde y azul). Aunque este método permite pasar un valor de 32 bits para cada componente, el valor de cada componente está limitado a 8 bits.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| alfa | int | El componente alfa. Los valores válidos están entre 0 y 255. |
+| red | int | El componente rojo. Los valores válidos están entre 0 y 255. |
+| verde | int | El componente verde. Los valores válidos están entre 0 y 255. |
+| azul | int | El componente azul. Los valores válidos están entre 0 y 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+Obtiene el valor del componente alfa de este objeto Color.
+
+**Returns:**
+byte - El valor del componente alfa de este objeto Color.
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+Obtiene el valor del componente azul de este objeto Color.
+
+**Returns:**
+byte - El valor del componente azul de este objeto Color.
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+Obtenga un color vacío definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+Obtiene el valor del componente verde de este objeto Color.
+
+**Returns:**
+byte - El valor del componente verde de este objeto Color.
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+Obtiene el valor del componente rojo de este objeto Color.
+
+**Returns:**
+byte - El valor del componente rojo de este objeto Color.
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+Obtenga un color definido por el sistema.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Devuelve un código hash para este objeto Color.
+
+**Returns:**
+int - Un valor entero que especifica el código hash para este objeto Color.
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Especifica si este objeto Color no está inicializado.
+
+**Returns:**
+boolean - Esta propiedad devuelve true si este color no está inicializado; de lo contrario, false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+Obtiene el valor ARGB de 32 bits de este objeto Color.
+
+**Returns:**
+int - El valor ARGB de 32 bits de este objeto Color.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/colorentry/_index.md
+++ b/spanish/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una entrada de tabla de colores.
+type: docs
+weight: 52
+url: /es/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+Contiene una entrada de tabla de colores. Cada entrada de tabla de colores especifica un color estándar que está disponible para aplicarse a objetos como formas, texto y capas en el documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Representa un color ARGB. |
+| [getIX()](#getIX--) | Entero requerido. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/colorentry\#getColor--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/colorentry\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Representa un color ARGB.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Entero requerido. El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/colorentry\#getColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/colorentry\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/spanish/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene la tabla de colores del documento.
+type: docs
+weight: 53
+url: /es/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+Contiene la tabla de colores del documento. Cada documento contiene una única tabla de colores, que enumera los 24 colores estándar que están disponibles para aplicarse a objetos como shapes, texto y capas en el documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | Añada el objeto Color a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | Elimine el objeto Color de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+Añada el objeto Color a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+Elimine el objeto Color de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/colorvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un valor de color
+type: docs
+weight: 54
+url: /es/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+Representa un valor de color
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor de color. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/colorvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+| unidad | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valor de color. Para establecer el color, introduzca un número del 0 al 23 o el valor RGB en notación hexadecimal.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX ComboBox.
+type: docs
+weight: 55
+url: /es/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+Representa un control ActiveX ComboBox.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | el color OLE del fondo. |
+| [getBorderStyle()](#getBorderStyle--) | el tipo de borde utilizado por el control. |
+| [getBoundColumn()](#getBoundColumn--) | Representa cómo se determina la propiedad Value para un ComboBox o ListBox cuando el valor de la propiedad MultiSelect (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Representa el número de columnas a mostrar en un ComboBox o ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | el ancho de la columna. |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Especifica el símbolo que se muestra en el botón desplegable |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Especifica el comportamiento de selección al entrar al control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getHideSelection()](#getHideSelection--) | Indica si el texto seleccionado en el control aparece resaltado cuando el control no tiene el foco. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getListRows()](#getListRows--) | Representa el número máximo de filas que se mostrarán en la lista. |
+| [getListStyle()](#getListStyle--) | la apariencia visual. |
+| [getListWidth()](#getListWidth--) | el ancho en unidades de puntos. |
+| [getMatchEntry()](#getMatchEntry--) | Indica cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe. |
+| [getMaxLength()](#getMaxLength--) | el número máximo de caracteres |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getSelectionMargin()](#getSelectionMargin--) | Indica si el usuario puede seleccionar una línea de texto haciendo clic en la zona a la izquierda del texto. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indica si se muestran los encabezados de columna. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Especifica el símbolo que se muestra en el botón desplegable |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getTextColumn()](#getTextColumn--) | Representa la columna en un ComboBox o ListBox que se mostrará al usuario. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getValue()](#getValue--) | el valor del control. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Especifica la unidad básica utilizada para ampliar una selección. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indica si arrastrar y soltar está habilitado para el control. |
+| [isEditable()](#isEditable--) | Indica si el usuario puede escribir en el control. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Para la descripción de esta propiedad, consulte [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Para la descripción de esta propiedad, consulte [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Para la descripción de esta propiedad, consulte [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Para la descripción de esta propiedad, consulte [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Para la descripción de esta propiedad, consulte [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Para la descripción de esta propiedad, consulte [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Para la descripción de esta propiedad, consulte [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Para la descripción de esta propiedad, consulte [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setListRows(int value)](#setListRows-int-) | Para la descripción de esta propiedad, consulte [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) |
+| [setListStyle(int value)](#setListStyle-int-) | Para la descripción de esta propiedad, consulte [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Para la descripción de esta propiedad, consulte [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Para la descripción de esta propiedad, consulte [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Para la descripción de esta propiedad, consulte [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | Para la descripción de esta propiedad, consulte [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Para la descripción de esta propiedad, consulte [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Para la descripción de esta propiedad, consulte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Para la descripción de esta propiedad, consulte [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+el tipo de borde utilizado por el control.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Representa cómo se determina la propiedad Value para un ComboBox o ListBox cuando el valor de la propiedad MultiSelect (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Representa el número de columnas a mostrar en un ComboBox o ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+el ancho de la columna.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Especifica el símbolo que se muestra en el botón desplegable
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Especifica el comportamiento de selección al entrar en el control. True especifica que la selección permanece sin cambios desde la última vez que el control estuvo activo. False especifica que todo el texto en el control será seleccionado al entrar en el control.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indica si el texto seleccionado en el control aparece resaltado cuando el control no tiene el foco.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+Representa el número máximo de filas que se mostrarán en la lista.
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+la apariencia visual.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+el ancho en unidades de puntos.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indica cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe.
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+el número máximo de caracteres
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+Indica si el usuario puede seleccionar una línea de texto haciendo clic en la zona a la izquierda del texto.
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indica si se muestran los encabezados de columna.
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Especifica el símbolo que se muestra en el botón desplegable
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Representa la columna en un ComboBox o ListBox que se mostrará al usuario.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+el valor del control.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Especifica la unidad básica utilizada para ampliar una selección. True especifica que la unidad básica es un solo carácter. false especifica que la unidad básica es una palabra completa.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indica si arrastrar y soltar está habilitado para el control.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indica si el usuario puede escribir en el control.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un botón de comando.
+type: docs
+weight: 56
+url: /es/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+Representa un botón de comando.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | la tecla de acceso rápido para el control. |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getCaption()](#getCaption--) | el texto descriptivo que aparece en un control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPicturePosition()](#getPicturePosition--) | la ubicación de la imagen del control relativa a su leyenda. |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | Indica si el control toma el foco cuando se hace clic. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica si el contenido del control se ajusta automáticamente al final de una línea. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--) |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | Para la descripción de esta propiedad, consulte [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+la tecla de acceso rápido para el control.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+el texto descriptivo que aparece en un control.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la ubicación de la imagen del control relativa a su leyenda.
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+Indica si el control toma el foco cuando se hace clic.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica si el contenido del control se ajusta automáticamente al final de una línea.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/compositingquality/_index.md
+++ b/spanish/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el nivel de calidad a usar durante la composición.
+type: docs
+weight: 57
+url: /es/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+Especifica el nivel de calidad a usar durante la composición.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | Asumir valores lineales. |
+| [DEFAULT](#DEFAULT) | Calidad predeterminada. |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | Se usa corrección gamma. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Composición de alta calidad y baja velocidad. |
+| [HIGH_SPEED](#HIGH-SPEED) | Alta velocidad, baja calidad. |
+| [INVALID](#INVALID) | Calidad no válida. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+Asumir valores lineales.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Calidad predeterminada.
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+Se usa corrección gamma.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Composición de alta calidad y baja velocidad.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Alta velocidad, baja calidad.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Calidad no válida.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/compoundtype/_index.md
+++ b/spanish/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tamaño de la punta de flecha de la línea.
+type: docs
+weight: 58
+url: /es/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+Especifica el tamaño de la punta de flecha de la línea.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tamaño de la punta de flecha de la línea. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tamaño de la punta de flecha de la línea.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/compoundtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el estilo de dibujo de líneas.
+type: docs
+weight: 59
+url: /es/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+Representa el estilo de dibujo de líneas.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [SINGLE](#SINGLE) | Línea única (de ancho lineWidth) |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | Tres líneas, delgada, gruesa, delgada |
+| [THICK_THIN](#THICK-THIN) | Líneas dobles, una gruesa, una delgada |
+| [THIN_THICK](#THIN-THICK) | Líneas dobles, una delgada, una gruesa |
+| [THIN_THIN](#THIN-THIN) | Líneas dobles de ancho igual |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Línea única (de ancho lineWidth)
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+Tres líneas, delgada, gruesa, delgada
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+Líneas dobles, una gruesa, una delgada
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+Líneas dobles, una delgada, una gruesa
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+Líneas dobles de ancho igual
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/compressiontype/_index.md
+++ b/spanish/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF.
+type: docs
+weight: 60
+url: /es/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. El valor indica el tipo de compresión aplicado al archivo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [GIF](#GIF) | Compresión GIF. |
+| [JPEG](#JPEG) | Compresión JPEG. |
+| [NO](#NO) | Sin compresión (por defecto). |
+| [PNG](#PNG) | Compresión PNG. |
+| [TIFF](#TIFF) | Compresión TIFF. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Compresión GIF.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Compresión JPEG.
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+Sin compresión (por defecto).
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Compresión PNG.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Compresión TIFF.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/confixedcode/_index.md
+++ b/spanish/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina cuándo se redirige un conector.
+type: docs
+weight: 61
+url: /es/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+Determina cuándo se redirige un conector.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina cuándo se redirige un conector. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina cuándo se redirige un conector.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina cuándo se redirige un conector.
+type: docs
+weight: 62
+url: /es/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+Determina cuándo se redirige un conector.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | Nunca redirigir. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | Redirigir libremente. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | Redirigir según sea necesario. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | Redirigir en cruce. |
+| [RESERVED_1](#RESERVED-1) | Reservado solo para uso interno. |
+| [RESERVED_2](#RESERVED-2) | Reservado solo para uso interno. |
+| [RESERVED_3](#RESERVED-3) | Reservado solo para uso interno. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+Nunca redirigir.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+Redirigir libremente.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+Redirigir según sea necesario.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+Redirigir en cruce.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+Reservado solo para uso interno.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+Reservado solo para uso interno.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+Reservado solo para uso interno.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si un conector salta cuando dos conectores se cruzan.
+type: docs
+weight: 63
+url: /es/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+Determina si un conector salta cuando dos conectores se cruzan.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina si un conector salta cuando dos conectores se cruzan. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina si un conector salta cuando dos conectores se cruzan.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si un conector salta cuando dos conectores se cruzan.
+type: docs
+weight: 64
+url: /es/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+Determina si un conector salta cuando dos conectores se cruzan.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Siempre |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | Ningún salto de conector. |
+| [NEVER](#NEVER) | Nunca. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | Otros saltos de conector. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Siempre
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+Ningún salto de conector.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Nunca.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+Otros saltos de conector.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+type: docs
+weight: 65
+url: /es/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+type: docs
+weight: 66
+url: /es/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DOWN](#DOWN) | Abajo. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [UP](#UP) | Arriba. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Abajo.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Arriba.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+type: docs
+weight: 67
+url: /es/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+type: docs
+weight: 68
+url: /es/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [LEFT](#LEFT) | Izquierda. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [RIGHT](#RIGHT) | Derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+type: docs
+weight: 69
+url: /es/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina el estilo de salto de línea para saltos de línea en un conector dinámico. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+type: docs
+weight: 70
+url: /es/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ARC](#ARC) | Arco. |
+| [GAP](#GAP) | Espacio. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | Cuadrado. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Arco.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Espacio.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Cuadrado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la apariencia de un conector.
+type: docs
+weight: 71
+url: /es/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+Determina la apariencia de un conector.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina la apariencia de un conector. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la apariencia de un conector.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina la apariencia de un conector.
+type: docs
+weight: 72
+url: /es/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+Determina la apariencia de un conector.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CURVED](#CURVED) | Curvado. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [STRAIGHT](#STRAIGHT) | Recto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Curvado.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Recto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connect/_index.md
+++ b/spanish/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa una conexión entre dos formas en un dibujo, como una línea y un cuadro en un organigrama.
+type: docs
+weight: 75
+url: /es/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+Representa una conexión entre dos formas en un dibujo, como una línea y un cuadro en un organigrama.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Connect()](#Connect--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | La celda desde la cual se realiza una conexión. |
+| [getFromPart()](#getFromPart--) | La celda desde la cual se origina una conexión. |
+| [getFromSheet()](#getFromSheet--) | El ID de la forma desde la cual se origina una o varias conexiones. |
+| [getToCell()](#getToCell--) | La celda a la que se realiza una conexión. |
+| [getToPart()](#getToPart--) | La parte de una forma a la que se hace una conexión. |
+| [getToSheet()](#getToSheet--) | El ID de la forma a la que se realiza una o más conexiones |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) |
+| [setFromPart(int value)](#setFromPart-int-) | Para la descripción de esta propiedad, consulte [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) |
+| [setFromSheet(long value)](#setFromSheet-long-) | Para la descripción de esta propiedad, consulte [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) |
+| [setToCell(String value)](#setToCell-java.lang.String-) | Para la descripción de esta propiedad, consulte [getToCell()](../../com.aspose.diagram/connect\#getToCell--) |
+| [setToPart(int value)](#setToPart-int-) | Para la descripción de esta propiedad, consulte [getToPart()](../../com.aspose.diagram/connect\#getToPart--) |
+| [setToSheet(long value)](#setToSheet-long-) | Para la descripción de esta propiedad, consulte [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+La celda desde la cual se realiza una conexión.
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+La celda desde la cual se origina una conexión.
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+El ID de la forma desde la cual se origina una o varias conexiones.
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+La celda a la que se realiza una conexión.
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+La parte de una forma a la que se hace una conexión.
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+El ID de la forma a la que se realiza una o más conexiones
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getToCell()](../../com.aspose.diagram/connect\#getToCell--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getToPart()](../../com.aspose.diagram/connect\#getToPart--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Connect.
+type: docs
+weight: 76
+url: /es/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Colección Connect.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | Agregar la conexión en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | Eliminar la conexión de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+Agregar la conexión en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+Eliminar la conexión de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/spanish/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Filtra la matriz de IDs de forma devueltos por la direccionalidad de los conectores.
+type: docs
+weight: 77
+url: /es/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+Filtra la matriz de IDs de forma devueltos por la direccionalidad de los conectores.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | Devuelve los IDs de las formas que están asociadas tanto a conexiones entrantes como salientes. |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | Devuelve los IDs de las formas que están asociadas a conexiones entrantes. |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | Devuelve los IDs de las formas que están asociadas a conexiones salientes. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+Devuelve los IDs de las formas que están asociadas tanto a conexiones entrantes como salientes.
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+Devuelve los IDs de las formas que están asociadas a conexiones entrantes.
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+Devuelve los IDs de las formas que están asociadas a conexiones salientes.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connection/_index.md
+++ b/spanish/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: Conexión
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos para un punto de conexión definido para la forma.
+type: docs
+weight: 78
+url: /es/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+Contiene elementos para un punto de conexión definido para la forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Connection()](#Connection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | Especifica si el punto de conexión se genera automáticamente. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDirX()](#getDirX--) | Especifica la componente x del vector de alineación requerido de un punto de conexión coincidente. |
+| [getDirY()](#getDirY--) | Especifica la componente y del vector de alineación requerido de un punto de conexión coincidente. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPrompt()](#getPrompt--) | Contiene información de indicación variable, según el elemento en el que se encuentre. |
+| [getType()](#getType--) | Especifica varios tipos, según el elemento en el que está contenido. |
+| [getX()](#getX--) | Especifica una coordenada x en una forma en coordenadas locales. |
+| [getY()](#getY--) | Especifica una coordenada y en una forma en coordenadas locales. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/connection\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/connection\#getID--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/connection\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/connection\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/connection\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+Especifica si el punto de conexión se genera automáticamente. Un valor de 1 indica que el punto de conexión se genera automáticamente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+Especifica la componente x del vector de alineación requerido de un punto de conexión coincidente. El elemento DirX también se usa para orientar la rama adjunta de un conector dinámico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+Especifica la componente y del vector de alineación requerido de un punto de conexión coincidente. El elemento DirY también se usa para orientar la rama adjunta de un conector dinámico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Contiene información de indicación variable, según el elemento en el que se encuentre.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+Especifica varios tipos, según el elemento en el que está contenido.
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Especifica una coordenada x en una forma en coordenadas locales.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Especifica una coordenada y en una forma en coordenadas locales. Las coordenadas locales son aquellas cuyo marco de referencia es la forma, en lugar de la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/connection\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/connection\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/connection\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/connection\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/connection\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/spanish/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El elemento ConnectionABCD es una versión obsoleta del elemento Connection y solo existe para compatibilidad hacia atrás.
+type: docs
+weight: 79
+url: /es/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+El elemento ConnectionABCD es una versión obsoleta del elemento Connection y solo existe para compatibilidad hacia atrás.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Representa información diferente según su elemento padre. |
+| [getB()](#getB--) | Representa información diferente según su elemento padre. |
+| [getC()](#getC--) | Representa información diferente basada en su elemento padre. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Representa información diferente basada en su elemento padre. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getX()](#getX--) | Especifica una coordenada x en una forma en coordenadas locales. |
+| [getY()](#getY--) | Especifica una coordenada y en una forma en coordenadas locales. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/connectionabcd\#getID--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/connectionabcd\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Representa información diferente según su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Representa información diferente según su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Representa información diferente basada en su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Representa información diferente basada en su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Especifica una coordenada x en una forma en coordenadas locales. La tabla siguiente describe el elemento X según el elemento que lo contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Especifica una coordenada y en una forma en coordenadas locales. Las coordenadas locales son aquellas cuyo marco de referencia es la forma, en lugar de la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/connectionabcd\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/connectionabcd\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección ConnectionABCD.
+type: docs
+weight: 80
+url: /es/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+Colección ConnectionABCD.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | Agregue el objeto ConnectionABCD a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | Elimine el objeto ConnectionABCD de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+Agregue el objeto ConnectionABCD a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+Elimine el objeto ConnectionABCD de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/spanish/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Connection.
+type: docs
+weight: 81
+url: /es/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Colección Connection.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | Agregar el objeto Connection a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | Eliminar el objeto Connection de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+Agregar el objeto Connection a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+Eliminar el objeto Connection de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/spanish/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la ubicación en la forma donde se conectará el conector.
+type: docs
+weight: 82
+url: /es/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+Especifica la ubicación en la forma donde se conectará el conector.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Parte inferior de la forma. |
+| [CENTER](#CENTER) | Centro de la forma. |
+| [LEFT](#LEFT) | Izquierda de la forma. |
+| [RIGHT](#RIGHT) | Derecha de la forma. |
+| [TOP](#TOP) | Parte superior de la forma. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Parte inferior de la forma.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro de la forma.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda de la forma.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha de la forma.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Parte superior de la forma.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectorrule/_index.md
+++ b/spanish/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la regla de conector entre dos formas con un connectorIncluding que indica el punto de conexión de qué forma comienza desde la forma final y su punto de conexión.
+type: docs
+weight: 83
+url: /es/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+Representa la regla de conector entre dos formas con un conector, incluyendo qué punto de conexión de qué forma inicia, la forma final y su punto de conexión.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | La conexión de la forma a la que se realiza una conexión. |
+| [getEndShapeId()](#getEndShapeId--) | La forma a la que se realiza una conexión. |
+| [getStartShapeConnection()](#getStartShapeConnection--) | La conexión de la forma desde la que se realiza una conexión. |
+| [getStartShapeId()](#getStartShapeId--) | La forma desde la que se realiza una conexión. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+La conexión de la forma a la que se realiza una conexión.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+La forma a la que se realiza una conexión.
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+La conexión de la forma desde la que se realiza una conexión.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+La forma desde la que se realiza una conexión.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Puede ser uno de los siguientes valores RightAngle StraightLines o CurvedLines.
+type: docs
+weight: 84
+url: /es/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+Puede ser uno de los siguientes valores: RightAngle, StraightLines o CurvedLines. Solo es relevante cuando WindowType se especifica como Drawing o Sheet.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Puede ser uno de los siguientes valores: Document, Page o Master.
+type: docs
+weight: 85
+url: /es/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+Puede ser uno de los siguientes valores: Document, Page o Master. Solo es relevante cuando WindowType se especifica como Drawing o Sheet.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Document. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Page. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Document.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Page.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica las propiedades del grupo o forma a usar para la comparación.
+type: docs
+weight: 86
+url: /es/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+Especifica las propiedades del grupo o forma que se usarán para la comparación. Los valores posibles se muestran en la tabla siguiente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DATA_1](#DATA-1) | Dato1. |
+| [DATA_2](#DATA-2) | Dato2. |
+| [DATA_3](#DATA-3) | Dato3. |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | Ángulo de geometría. |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | Altura de geometría. |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | Ancho de la geometría. |
+| [MASTER_NAME](#MASTER-NAME) | Nombre del maestro. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | Etiqueta del elemento de datos de forma (propiedad personalizada). |
+| [SHAPE_ID](#SHAPE-ID) | ID de forma. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | Nombre local de la forma. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | Texto de la forma. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | Tipo de forma. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | Nombre local de fila de celda de usuario. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+Dato1.
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+Dato2.
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+Dato3.
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+Ángulo de geometría.
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+Altura de geometría.
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+Ancho de la geometría.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+Nombre del maestro.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+Etiqueta del elemento de datos de forma (propiedad personalizada).
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+ID de forma.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+Nombre local de la forma.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+Texto de la forma.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+Tipo de forma.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+Nombre local de fila de celda de usuario.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/control/_index.md
+++ b/spanish/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: Control
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos para las coordenadas x e y de cada controlador definido para una forma y elementos que especifican la forma en que el controlador debe comportarse.
+type: docs
+weight: 87
+url: /es/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+Contiene elementos para las coordenadas x e y de cada mango de control definido para una forma, y elementos que especifican la forma en que el mango de control debe comportarse.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Control()](#Control--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [canGlue()](#canGlue--) | Determina si un controlador puede adherirse a otras formas. |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPrompt()](#getPrompt--) | El elemento de aviso especifica el texto descriptivo que aparece como información sobre herramientas cuando el puntero del ratón se detiene sobre el controlador de una forma. |
+| [getX()](#getX--) | La coordenada x que indica la ubicación del controlador de una forma. |
+| [getXCon()](#getXCon--) | Especifica el tipo de comportamiento que la coordenada x del controlador muestra después de mover el controlador. |
+| [getXDyn()](#getXDyn--) | Especifica la coordenada x del punto de anclaje de un controlador en coordenadas locales. |
+| [getY()](#getY--) | La coordenada y que indica la ubicación del controlador de una forma. |
+| [getYCon()](#getYCon--) | Especifica el tipo de comportamiento que la coordenada x del controlador muestra después de mover el controlador. |
+| [getYDyn()](#getYDyn--) | Especifica la coordenada y del punto de anclaje de un controlador en coordenadas locales. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [canGlue()](../../com.aspose.diagram/control\#canGlue--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/control\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/control\#getID--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/control\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/control\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/control\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/control\#getPrompt--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/control\#getX--) |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | Para la descripción de esta propiedad, consulte [getXCon()](../../com.aspose.diagram/control\#getXCon--) |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getXDyn()](../../com.aspose.diagram/control\#getXDyn--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/control\#getY--) |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | Para la descripción de esta propiedad, consulte [getYCon()](../../com.aspose.diagram/control\#getYCon--) |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getYDyn()](../../com.aspose.diagram/control\#getYDyn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+Constructor.
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+Determina si un controlador puede adherirse a otras formas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+El elemento de aviso especifica el texto descriptivo que aparece como información sobre herramientas cuando el puntero del ratón se detiene sobre el controlador de una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x que indica la ubicación del controlador de una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+Especifica el tipo de comportamiento que la coordenada x del controlador muestra después de mover el controlador.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+Especifica la coordenada x del punto de anclaje de un controlador en coordenadas locales. El punto de anclaje se usa para rubber-banding durante la dinámica.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y que indica la ubicación del controlador de una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+Especifica el tipo de comportamiento que la coordenada x del controlador muestra después de mover el controlador.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+Especifica la coordenada y del punto de anclaje de un controlador en coordenadas locales. El punto de anclaje se usa para rubber-banding durante la dinámica.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [canGlue()](../../com.aspose.diagram/control\#canGlue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/control\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/control\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/control\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/control\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/control\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/control\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getXCon()](../../com.aspose.diagram/control\#getXCon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/control\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getYCon()](../../com.aspose.diagram/control\#getYCon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de borde del control ActiveX.
+type: docs
+weight: 88
+url: /es/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+Representa el tipo de borde del control ActiveX.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NONE](#NONE) | Sin borde. |
+| [SINGLE](#SINGLE) | La línea única. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Sin borde.
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+La línea única.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la posición del Caption relativo al control.
+type: docs
+weight: 89
+url: /es/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+Representa la posición del Caption relativo al control.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [LEFT](#LEFT) | El lado izquierdo del control. |
+| [RIGHT](#RIGHT) | El lado derecho del control. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+El lado izquierdo del control.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+El lado derecho del control.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Control.
+type: docs
+weight: 90
+url: /es/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Colección Control.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | Agregue el objeto Control a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | Obtiene el elemento en el índice especificado IX. |
+| [getControlFromId(int ID)](#getControlFromId-int-) | Obtiene el elemento con el ID especificado. |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | Obtiene el elemento con el nombre especificado. |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | Elimine el objeto Control de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+Agregue el objeto Control a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+Obtiene el elemento en el índice especificado IX.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+Obtiene el elemento con el nombre especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+Elimine el objeto Control de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/spanish/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la apariencia visual de la lista en un ListBox o ComboBox.
+type: docs
+weight: 91
+url: /es/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+Representa la apariencia visual de la lista en un ListBox o ComboBox.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [OPTION](#OPTION) | Muestra una lista en la que un botón de opción o una casilla de verificación junto a cada entrada muestra el estado de selección de ese elemento. |
+| [PLAIN](#PLAIN) | Muestra una lista en la que el fondo de un elemento se resalta cuando está seleccionado. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+Muestra una lista en la que un botón de opción o una casilla de verificación junto a cada entrada muestra el estado de selección de ese elemento.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Muestra una lista en la que el fondo de un elemento se resalta cuando está seleccionado.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe.
+type: docs
+weight: 92
+url: /es/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+Representa cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | A medida que se escribe cada carácter, el control busca una entrada que coincida con todos los caracteres ingresados. |
+| [FIRST_LETTER](#FIRST-LETTER) | El control busca la siguiente entrada que comienza con el carácter ingresado. |
+| [NONE](#NONE) | La lista no se buscará cuando se escriban caracteres. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+A medida que se escribe cada carácter, el control busca una entrada que coincida con todos los caracteres ingresados.
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+El control busca la siguiente entrada que comienza con el carácter ingresado. Escribir repetidamente la misma letra recorre todas las entradas que comienzan con esa letra.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+La lista no se buscará cuando se escriban caracteres.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de ícono que se muestra como puntero del ratón para el control.
+type: docs
+weight: 93
+url: /es/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+Representa el tipo de ícono que se muestra como puntero del ratón para el control.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | Flecha con un reloj de arena. |
+| [ARROW](#ARROW) | Flecha. |
+| [CROSS](#CROSS) | Puntero de cruz. |
+| [CUSTOM](#CUSTOM) | Utiliza el ícono especificado por la propiedad MouseIcon. |
+| [DEFAULT](#DEFAULT) | Puntero estándar. |
+| [HELP](#HELP) | Flecha con un signo de interrogación. |
+| [HOUR_GLASS](#HOUR-GLASS) | Reloj de arena. |
+| [I_BEAM](#I-BEAM) | Viga en I. |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | Doble flecha apuntando al noreste y suroeste. |
+| [SIZE_NS](#SIZE-NS) | Doble flecha apuntando al norte y al sur. |
+| [SIZE_NWSE](#SIZE-NWSE) | Doble flecha apuntando al noroeste y al sureste. |
+| [SIZE_WE](#SIZE-WE) | Doble flecha apuntando al oeste y al este. |
+| [UP_ARROW](#UP-ARROW) | Flecha hacia arriba. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+Flecha con un reloj de arena.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Flecha.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Puntero de cruz.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Utiliza el ícono especificado por la propiedad MouseIcon.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Puntero estándar.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+Flecha con un signo de interrogación.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+Reloj de arena.
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+Viga en I.
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?símbolo (círculo con una línea diagonal) sobre el objeto que se está arrastrando.
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?cursor (flechas apuntando al norte, sur, este y oeste).
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+Doble flecha apuntando al noreste y suroeste.
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+Doble flecha apuntando al norte y al sur.
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+Doble flecha apuntando al noroeste y al sureste.
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+Doble flecha apuntando al oeste y al este.
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+Flecha hacia arriba.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la alineación de la imagen dentro del Formulario o Imagen.
+type: docs
+weight: 94
+url: /es/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Representa la alineación de la imagen dentro del Formulario o Imagen.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | La esquina inferior izquierda. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | La esquina inferior derecha. |
+| [CENTER](#CENTER) | El centro. |
+| [TOP_LEFT](#TOP-LEFT) | La esquina superior izquierda. |
+| [TOP_RIGHT](#TOP-RIGHT) | La esquina superior derecha. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+La esquina inferior izquierda.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+La esquina inferior derecha.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+El centro.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+La esquina superior izquierda.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+La esquina superior derecha.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la ubicación de la imagen del control con respecto a su leyenda.
+type: docs
+weight: 95
+url: /es/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+Representa la ubicación de la imagen del control en relación con su título.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | La imagen aparece encima de la leyenda. |
+| [ABOVE_LEFT](#ABOVE-LEFT) | La imagen aparece encima de la leyenda. |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | La imagen aparece encima de la leyenda. |
+| [BELOW_CENTER](#BELOW-CENTER) | La imagen aparece debajo de la leyenda. |
+| [BELOW_LEFT](#BELOW-LEFT) | La imagen aparece debajo de la leyenda. |
+| [BELOW_RIGHT](#BELOW-RIGHT) | La imagen aparece debajo de la leyenda. |
+| [CENTER](#CENTER) | La imagen aparece en el centro del control. |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | La imagen aparece a la izquierda de la leyenda. |
+| [LEFT_CENTER](#LEFT-CENTER) | La imagen aparece a la izquierda de la leyenda. |
+| [LEFT_TOP](#LEFT-TOP) | La imagen aparece a la izquierda de la leyenda. |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | La imagen aparece a la derecha de la leyenda. |
+| [RIGHT_CENTER](#RIGHT-CENTER) | La imagen aparece a la derecha de la leyenda. |
+| [RIGHT_TOP](#RIGHT-TOP) | La imagen aparece a la derecha de la leyenda. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+La imagen aparece encima de la leyenda. La leyenda está centrada debajo de la imagen.
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+La imagen aparece encima de la leyenda. La leyenda está alineada con el borde izquierdo de la imagen.
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+La imagen aparece encima de la leyenda. La leyenda está alineada con el borde derecho de la imagen.
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+La imagen aparece debajo de la leyenda. La leyenda está centrada encima de la imagen.
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+La imagen aparece debajo del subtítulo. El subtítulo está alineado con el borde izquierdo de la imagen.
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+La imagen aparece debajo del subtítulo. El subtítulo está alineado con el borde derecho de la imagen.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+La imagen aparece en el centro del control. El subtítulo está centrado horizontal y verticalmente sobre la imagen.
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+La imagen aparece a la izquierda del subtítulo. El subtítulo está alineado con la parte inferior de la imagen.
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+La imagen aparece a la izquierda del subtítulo. El subtítulo está centrado respecto a la imagen.
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+La imagen aparece a la izquierda del subtítulo. El subtítulo está alineado con la parte superior de la imagen.
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+La imagen aparece a la derecha del subtítulo. El subtítulo está alineado con la parte inferior de la imagen.
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+La imagen aparece a la derecha del subtítulo. El subtítulo está centrado respecto a la imagen.
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+La imagen aparece a la derecha del subtítulo. El subtítulo está alineado con la parte superior de la imagen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/spanish/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa cómo mostrar la imagen.
+type: docs
+weight: 96
+url: /es/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+Representa cómo mostrar la imagen.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CLIP](#CLIP) | Recorta cualquier parte de la imagen que sea mayor que los límites del control. |
+| [STRETCH](#STRETCH) | Estira la imagen para llenar el área del control. |
+| [ZOOM](#ZOOM) | Amplía la imagen, pero no la distorsiona ni horizontal ni verticalmente. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+Recorta cualquier parte de la imagen que sea mayor que los límites del control.
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+Estira la imagen para llenar el área del control. Esta configuración distorsiona la imagen tanto horizontal como verticalmente.
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+Amplía la imagen, pero no la distorsiona ni horizontal ni verticalmente.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de barra de desplazamiento.
+type: docs
+weight: 97
+url: /es/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+Representa el tipo de barra de desplazamiento.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | Muestra tanto una barra de desplazamiento horizontal como una vertical. |
+| [BARS_VERTICAL](#BARS-VERTICAL) | Muestra una barra de desplazamiento vertical. |
+| [HORIZONTAL](#HORIZONTAL) | Muestra una barra de desplazamiento horizontal. |
+| [NONE](#NONE) | No muestra barras de desplazamiento. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+Muestra tanto una barra de desplazamiento horizontal como una vertical.
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+Muestra una barra de desplazamiento vertical.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Muestra una barra de desplazamiento horizontal.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+No muestra barras de desplazamiento.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/spanish/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de orientación del desplazamiento
+type: docs
+weight: 98
+url: /es/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+Representa el tipo de orientación del desplazamiento
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [AUTO](#AUTO) | El control se muestra horizontalmente cuando el ancho del control es mayor que su altura. |
+| [HORIZONTAL](#HORIZONTAL) | El control se muestra horizontalmente. |
+| [VERTICAL](#VERTICAL) | El control se muestra verticalmente. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+El control se muestra horizontalmente cuando el ancho del control es mayor que su altura. El control se muestra verticalmente en caso contrario.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+El control se muestra horizontalmente.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+El control se muestra verticalmente.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/spanish/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de efecto especial.
+type: docs
+weight: 99
+url: /es/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+Representa el tipo de efecto especial.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/controltype/_index.md
+++ b/spanish/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa todos los tipos de control ActiveX.
+type: docs
+weight: 100
+url: /es/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+Representa todos los tipos de control ActiveX.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | Imagen |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | Desconocido |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+Imagen
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Desconocido
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/contype/_index.md
+++ b/spanish/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango.
+type: docs
+weight: 73
+url: /es/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/contype\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/contype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/contype\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/contype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/convalue/_index.md
+++ b/spanish/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango.
+type: docs
+weight: 74
+url: /es/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+Especifica el tipo de comportamiento que la coordenada x o y del mango de control exhibe después de mover el mango.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | Desplazamiento desde el centro. |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | Desplazamiento desde el centro, oculto. |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | Desplazamiento desde el borde izquierdo. |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | Desplazamiento desde el borde izquierdo, oculto. |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | Desplazamiento desde el borde derecho. |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | Desplazamiento desde el borde derecho, oculto. |
+| [PROPORTIONAL](#PROPORTIONAL) | Proporcional. |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | Proporcional, oculto.Mismo que 0, pero el controlador no es visible. |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | Proporcional bloqueado. |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | Proporcional bloqueado, oculto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+Desplazamiento desde el centro. El controlador está desplazado una distancia constante desde el centro de la forma.
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+Desplazamiento desde el centro, oculto. Igual que 3, pero el controlador no es visible.
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+Desplazamiento desde el borde izquierdo. El controlador está desplazado una distancia constante desde el lado izquierdo de la forma.
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+Desplazamiento desde el borde izquierdo, oculto. Igual que 2, pero el controlador no es visible.
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+Desplazamiento desde el borde derecho. El controlador está desplazado una distancia constante desde el lado derecho de la forma.
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+Desplazamiento desde el borde derecho, oculto. Igual que 4, pero el controlador no es visible.
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+Proporcional. El controlador puede moverse y también se desplaza en proporción con la forma cuando se estira.
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+Proporcional, oculto.Mismo que 0, pero el controlador no es visible.
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+Proporcional bloqueado. El controlador se desplaza en proporción con la forma, pero el propio controlador no puede moverse.
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+Proporcional bloqueado, oculto. Igual que 1, pero el controlador no es visible.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/coordinate/_index.md
+++ b/spanish/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: Coordenada
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Clase abstracta para las coordenadas x e y.
+type: docs
+weight: 101
+url: /es/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+Clase abstracta para las coordenadas x e y.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte @PREF1\_ |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte @PREF0\_ |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte @PREF1\_
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte @PREF0\_
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de coordenadas.
+type: docs
+weight: 102
+url: /es/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+Colección de coordenadas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | Agrega el objeto ArcTo a la colección. |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | Agrega el objeto Coordinate a la colección. |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | Agrega el objeto Ellipse a la colección. |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | Agrega el objeto EllipticalArcTo a la colección. |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | Agrega el objeto InfiniteLine a la colección. |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | Agrega el objeto LineTo a la colección. |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | Agrega el objeto MoveTo a la colección. |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | Agrega el objeto NURBSTo a la colección. |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | Agrega el objeto PolylineTo a la colección. |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | Agrega el objeto RelCubBezTo a la colección. |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | Agregar el objeto RelEllipticalArcTo a la colección. |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | Agregar el objeto RelLineTo a la colección. |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | Agregar el objeto RelMoveTo a la colección. |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | Agregar el objeto RelQuadBezTo a la colección. |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | Agregar el objeto SplineKnot a la colección. |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | Agregar el objeto SplineStart a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getArcToCol()](#getArcToCol--) | Contiene las coordenadas x e y y la curvatura de un arco circular representados respectivamente por los elementos X, Y y A. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getEllipseCol()](#getEllipseCol--) | Contiene elementos que especifican las coordenadas x e y del punto central de la elipse y dos puntos en la elipse. |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | Contiene elementos que especifican información sobre un arco elíptico. |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | Contiene elementos que especifican las coordenadas x e y de dos puntos en una línea infinita. |
+| [getLineToCol()](#getLineToCol--) | Contiene las coordenadas x e y del vértice final de un segmento de línea recta. |
+| [getMoveToCol()](#getMoveToCol--) | Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. |
+| [getNURBSToCol()](#getNURBSToCol--) | Contiene las coordenadas x e y, la posición del penúltimo nudo, la posición del último peso, la posición del primer nudo, la posición del primer peso y la fórmula de una B-spline racional no uniforme (NURBS). |
+| [getPolylineToCol()](#getPolylineToCol--) | Contiene las coordenadas x e y del último punto de una polilínea y la fórmula de la polilínea. |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | Contiene coordenadas x e y para los puntos de un RelCubBezTo. Las coordenadas se especifican como coordenadas relativas. |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | Contiene elementos que especifican información sobre un arco elíptico. Las coordenadas se especifican como coordenadas relativas. |
+| [getRelLineToCol()](#getRelLineToCol--) | Contiene las coordenadas x e y del vértice final de un segmento de línea recta. |
+| [getRelMoveToCol()](#getRelMoveToCol--) | Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. Las coordenadas se especifican como coordenadas relativas. |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | Contiene coordenadas x e y para los puntos de un RelQuadBezTo. Las coordenadas se especifican como coordenadas relativas. |
+| [getSplineKnotCol()](#getSplineKnotCol--) | Contiene coordenadas x e y para el punto de control de una spline y el nudo de una spline, representados por los elementos X, Y y A, respectivamente. |
+| [getSplineStartCol()](#getSplineStartCol--) | Contiene coordenadas x e y para el segundo punto de control de una spline, su segundo nudo, su primer nudo, el último nudo y el grado de la spline. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | Eliminar el objeto ArcTo de la colección. |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | Eliminar el objeto Coordinate de la colección. |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | Eliminar el objeto Ellipse de la colección. |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | Eliminar el objeto EllipticalArcTo de la colección. |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | Eliminar el objeto InfiniteLine de la colección. |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | Eliminar el objeto LineTo de la colección. |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | Eliminar el objeto MoveTo de la colección. |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | Eliminar el objeto NURBSTo de la colección. |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | Eliminar el objeto PolylineTo de la colección. |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | Eliminar el objeto RelCubBezTo de la colección. |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | Eliminar el objeto RelEllipticalArcTo de la colección. |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | Eliminar el objeto RelLineTo de la colección. |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | Eliminar el objeto RelMoveTo de la colección. |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | Eliminar el objeto RelQuadBezTo de la colección. |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | Eliminar el objeto SplineKnot de la colección. |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | Eliminar el objeto SplineStart de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+Agrega el objeto ArcTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+Agrega el objeto Coordinate a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+Agrega el objeto Ellipse a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+Agrega el objeto EllipticalArcTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+Agrega el objeto InfiniteLine a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+Agrega el objeto LineTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+Agrega el objeto MoveTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+Agrega el objeto NURBSTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+Agrega el objeto PolylineTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+Agrega el objeto RelCubBezTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+Agregar el objeto RelEllipticalArcTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+Agregar el objeto RelLineTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+Agregar el objeto RelMoveTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+Agregar el objeto RelQuadBezTo a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+Agregar el objeto SplineKnot a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+Agregar el objeto SplineStart a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+Contiene las coordenadas x e y y la curvatura de un arco circular representados respectivamente por los elementos X, Y y A.
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+Contiene elementos que especifican las coordenadas x e y del punto central de la elipse y dos puntos en la elipse.
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+Contiene elementos que especifican información sobre un arco elíptico.
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+Contiene elementos que especifican las coordenadas x e y de dos puntos en una línea infinita. Los elementos X y Y especifican las coordenadas x e y del primer punto, y los elementos A y B especifican las coordenadas x e y del segundo punto.
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+Contiene las coordenadas x e y del vértice final de un segmento de línea recta. Estas coordenadas se encuentran en los elementos X y Y, respectivamente.
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta.
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+Contiene las coordenadas x e y, la posición del penúltimo nudo, la posición del último peso, la posición del primer nudo, la posición del primer peso y la fórmula de una B-spline racional no uniforme (NURBS). Esta información se especifica en los elementos X, Y, A, B, C, D y E, respectivamente.
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+Contiene las coordenadas x e y del último punto de una polilínea y la fórmula de la polilínea. Las coordenadas se especifican en los elementos X y Y, y la fórmula se especifica en el elemento A.
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+Contiene coordenadas x e y para los puntos de un RelCubBezTo. Las coordenadas se especifican como coordenadas relativas.
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+Contiene elementos que especifican información sobre un arco elíptico. Las coordenadas se especifican como coordenadas relativas.
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+Contiene las coordenadas x e y del vértice final de un segmento de línea recta. Estas coordenadas se encuentran en los elementos X y Y, respectivamente. Las coordenadas se especifican como coordenadas relativas.
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. Las coordenadas se especifican como coordenadas relativas.
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+Contiene coordenadas x e y para los puntos de un RelQuadBezTo. Las coordenadas se especifican como coordenadas relativas.
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+Contiene coordenadas x e y para el punto de control de una spline y el nudo de una spline, representados por los elementos X, Y y A, respectivamente.
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+Contiene las coordenadas x e y para el segundo punto de control de una spline, su segundo nudo, su primer nudo, el último nudo y el grado de la spline. Esta información se encuentra en los elementos X, Y, A, B, C y D, respectivamente.
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+Eliminar el objeto ArcTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+Eliminar el objeto Coordinate de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+Eliminar el objeto Ellipse de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+Eliminar el objeto EllipticalArcTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+Eliminar el objeto InfiniteLine de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+Eliminar el objeto LineTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+Eliminar el objeto MoveTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+Eliminar el objeto NURBSTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+Eliminar el objeto PolylineTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+Eliminar el objeto RelCubBezTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+Eliminar el objeto RelEllipticalArcTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+Eliminar el objeto RelLineTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+Eliminar el objeto RelMoveTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+Eliminar el objeto RelQuadBezTo de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+Eliminar el objeto SplineKnot de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+Eliminar el objeto SplineStart de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/countrycode/_index.md
+++ b/spanish/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: CountryCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa los identificadores de país del diagrama.
+type: docs
+weight: 103
+url: /es/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+Representa los identificadores de país del diagrama.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | Argelia |
+| [AUSTRALIA](#AUSTRALIA) | Australia |
+| [AUSTRIA](#AUSTRIA) | Austria |
+| [BELGIUM](#BELGIUM) | Bélgica |
+| [BRAZIL](#BRAZIL) | Brasil |
+| [CANADA](#CANADA) | Canadá |
+| [CHINA](#CHINA) | República Popular China |
+| [CZECH](#CZECH) | República Checa |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | Dinamarca |
+| [EGYPT](#EGYPT) | Egipto |
+| [FINLAND](#FINLAND) | Finlandia |
+| [FRANCE](#FRANCE) | Francia |
+| [GERMANY](#GERMANY) | Alemania |
+| [GREECE](#GREECE) | Grecia |
+| [HUNGARY](#HUNGARY) | Hungría |
+| [ICELAND](#ICELAND) | Islandia |
+| [INDIA](#INDIA) | India |
+| [IRAN](#IRAN) | Irán |
+| [IRAQ](#IRAQ) | Irak |
+| [ISRAEL](#ISRAEL) | Israel |
+| [ITALY](#ITALY) | Italia |
+| [JAPAN](#JAPAN) | Japón |
+| [JORDAN](#JORDAN) | Jordania |
+| [KUWAIT](#KUWAIT) | Kuwait |
+| [LATIN_AMERIC](#LATIN-AMERIC) | América Latina, excepto Brasil |
+| [LEBANON](#LEBANON) | Líbano |
+| [LIBYA](#LIBYA) | Libia |
+| [MEXICO](#MEXICO) | México |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+Argelia
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+Australia
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+Austria
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+Bélgica
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+Brasil
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+Canadá
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+República Popular China
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+República Checa
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+Dinamarca
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+Egipto
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+Finlandia
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+Francia
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+Alemania
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+Grecia
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+Hungría
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+Islandia
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+India
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+Irán
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+Irak
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+Israel
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+Italia
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+Japón
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+Jordania
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+Kuwait
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+América Latina, excepto Brasil
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+Líbano
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+Libia
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+México
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/cp/_index.md
+++ b/spanish/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Marca el inicio de una secuencia de propiedades de carácter que se formatea según el elemento Char correspondiente.
+type: docs
+weight: 104
+url: /es/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+Marca el inicio de una secuencia de propiedades de carácter que está formateada según el elemento Char correspondiente. La secuencia se define hasta el final del texto o hasta el siguiente
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int | El índice del elemento Char que representa esta secuencia de propiedades. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/customprop/_index.md
+++ b/spanish/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Estructura CustomProp.
+type: docs
+weight: 105
+url: /es/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+Estructura CustomProp.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | Valor de la propiedad. |
+| [getName()](#getName--) | El nombre de la propiedad personalizada. |
+| [getPropType()](#getPropType--) | El tipo de datos de la propiedad personalizada. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | Para la descripción de esta propiedad, consulte [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/customprop\#getName--) |
+| [setPropType(int value)](#setPropType-int-) | Para la descripción de esta propiedad, consulte [getPropType()](../../com.aspose.diagram/customprop\#getPropType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+Valor de la propiedad.
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre de la propiedad personalizada.
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+El tipo de datos de la propiedad personalizada.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/customprop\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección CustomProps.
+type: docs
+weight: 106
+url: /es/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+Colección CustomProps.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | Añade el objeto CustomProp a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | Elimina el objeto CustomProp de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+Constructor.
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+Añade el objeto CustomProp a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+Elimina el objeto CustomProp de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/customvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor de la propiedad.
+type: docs
+weight: 107
+url: /es/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+Valor de la propiedad.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | Valor booleano. |
+| [getValueDate()](#getValueDate--) | Valor de fecha y hora. |
+| [getValueNumber()](#getValueNumber--) | Valor numérico. |
+| [getValueString()](#getValueString--) | Valor de cadena. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | Para la descripción de esta propiedad, consulte [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) |
+| [setValueNumber(double value)](#setValueNumber-double-) | Para la descripción de esta propiedad, consulte [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) |
+| [setValueString(String value)](#setValueString-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+Valor booleano.
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+Valor de fecha y hora.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+Valor numérico.
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+Valor de cadena.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datacolumn/_index.md
+++ b/spanish/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Define cómo aparece una columna de datos en la ventana de Datos externos en la interfaz de usuario de Visio y califica los datos en la columna definiendo su tipo de datos y formato.
+type: docs
+weight: 108
+url: /es/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Define cómo aparece una columna de datos en la ventana de Datos externos en la interfaz de usuario de Visio y califica los datos en la columna definiendo su tipo de datos y formato.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | ID de calendario de la columna de datos. |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | Nombre externo de la columna de datos. |
+| [getCurrency()](#getCurrency--) | ID de moneda de la columna de datos. |
+| [getDataType()](#getDataType--) | Tipo de los datos en la columna de datos. |
+| [getDegree()](#getDegree--) | Especifica el grado (potencia) de las unidades, por ejemplo al cuadrado o al cubo. |
+| [getDisplayOrder()](#getDisplayOrder--) | Define la posición de visualización de la columna de datos en la ventana de Datos externos, desde la columna más a la izquierda (0) hasta la columna más a la derecha (valor máximo). |
+| [getDisplayWidth()](#getDisplayWidth--) | Ancho de la columna de datos en la ventana de Datos externos. |
+| [getHyperlink()](#getHyperlink--) | Si la columna de datos crea un hipervínculo en una forma cuando la forma está vinculada a datos. |
+| [getLabel()](#getLabel--) | Etiqueta de la columna de datos. |
+| [getLangID()](#getLangID--) | El ID de idioma de la columna de datos |
+| [getMapped()](#getMapped--) | Especifica si la columna es visible en la ventana de Datos externos. |
+| [getName()](#getName--) | Nombre interno de la columna de datos. |
+| [getOrigLabel()](#getOrigLabel--) | Etiqueta de columna devuelta a Visio por la interfaz ADO subyacente. |
+| [getUnitType()](#getUnitType--) | Tipo de unidad de los datos en la columna de datos. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getCalendar() & 0xFFFF)\} |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | Para la descripción de esta propiedad, consulte [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--) |
+| [setCurrency(int value)](#setCurrency-int-) | Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getCurrency() & 0xFFFF)\} |
+| [setDataType(int value)](#setDataType-int-) | Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getDataType() & 0xFFFF)\} |
+| [setDegree(long value)](#setDegree-long-) | Para la descripción de esta propiedad, consulte [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--) |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | Para la descripción de esta propiedad, consulte [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--) |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | Para la descripción de esta propiedad, consulte [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--) |
+| [setHyperlink(int value)](#setHyperlink-int-) | Para la descripción de esta propiedad, consulte [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--) |
+| [setLabel(String value)](#setLabel-java.lang.String-) | Para la descripción de esta propiedad, consulte [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--) |
+| [setLangID(long value)](#setLangID-long-) | Para la descripción de esta propiedad, consulte [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--) |
+| [setMapped(int value)](#setMapped-int-) | Para la descripción de esta propiedad, consulte [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/datacolumn\#getName--) |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | Para la descripción de esta propiedad, consulte [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--) |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | Para la descripción de esta propiedad, consulte [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+ID de calendario de la columna de datos.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+Nombre externo de la columna de datos. Aparece en los encabezados de la ventana de Datos externos y en las etiquetas de los gráficos de datos.
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+ID de moneda de la columna de datos.
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+Tipo de los datos en la columna de datos.
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+Especifica el grado (potencia) de las unidades, por ejemplo al cuadrado o al cubo. El valor predeterminado (atributo ausente) es 1.
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+Define la posición de visualización de la columna de datos en la ventana de Datos externos, desde la columna más a la izquierda (0) hasta la columna más a la derecha (valor máximo).
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+Ancho de la columna de datos en la ventana de Datos externos.
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+Si la columna de datos crea un hipervínculo en una forma cuando la forma está vinculada a datos.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+Etiqueta de la columna de datos.
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+El ID de idioma de la columna de datos
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+Especifica si la columna es visible en la ventana de Datos externos. Verdadero (1) para que la columna sea visible; falso (0) para que la columna no sea visible. El valor predeterminado (atributo ausente) es que la columna sea visible.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Nombre interno de la columna de datos. Se usa como nombre de fila para el elemento de datos de forma (propiedad personalizada) añadido a una forma cuando la forma está vinculada a una fila de datos.
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+Etiqueta de columna devuelta a Visio por la interfaz ADO subyacente.
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+Tipo de unidad de los datos en la columna de datos.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getCalendar() & 0xFFFF)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnNameID()](../../com.aspose.diagram/datacolumn\#getColumnNameID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getCurrency() & 0xFFFF)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataColumn\#(getDataType() & 0xFFFF)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDegree()](../../com.aspose.diagram/datacolumn\#getDegree--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDisplayOrder()](../../com.aspose.diagram/datacolumn\#getDisplayOrder--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDisplayWidth()](../../com.aspose.diagram/datacolumn\#getDisplayWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHyperlink()](../../com.aspose.diagram/datacolumn\#getHyperlink--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLabel()](../../com.aspose.diagram/datacolumn\#getLabel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLangID()](../../com.aspose.diagram/datacolumn\#getLangID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMapped()](../../com.aspose.diagram/datacolumn\#getMapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/datacolumn\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOrigLabel()](../../com.aspose.diagram/datacolumn\#getOrigLabel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnitType()](../../com.aspose.diagram/datacolumn\#getUnitType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/spanish/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección DataColumn.
+type: docs
+weight: 109
+url: /es/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+Colección DataColumn.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | Agregue la dataColumn a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getSortAsc()](#getSortAsc--) | Indica si se debe ordenar la columna SortColumn en orden ascendente (1) o descendente (0). |
+| [getSortColumn()](#getSortColumn--) | La columna en la que se ordenarán los datos. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | Elimine la dataColumn de la colección. |
+| [setSortAsc(int value)](#setSortAsc-int-) | Para la descripción de esta propiedad, consulte [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--) |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | Para la descripción de esta propiedad, consulte [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+Agregue la dataColumn a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+Indica si se debe ordenar la columna SortColumn en orden ascendente (1) o descendente (0).
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+La columna en la que se ordenarán los datos.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+Elimine la dataColumn de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dataconnection/_index.md
+++ b/spanish/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Abstrae la comunicación entre uno o más elementos DataRecordset y una fuente de datos no XML.
+type: docs
+weight: 110
+url: /es/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+Abstrae la comunicación entre uno o más elementos DataRecordset y una fuente de datos no XML.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | El valor predeterminado es falso. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | La cadena de comando utilizada para consultar la fuente de datos. |
+| [getConnectionString()](#getConnectionString--) | La cadena de conexión que define los parámetros necesarios para conectarse a una fuente de datos. |
+| [getFileName()](#getFileName--) | El nombre del archivo de conexión. |
+| [getID()](#getID--) | El ID asignado por Visio para una conexión dada, único dentro del documento. |
+| [getTimeout()](#getTimeout--) | Tiempo de espera en minutos mientras se intenta establecer una conexión antes de terminar el intento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | Para la descripción de esta propiedad, consulte [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | Para la descripción de esta propiedad, consulte [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) |
+| [setFileName(String value)](#setFileName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, consulte \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} |
+| [setTimeout(long value)](#setTimeout-long-) | Para la descripción de esta propiedad, consulte [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+El valor predeterminado es false. Consulte Remarks para obtener más información.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+La cadena de comando utilizada para consultar la fuente de datos.
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+La cadena de conexión que define los parámetros necesarios para conectarse a una fuente de datos.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+El nombre del archivo de conexión. Consulte Remarks para obtener más información.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+El ID asignado por Visio para una conexión dada, único dentro del documento.
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+Tiempo de espera en minutos mientras se intenta establecer una conexión antes de terminar el intento.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/spanish/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección DataConnection.
+type: docs
+weight: 111
+url: /es/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+Colección DataConnection.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | Agregue la dataConnection a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getDataConnection(long ID)](#getDataConnection-long-) | Obtiene el elemento con el ID especificado. |
+| [getNextID()](#getNextID--) | El siguiente ID disponible para nuevas conexiones. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | Elimine la dataConnection de la colección. |
+| [setNextID(long value)](#setNextID-long-) | Para la descripción de esta propiedad, consulte \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+Agregue la dataConnection a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | long | ID de DataConnectionUInt32. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+El siguiente ID disponible para nuevas conexiones.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+Elimine la dataConnection de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/spanish/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite configurar opciones para las conexiones a la base de datos.
+type: docs
+weight: 112
+url: /es/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+Permite configurar opciones para las conexiones a la base de datos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ODBC](#ODBC) | Uso System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | Uso System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | Uso System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | Tipo de conexión desconocido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+Uso System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+Uso System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+Uso System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Tipo de conexión desconocido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datarecordset/_index.md
+++ b/spanish/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Almacena formatos, actualizaciones y expone los datos consultados de una base de datos en Microsoft Visio.
+type: docs
+weight: 113
+url: /es/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Almacena, formatea, actualiza y expone datos consultados de una base de datos en Microsoft Visio.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | Contiene XML que se ajusta al esquema XML clásico de ADO para un conjunto de registros ADO y que describe los datos en el conjunto de registros de datos. |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | Define una regla que compara una columna en el elemento DataRecordset padre con un elemento de datos de forma de la última acción de enlace automático exitosa realizada en la interfaz de usuario. |
+| [getChecksum()](#getChecksum--) | Un valor de suma de verificación, generado por Visio, y basado en las propiedades del conjunto de registros de datos. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | La cadena de comando utilizada para consultar datos de la fuente de datos. |
+| [getConnectionID()](#getConnectionID--) | El ID de conexión para el objeto DataConnection asociado. |
+| [getDataColumns()](#getDataColumns--) | Contiene todos los elementos DataColumn en un conjunto de registros de datos. |
+| [getID()](#getID--) | El ID del conjunto de registros de datos, único dentro del documento. |
+| [getName()](#getName--) | El nombre de visualización (o "amigable") del conjunto de registros de datos. |
+| [getNextRowID()](#getNextRowID--) | El siguiente ID de fila de Visio disponible. |
+| [getOptions()](#getOptions--) | Opciones para aplicar al conjunto de registros de datos. |
+| [getPrimaryKeys()](#getPrimaryKeys--) | Identifica una o más columnas de clave primaria en el conjunto de registros de datos. |
+| [getRefreshConflicts()](#getRefreshConflicts--) | Indica una fila en el conjunto de registros de datos vinculada a una forma que está en conflicto después de que el conjunto de registros de datos se actualiza. |
+| [getRefreshInterval()](#getRefreshInterval--) | Con qué frecuencia (en minutos) Visio actualiza automáticamente el conjunto de registros de datos. |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | Si la interfaz de usuario de conciliación de datos debe estar deshabilitada. |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | Si se deben sobrescribir los cambios del usuario en los elementos de datos de forma en las formas vinculadas a datos cuando el conjunto de registros de datos se actualiza. |
+| [getReplaceLinks()](#getReplaceLinks--) | Define cómo se tratan los enlaces de datos de forma cuando las formas se copian o recortan. 1 para reemplazar los enlaces existentes en la forma de destino. 0 para mantener los enlaces existentes en la forma de destino. |
+| [getRowMaps()](#getRowMaps--) | Mapea una fila del conjunto de registros de datos a una forma. |
+| [getRowOrder()](#getRowOrder--) | Si se debe usar el orden de las filas en el conjunto de registros de datos como clave primaria. |
+| [getTimeRefreshed()](#getTimeRefreshed--) | La fecha y hora en que el conjunto de registros de datos se actualizó por última vez. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | Ejecuta la cadena de consulta asociada con el DataRecordset conectado (no basado en XML) y actualiza las formas vinculadas con nuevos datos de la fuente de datos devueltos por la consulta. |
+| [setADOData(String value)](#setADOData-java.lang.String-) | Para la descripción de esta propiedad, por favor vea [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--) |
+| [setChecksum(long value)](#setChecksum-long-) | Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\} |
+| [setCommand(String value)](#setCommand-java.lang.String-) | Para la descripción de esta propiedad, por favor vea [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--) |
+| [setConnectionID(long value)](#setConnectionID-long-) | Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\} |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\} |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/datarecordset\#getName--) |
+| [setNextRowID(long value)](#setNextRowID-long-) | Para la descripción de esta propiedad, consulte \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\} |
+| [setOptions(int value)](#setOptions-int-) | Para la descripción de esta propiedad, consulte [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--) |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | Para la descripción de esta propiedad, consulte \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\} |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | Para la descripción de esta propiedad, consulte [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--) |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | Para la descripción de esta propiedad, consulte [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--) |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | Para la descripción de esta propiedad, consulte [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--) |
+| [setRowOrder(int value)](#setRowOrder-int-) | Para la descripción de esta propiedad, consulte [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--) |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+Contiene XML que se ajusta al esquema XML clásico de ADO para un conjunto de registros ADO y que describe los datos en el conjunto de registros de datos.
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+Define una regla que compara una columna en el elemento DataRecordset padre con un elemento de datos de forma de la última acción de enlace automático exitosa realizada en la interfaz de usuario.
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+Un valor de suma de verificación, generado por Visio, y basado en las propiedades del conjunto de datos. Establezca este atributo en 0; Visio recalcula este valor en tiempo de ejecución.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+La cadena de comando utilizada para consultar datos de la fuente de datos.
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+El ID de conexión para el objeto DataConnection asociado. No existe para fuentes de datos XML.
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+Contiene todos los elementos DataColumn en un conjunto de registros de datos.
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+El ID del conjunto de registros de datos, único dentro del documento.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre de visualización (o "amigable") del conjunto de registros de datos.
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+El siguiente ID de fila de Visio disponible.
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+Opciones para aplicar al conjunto de datos. Los valores posibles pueden ser cualquier combinación de uno o más de los mostrados en la tabla siguiente.
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+Identifica una o más columnas de clave primaria en el conjunto de registros de datos.
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+Indica una fila en el conjunto de datos vinculada a una forma que está en conflicto después de que el conjunto de datos se actualiza. RowID - Indica una fila en el conjunto de datos vinculada a una forma que está en conflicto después de que el conjunto de datos se actualiza. ShapeID - ID de la forma involucrada en el conflicto. PageID - ID de la página de la forma involucrada en el conflicto.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+Con qué frecuencia (en minutos) Visio actualiza automáticamente el conjunto de datos. Este valor debe ser 1 o mayor.
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+Si la interfaz de usuario de reconciliación de datos debe estar deshabilitada. Verdadero (1) para deshabilitar la interfaz de usuario (UI). Falso (0) para habilitar la UI.
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+Si se deben sobrescribir los cambios del usuario en los elementos de datos de forma en las formas vinculadas a datos cuando el conjunto de registros de datos se actualiza.
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+Define cómo se tratan los enlaces de datos de forma cuando las formas se copian o recortan. 1 para reemplazar los enlaces existentes en la forma de destino. 0 para mantener los enlaces existentes en la forma de destino. Si este atributo está ausente, Visio pregunta al usuario si desea reemplazar los enlaces al copiar o recortar.
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+Mapea una fila del conjunto de datos a una forma. RowID - ID de fila de la fila, único dentro del conjunto de datos. ShapeID - ID de la forma vinculada a los datos en la fila del conjunto de datos identificada por RowID. PageID - ID de la página de la forma vinculada a los datos en la fila del conjunto de datos identificada por RowID.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+Si se debe usar el orden de las filas en el conjunto de datos como clave primaria. Verdadero (1) si los IDs de fila se determinan por el orden de las filas. Falso (0) si los IDs de fila se determinan por los valores en la(s) columna(s) de clave primaria del conjunto de datos.
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+La fecha y hora en que el conjunto de registros de datos se actualizó por última vez.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+Ejecuta la cadena de consulta asociada con el DataRecordset conectado (no basado en XML) y actualiza las formas vinculadas con nuevos datos de la fuente de datos devueltos por la consulta.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| connectionType | int | El tipo de proveedor que se utilizará para connectionAspose.Diagram.Manipulation.DataConnectionType. |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/datarecordset\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección DataRecordSet.
+type: docs
+weight: 114
+url: /es/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+Colección DataRecordSet.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | Agregue el dataRecordSet a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | Elimine el dataRecordSet de la colección. |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | Para la descripción de esta propiedad, consulte [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) |
+| [setNextId(String value)](#setNextId-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+Agregue el dataRecordSet a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+Elimine el dataRecordSet de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datetime/_index.md
+++ b/spanish/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un instante en el tiempo que normalmente se expresa como una fecha y hora del día.
+type: docs
+weight: 115
+url: /es/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+Representa un instante en el tiempo, típicamente expresado como una fecha y hora del día.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | Inicializa una nueva instancia del objeto DateTime con el año, mes y día especificados. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | Inicializa una nueva instancia del objeto DateTime con el año, mes, día, hora, minuto y segundo especificados. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | Inicializa una nueva instancia del objeto DateTime con el año, mes, día, hora, minuto, segundo y milisegundo especificados. |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | Inicializa una nueva instancia del objeto DateTime con el objeto Date especificado |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | Inicializa una nueva instancia del objeto DateTime con el objeto Calendar especificado |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | Agrega el número especificado de días al valor de esta instancia. |
+| [addHours(double value)](#addHours-double-) | Agrega el número especificado de horas al valor de esta instancia. |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | Agrega el número especificado de milisegundos al valor de esta instancia. |
+| [addMinutes(double value)](#addMinutes-double-) | Agrega el número especificado de minutos al valor de esta instancia. |
+| [addMonths(int months)](#addMonths-int-) | Agrega el número especificado de meses al valor de esta instancia. |
+| [addSeconds(double value)](#addSeconds-double-) | Agrega el número especificado de segundos al valor de esta instancia. |
+| [addYears(int value)](#addYears-int-) | Agrega el número especificado de años al valor de esta instancia. |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | Compara el valor de esta instancia con un valor DateTime especificado y devuelve un entero que indica si esta instancia es anterior, igual o posterior al valor DateTime especificado. |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | Compara el valor de esta instancia con un objeto especificado que contiene un valor DateTime, y devuelve un entero que indica si esta instancia es anterior, igual o posterior al valor DateTime especificado. |
+| [equals(Object value)](#equals-java.lang.Object-) | Devuelve un valor que indica si esta instancia es igual a un objeto especificado. |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | Obtiene el día del mes representado por esta instancia. |
+| [getDayOfWeek()](#getDayOfWeek--) | Obtiene el día de la semana representado por esta instancia. |
+| [getDayOfYear()](#getDayOfYear--) | Obtiene el día del año representado por esta instancia. |
+| [getHour()](#getHour--) | Obtiene la componente de hora de la fecha representada por esta instancia. |
+| [getMillisecond()](#getMillisecond--) | Obtiene la componente de milisegundos de la fecha representada por esta instancia. |
+| [getMinute()](#getMinute--) | Obtiene la componente de minuto de la fecha representada por esta instancia. |
+| [getMonth()](#getMonth--) | Obtiene la componente de mes de la fecha representada por esta instancia. |
+| [getNow()](#getNow--) | Obtiene un objeto DateTime que está configurado a la fecha y hora actuales en este equipo, expresado como hora local. |
+| [getSecond()](#getSecond--) | Obtiene la componente de segundos de la fecha representada por esta instancia. |
+| [getYear()](#getYear--) | Obtiene la componente de año de la fecha representada por esta instancia. |
+| [hashCode()](#hashCode--) | Devuelve el código hash de esta instancia. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | Convierte el valor del objeto DateTime actual a un objeto Calendar. |
+| [toDate()](#toDate--) | Convierte el valor del objeto DateTime actual a un objeto Date. |
+| [toLocalTime()](#toLocalTime--) | Convierte el valor del objeto DateTime actual a la hora local. |
+| [toString()](#toString--) | Convierte el valor del objeto DateTime actual a su representación de cadena equivalente. |
+| [toUniversalTime()](#toUniversalTime--) | Convierte el valor del objeto DateTime actual a Tiempo Universal Coordinado (UTC). |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+Inicializa una nueva instancia del objeto DateTime con el año, mes y día especificados.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| year | int | El año (1 a 9999). |
+| month | int | El mes (1 a 12). |
+| day | int | El día (1 al número de días del mes). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+Inicializa una nueva instancia del objeto DateTime con el año, mes, día, hora, minuto y segundo especificados.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| year | int | El año (1 a 9999). |
+| month | int | El mes (1 a 12). |
+| day | int | El día (1 al número de días del mes). |
+| hour | int | Las horas (0 a 23). |
+| minute | int | Los minutos (0 a 59). |
+| second | int | Los segundos (0 a 59). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+Inicializa una nueva instancia del objeto DateTime con el año, mes, día, hora, minuto, segundo y milisegundo especificados.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| year | int | El año (1 a 9999). |
+| month | int | El mes (1 a 12). |
+| day | int | El día (1 al número de días del mes). |
+| hour | int | Las horas (0 a 23). |
+| minute | int | Los minutos (0 a 59). |
+| second | int | Los segundos (0 a 59). |
+| milisegundo | int | Los milisegundos (0 a 999). |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+Inicializa una nueva instancia del objeto DateTime con el objeto Date especificado
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fecha | java.util.Date | El objeto Date |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+Inicializa una nueva instancia del objeto DateTime con el objeto Calendar especificado
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| cld | java.util.Calendar | El objeto Calendar |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+Agrega el número especificado de días al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Un número de días enteros y fraccionarios. El parámetro value puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+Agrega el número especificado de horas al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Un número de horas enteras y fraccionarias. El parámetro value puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+Agrega el número especificado de milisegundos al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Un número de milisegundos enteros y fraccionarios. El parámetro value puede ser negativo o positivo. Nota: este valor se redondea al entero más cercano. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+Agrega el número especificado de minutos al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Un número de minutos enteros y fraccionarios. El parámetro value puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+Agrega el número especificado de meses al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| meses | int | Un número de meses. El parámetro months puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+Agrega el número especificado de segundos al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double | Un número de segundos enteros y fraccionarios. El parámetro value puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+Agrega el número especificado de años al valor de esta instancia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int | Un número de años. El parámetro value puede ser negativo o positivo. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+Compara el valor de esta instancia con un valor DateTime especificado y devuelve un entero que indica si esta instancia es anterior, igual o posterior al valor DateTime especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | Un objeto DateTime para comparar. |
+
+**Returns:**
+int - Un número con signo que indica los valores relativos de esta instancia y del parámetro value. Descripción del valor Menor que cero Esta instancia es anterior a value. Cero Esta instancia es igual a value. Mayor que cero Esta instancia es posterior a value.
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+Compara el valor de esta instancia con un objeto especificado que contiene un valor DateTime, y devuelve un entero que indica si esta instancia es anterior, igual o posterior al valor DateTime especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object | Un objeto DateTime empaquetado para comparar, o null. |
+
+**Returns:**
+int - Un número con signo que indica los valores relativos de esta instancia y value. Descripción del valor Menor que cero Esta instancia es anterior a value. Cero Esta instancia es igual a value. Mayor que cero Esta instancia es posterior a value, o value es null.
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Devuelve un valor que indica si esta instancia es igual a un objeto especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object | Un objeto para comparar con esta instancia. |
+
+**Returns:**
+boolean - true si value es una instancia de DateTime y es igual al valor de esta instancia; de lo contrario, false.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+Obtiene el día del mes representado por esta instancia.
+
+**Returns:**
+int - El componente día, expresado como un valor entre 1 y 31.
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+Obtiene el día de la semana representado por esta instancia.
+
+**Returns:**
+int - el día de la semana de este valor DateTime.
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+Obtiene el día del año representado por esta instancia.
+
+**Returns:**
+int - El día del año, expresado como un valor entre 1 y 366.
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+Obtiene la componente de hora de la fecha representada por esta instancia.
+
+**Returns:**
+int - El componente de hora, expresado como un valor entre 0 y 23.
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+Obtiene la componente de milisegundos de la fecha representada por esta instancia.
+
+**Returns:**
+int - El componente de milisegundos, expresado como un valor entre 0 y 999.
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+Obtiene la componente de minuto de la fecha representada por esta instancia.
+
+**Returns:**
+int - El componente de minuto, expresado como un valor entre 0 y 59.
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+Obtiene la componente de mes de la fecha representada por esta instancia.
+
+**Returns:**
+int - El componente de mes, expresado como un valor entre 1 y 12.
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+Obtiene un objeto DateTime que está configurado a la fecha y hora actuales en este equipo, expresado como hora local.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+Obtiene la componente de segundos de la fecha representada por esta instancia.
+
+**Returns:**
+int - Los segundos, entre 0 y 59.
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+Obtiene la componente de año de la fecha representada por esta instancia.
+
+**Returns:**
+int - El año, entre 1 y 9999.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Devuelve el código hash de esta instancia.
+
+**Returns:**
+int - Un código hash entero con signo de 32 bits.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+Convierte el valor del objeto DateTime actual a un objeto Calendar.
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+Convierte el valor del objeto DateTime actual a un objeto Date.
+
+**Returns:**
+java.util.Date - Objeto Date
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+Convierte el valor del objeto DateTime actual a la hora local.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Convierte el valor del objeto DateTime actual a su representación de cadena equivalente.
+
+**Returns:**
+java.lang.String - Una representación en cadena del valor del objeto DateTime actual.
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+Convierte el valor del objeto DateTime actual a Tiempo Universal Coordinado (UTC).
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/datevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor de fecha y hora.
+type: docs
+weight: 116
+url: /es/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+Valor de fecha y hora.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor de fecha y hora. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/datevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| unidad | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+Valor de fecha y hora.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/datevalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/diagram/_index.md
+++ b/spanish/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: Diagrama
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Elemento raíz de la jerarquía de objetos de Visio.
+type: docs
+weight: 117
+url: /es/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Elemento raíz de la jerarquía de objetos de Visio.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | Constructor público de clase, carga el diagrama desde el archivo. |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | Constructor público de clase, carga el diagrama desde el flujo. |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | Constructor público de clase, carga el diagrama desde el flujo usando un formato predefinido. |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | Constructor público de clase, carga el diagrama desde el flujo usando opciones de carga de archivo predefinidas. |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | Constructor público de clase, carga el diagrama desde el archivo usando un formato predefinido. |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | Constructor público de clase, carga el diagrama desde el archivo usando opciones de carga de archivo predefinidas. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | Agrega master al diagrama desde el diagrama fuente por el Nombre o NameU del master. |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | Agrega master al diagrama desde el flujo de plantilla por el ID del master. |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | Agrega master al diagrama desde el flujo de plantilla por el Nombre o NameU del master. |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | Agrega master al diagrama desde el archivo de plantilla por el ID del master. |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | Agrega master al diagrama desde el archivo de plantilla por el Nombre o NameU del master. |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | Añade una forma creada por el maestro a una página específica. |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | Añade una forma creada por el maestro en la página con PinX, PinY, Width y Height definidos. |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | Añade una forma creada por el maestro en la página con PinX y PinY definidos. |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | Combina otro objeto Diagram. |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | Copia Theme de un Diagram fuente. |
+| [dispose()](#dispose--) | Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | Exporta el diagrama desde el flujo vsd al formato de flujo vdw. |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | Exporta el diagrama desde el flujo vsd al formato de archivo \*.vdw. |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | Exporta el diagrama desde el archivo vsd al formato de flujo vdw. |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | Exporta el diagrama desde vsd a formato vdw. |
+| [getActivePage()](#getActivePage--) | Especifica la página activa |
+| [getBuildnum()](#getBuildnum--) | El número de compilación de la instancia de Visio utilizada para crear el documento. |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | Contiene la tabla de colores del documento. |
+| [getDataConnections()](#getDataConnections--) | Contiene los elementos DataConnection del documento. |
+| [getDataRecordSets()](#getDataRecordSets--) | La colección de objetos DataRecordset asociados a un objeto Document. |
+| [getDefaultFontDir()](#getDefaultFontDir--) | Obtener la ruta de la carpeta de fuentes predeterminadas |
+| [getDocLangID()](#getDocLangID--) | El ID único del idioma de la interfaz de usuario que el usuario ha especificado en las Preferencias de idioma de Microsoft Office 2010. |
+| [getDocumentProps()](#getDocumentProps--) | Contiene elementos de propiedades del documento, como el título del documento, el autor, etc. |
+| [getDocumentSettings()](#getDocumentSettings--) | Contiene elementos que especifican la configuración del documento. |
+| [getDocumentSheet()](#getDocumentSheet--) | Especifica la estructura ShapeSheet de un documento. |
+| [getEmailRoutingData()](#getEmailRoutingData--) | Contiene una hoja de ruta de correo electrónico MAPI codificada en MIME (Multipurpose Internet Mail Extensions) para el documento. |
+| [getEventItems()](#getEventItems--) | Contiene un elemento EventItem para cada evento al que un objeto debe responder. |
+| [getFonts()](#getFonts--) | Contiene una colección de elementos Font |
+| [getHeaderFooter()](#getHeaderFooter--) | Contiene elementos para el encabezado y pie de página de un documento. |
+| [getInterruptMonitor()](#getInterruptMonitor--) | el monitor de interrupciones. |
+| [getKey()](#getKey--) | Indica si el documento ha sido modificado fuera de Visio. |
+| [getMasters()](#getMasters--) | Colección de objetos Master. |
+| [getMetric()](#getMetric--) | Indica si se deben usar unidades métricas en el dibujo. |
+| [getPages()](#getPages--) | Colección de objetos Page. |
+| [getRibbonX()](#getRibbonX--) | La cadena XML del Ribbon que se pasa al documento para personalizar la interfaz de usuario del ribbon. |
+| [getSolutionXMLs()](#getSolutionXMLs--) | Valor XML. |
+| [getStart()](#getStart--) | Indica si el documento ha sido modificado fuera de Visio. |
+| [getStyleSheets()](#getStyleSheets--) | Colección de objetos StyleSheet. |
+| [getUnusedStyles()](#getUnusedStyles--) | Obtener estilos no utilizados |
+| [getUserCustomUI()](#getUserCustomUI--) | La cadena XML del Ribbon que se pasa al documento para personalizar la barra de acceso rápido o el ribbon. |
+| [getValidation()](#getValidation--) | Almacena información sobre la validación del diagrama para el documento. |
+| [getVbProjectData()](#getVbProjectData--) | Contiene los datos del proyecto Microsoft Visual Basic for Applications en formato codificado MIME (Multipurpose Internet Mail Extensions). |
+| [getVbaProject()](#getVbaProject--) | Obtiene el VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--). |
+| [getVersion()](#getVersion--) | El número de versión de la instancia de Visio. |
+| [getWindows()](#getWindows--) | Contiene los elementos Window para un documento. |
+| [hasHiddenInfo()](#hasHiddenInfo--) | Indica si este diagrama tiene información oculta. |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Distribuye las formas y/o redirige los conectores para todas las páginas del diagrama. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | Imprime todo el documento en la impresora especificada,usando el controlador de impresión estándar (sin interfaz de usuario). |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Imprime todo el documento en la impresora especificada,usando el controlador de impresión estándar (sin interfaz de usuario). |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | Imprime el documento,usando el controlador de impresión estándar (sin interfaz de usuario) y un nombre de documento. |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Imprime el documento,usando el controlador de impresión estándar (sin interfaz de usuario) y un nombre de documento. |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | Eliminar información no utilizada |
+| [removeMacro()](#removeMacro--) | Elimina VBA/macro de este diagrama. |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | Guarda el diagrama en el flujo. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Guarda el diagrama en el flujo. |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | Guarda el documento en un archivo usando las opciones de guardado especificadas. |
+| [save(String filename, int format)](#save-java.lang.String-int-) | Guarda los datos del diagrama en el archivo. |
+| [setBuildnum(long value)](#setBuildnum-long-) | Para la descripción de esta propiedad, consulte [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) |
+| [setDocLangID(int value)](#setDocLangID-int-) | Para la descripción de esta propiedad, consulte [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | Para la descripción de esta propiedad, consulte [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | Indica la ruta de la carpeta Fonts |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Para la descripción de esta propiedad, consulte [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) |
+| [setKey(String value)](#setKey-java.lang.String-) | Para la descripción de esta propiedad, consulte [getKey()](../../com.aspose.diagram/diagram\#getKey--) |
+| [setMetric(int value)](#setMetric-int-) | Para la descripción de esta propiedad, consulte [getMetric()](../../com.aspose.diagram/diagram\#getMetric--) |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | Para la descripción de esta propiedad, consulte [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) |
+| [setStart(long value)](#setStart-long-) | Para la descripción de esta propiedad, consulte [getStart()](../../com.aspose.diagram/diagram\#getStart--) |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | Para la descripción de esta propiedad, consulte [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | Para la descripción de esta propiedad, consulte [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) |
+| [setVersion(String value)](#setVersion-java.lang.String-) | Para la descripción de esta propiedad, consulte [getVersion()](../../com.aspose.diagram/diagram\#getVersion--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+Constructor público de clase, carga el diagrama desde el archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre de archivo | java.lang.String | El nombre del archivo. |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+Constructor público de clase, carga el diagrama desde el flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | El flujo de datos. |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+Constructor público de clase, carga el diagrama desde el flujo usando un formato predefinido.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | El flujo de datos. |
+| formato | int | Los datos Aspose.Diagram.LoadFileFormat. |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+Constructor público de clase, carga el diagrama desde el flujo usando opciones de carga de archivo predefinidas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | El flujo de datos. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | Los datos [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+Constructor público de clase, carga el diagrama desde el archivo usando un formato predefinido.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre de archivo | java.lang.String | El nombre del archivo. |
+| formato | int | El formato de archivo. |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+Constructor público de clase, carga el diagrama desde el archivo usando opciones de carga de archivo predefinidas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre de archivo | java.lang.String | El nombre del archivo. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | Los datos [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+Agrega master al diagrama desde el diagrama fuente por el Nombre o NameU del master.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | diagrama fuente. |
+| masterName | java.lang.String | Nombre del Master o NameU. |
+
+**Returns:**
+int - El ID único del master dentro de la colección de masters en este diagrama.
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+Agrega master al diagrama desde el flujo de plantilla por el ID del master.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | flujo de plantilla. |
+| masterID | int | El ID único del master dentro de la colección de masters en la plantilla. |
+
+**Returns:**
+int - El ID único del master dentro de la colección de masters en este diagrama.
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+Agrega master al diagrama desde el flujo de plantilla por el Nombre o NameU del master.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | flujo de plantilla. |
+| masterName | java.lang.String | Nombre del Master o NameU. |
+
+**Returns:**
+int - El ID único del master dentro de la colección de masters en este diagrama.
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+Agrega master al diagrama desde el archivo de plantilla por el ID del master.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Ruta al archivo de plantilla (puede ser formato vdx, vst o vsd). |
+| masterID | int | El ID único del master dentro de la colección de masters en la plantilla. |
+
+**Returns:**
+int - El ID único del master dentro de la colección de masters en este diagrama.
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+Agrega master al diagrama desde el archivo de plantilla por el Nombre o NameU del master.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Ruta al archivo de plantilla (puede ser formato vdx, vst o vsd). |
+| masterName | java.lang.String | Nombre del Master o NameU. |
+
+**Returns:**
+int - El ID único del master dentro de la colección de masters en este diagrama.
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+Añade una forma creada por el maestro a una página específica.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nuevo objeto de forma[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Nombre del maestro. |
+| pageNumber | int | Índice de la página. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+Añade una forma creada por el maestro en la página con PinX, PinY, Width y Height definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma en pulgadas. |
+| height | double | Especifica la altura de la forma en pulgadas. |
+| masterName | java.lang.String | Nombre del maestro. |
+| pageNumber | int | Índice de la página. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+Añade una forma creada por el maestro en la página con PinX y PinY definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| masterName | java.lang.String | Nombre del maestro. |
+| pageNumber | int | Índice de la página. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+Combina otro objeto Diagram.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | Otro objeto Diagram. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+Copia Theme de un Diagram fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | diagrama fuente. |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+Exporta el diagrama del flujo vsd al formato de flujo vdw. Aún no implementado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | flujo vsd. |
+| outputVdw | java.io.InputStream | flujo vdw. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+Exporta el diagrama del flujo vsd al formato de archivo \*.vdw. Aún no implementado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | Nombre de archivo \*.vsd. |
+| outputVdw | java.lang.String | flujo vdw. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+Exporta el diagrama del archivo vsd al formato de flujo vdw. Aún no implementado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| inputVsd | java.lang.String | Nombre de archivo \*.vsd. |
+| outputVdw | java.io.InputStream | flujo vdw. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+Exporta el diagrama de vsd a formato vdw. Aún no implementado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| inputVsd | java.lang.String | Nombre de archivo \*.vsd. |
+| outputVdw | java.lang.String | Nombre de archivo \*.vdw. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+Especifica la página activa
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+El número de compilación de la instancia de Visio utilizada para crear el documento.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+Contiene la tabla de colores del documento. Cada documento contiene una única tabla de colores, que enumera los 24 colores estándar que están disponibles para aplicarse a objetos como shapes, texto y capas en el documento.
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+Contiene los elementos DataConnection del documento.
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+La colección de objetos DataRecordset asociados a un objeto Document.
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+Obtener la ruta de la carpeta de fuentes predeterminadas
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+El ID único del idioma de la interfaz de usuario que el usuario ha especificado en las Preferencias de idioma de Microsoft Office 2010.
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+Contiene elementos de propiedades del documento, como el título del documento, el autor, etc.
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+Contiene elementos que especifican la configuración del documento.
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+Especifica la estructura ShapeSheet de un documento.
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+Contiene una hoja de ruta de correo electrónico MAPI codificada en MIME (Multipurpose Internet Mail Extensions) para el documento.
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+Contiene un elemento EventItem para cada evento al que un objeto debe responder.
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Contiene una colección de elementos Font
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+Contiene elementos para el encabezado y pie de página de un documento.
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+el monitor de interrupciones.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+Indica si el documento ha sido modificado fuera de Visio. Si está presente, Visio probará completamente el contenido del archivo. Omitir para archivos que cree fuera de Visio.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Colección de objetos Master.
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+Indica si se deben usar unidades métricas en el dibujo. Establezca este atributo en True (1) para usar unidades métricas; establézcalo en False (0) para usar unidades inglesas.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Colección de objetos Page.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+La cadena XML del Ribbon que se pasa al documento para personalizar la interfaz de usuario del ribbon.
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+Valor XML.
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+Indica si el documento ha sido modificado fuera de Visio. Si está presente, Visio probará completamente el contenido del archivo. Omitir para archivos que cree fuera de Visio.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+Colección de objetos StyleSheet.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+Obtener estilos no utilizados
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+La cadena XML del Ribbon que se pasa al documento para personalizar la barra de acceso rápido o el ribbon.
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+Almacena información sobre la validación del diagrama para el documento.
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+Contiene los datos del proyecto Microsoft Visual Basic for Applications en formato codificado MIME (Multipurpose Internet Mail Extensions).
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+Obtiene el VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--).
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+El número de versión de la instancia de Visio. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+Contiene los elementos Window para un documento.
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+Indica si este diagrama tiene información oculta.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Distribuye las formas y/o redirige los conectores para todas las páginas del diagrama.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Usando [LayoutOptions](../../com.aspose.diagram/layoutoptions) para configurar las opciones de diseño. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Imprime todo el documento en la impresora especificada, usando el controlador de impresión estándar (sin interfaz de usuario). Si printerName es Null o está vacío, se usará la impresora predeterminada.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerName | java.lang.String | El nombre de la impresora. Puede ser Null. |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+Imprime todo el documento en la impresora especificada, usando el controlador de impresión estándar (sin interfaz de usuario). Si printerName es Null o está vacío, se usará la impresora predeterminada.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerName | java.lang.String | El nombre de la impresora. Puede ser Null. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Las opciones de impresión. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+Imprime el documento,usando el controlador de impresión estándar (sin interfaz de usuario) y un nombre de documento.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerName | java.lang.String | El nombre de la impresora. Puede ser Null. |
+| documentName | java.lang.String | El nombre del documento a mostrar (por ejemplo, en un cuadro de diálogo de estado de impresión o en la cola de la impresora) al imprimir el documento. |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+Imprime el documento,usando el controlador de impresión estándar (sin interfaz de usuario) y un nombre de documento.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| printerName | java.lang.String | El nombre de la impresora. Puede ser Null. |
+| documentName | java.lang.String | El nombre del documento a mostrar (por ejemplo, en un cuadro de diálogo de estado de impresión o en la cola de la impresora) al imprimir el documento. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Las opciones de impresión. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+Eliminar información no utilizada
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+Elimina VBA/macro de este diagrama.
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+Guarda el diagrama en el flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | El flujo de archivo. |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | Las opciones de guardado. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Guarda el diagrama en el flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | El flujo de archivo. |
+| formato | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+Guarda el documento en un archivo usando las opciones de guardado especificadas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre de archivo | java.lang.String | El nombre del archivo. |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) opciones para guardar el diagrama. |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+Guarda los datos del diagrama en el archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre de archivo | java.lang.String | El nombre del archivo. |
+| formato | int | Aspose.Diagram.SaveFileFormat formato de archivo de guardado. |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+Indica la ruta de la carpeta Fonts
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getKey()](../../com.aspose.diagram/diagram\#getKey--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStart()](../../com.aspose.diagram/diagram\#getStart--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/diagramexception/_index.md
+++ b/spanish/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Clase base para todas las excepciones de Aspose.Diagram
+type: docs
+weight: 118
+url: /es/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+Clase base para todas las excepciones de Aspose.Diagram
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Puede usarse para especificar opciones adicionales al guardar un diagrama en formato Visio VDXVSX.
+type: docs
+weight: 119
+url: /es/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Puede usarse para especificar opciones adicionales al guardar un diagrama en formato Visio (VDX\\VSX). Por el momento solo proporciona la propiedad SaveFormat, pero en el futuro se añadirán otras opciones.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un diagrama en formato VDX. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un diagrama en formato VDX o VSX. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | Define si es necesario ampliar la página para ajustarse al contenido del dibujo o no. |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardará el diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | Para la descripción de esta propiedad, consulte [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un diagrama en formato VDX.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un diagrama en formato VDX o VSX.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+Define si es necesario ampliar la página para ajustarse al contenido del dibujo o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardará el diagrama renderizado si se utiliza este objeto de opciones de guardado. Puede ser Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/displaymode/_index.md
+++ b/spanish/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros.
+type: docs
+weight: 120
+url: /es/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. Cuando está contenido en un elemento SmartTagDef, el elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/displaymode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. Cuando está contenido en un elemento SmartTagDef, el elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/displaymode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/spanish/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta mientras la forma está seleccionada o todo el tiempo.
+type: docs
+weight: 121
+url: /es/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta mientras la forma está seleccionada o todo el tiempo.
+type: docs
+weight: 122
+url: /es/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | Muestra la forma de grupo delante de las formas miembro. |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | Oculta la forma de grupo y el texto. |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | Muestra la forma de grupo detrás de las formas miembro. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+Muestra la forma de grupo delante de las formas miembro.
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+Oculta la forma de grupo y el texto.
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+Muestra la forma de grupo detrás de las formas miembro.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros.
+type: docs
+weight: 123
+url: /es/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. Cuando está contenido en un elemento SmartTagDef, el elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | Muestra la forma de grupo detrás de las formas miembro. |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | Muestra la forma de grupo delante de las formas miembro. |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | Oculta la forma de grupo y el texto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+Muestra la forma de grupo detrás de las formas miembro.
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+Muestra la forma de grupo delante de las formas miembro.
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+Oculta la forma de grupo y el texto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/docprops/_index.md
+++ b/spanish/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan el alcance de la calidad de vista previa del documento y el formato de salida.
+type: docs
+weight: 124
+url: /es/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+Contiene elementos que controlan la calidad de vista previa del documento, el alcance y el formato de salida.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | Indica si el documento está siendo revisado para anotaciones. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDocLangID()](#getDocLangID--) | Indica el idioma predeterminado del documento. |
+| [getLockPreview()](#getLockPreview--) | Especifica si se guarda una vista previa cada vez que guarda un dibujo. |
+| [getOutputFormat()](#getOutputFormat--) | Especifica el formato de salida para un dibujo. |
+| [getPreviewQuality()](#getPreviewQuality--) | Especifica si la vista previa del dibujo es de calidad preliminar o detallada. |
+| [getPreviewScope()](#getPreviewScope--) | Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento. |
+| [getViewMarkup()](#getViewMarkup--) | Determina si las anotaciones aparecen en la ventana del dibujo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/docprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+Indica si el documento está siendo revisado para anotaciones.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+Indica el idioma predeterminado del documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+Especifica si se guarda una vista previa cada vez que guarda un dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+Especifica el formato de salida para un dibujo.
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+Especifica si la vista previa del dibujo es de calidad preliminar o detallada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+Determina si las anotaciones aparecen en la ventana del dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/docprops\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/documentproperties/_index.md
+++ b/spanish/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos de propiedades del documento, como el título del documento, el autor, etc.
+type: docs
+weight: 125
+url: /es/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+Contiene elementos de propiedades del documento, como el título del documento, el autor, etc.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | Especifica los nombres alternativos de un documento. |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | Contiene el número de compilación completo de la instancia utilizada para crear el documento. |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | Contiene el número de compilación de la instancia utilizada por última vez para editar el documento. |
+| [getCategory()](#getCategory--) | Especifica el texto descriptivo para el tipo de dibujo, como diagrama de flujo o diseño de oficina. |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | Contiene información ingresada por el usuario que identifica la empresa que crea el dibujo o la empresa para la que se está creando el dibujo. |
+| [getCreator()](#getCreator--) | Identifica quién creó o actualizó por última vez el archivo. |
+| [getCustomProps()](#getCustomProps--) | Colección de CustomProp. |
+| [getDesc()](#getDesc--) | Contiene una cadena de texto descriptiva para un documento. |
+| [getHyperlinkBase()](#getHyperlinkBase--) | Contiene la ruta que se utilizará para hipervínculos relativos (hipervínculos cuya ubicación del archivo enlazado se describe en relación con el diagrama de Microsoft Visio). |
+| [getKeywords()](#getKeywords--) | Contiene una cadena de texto que identifica temas u otra información importante sobre el archivo, como el nombre del proyecto, el nombre del cliente o el número de versión. |
+| [getLanguage()](#getLanguage--) | Especifica el idioma |
+| [getManager()](#getManager--) | Contiene una cadena de texto introducida por el usuario que identifica a la persona a cargo del proyecto o departamento. |
+| [getPreviewPicture()](#getPreviewPicture--) | Contiene un flujo de metafile que sirve como vista previa del documento. |
+| [getSubject()](#getSubject--) | Contiene una cadena de texto definida por el usuario que describe el contenido del documento. |
+| [getTemplate()](#getTemplate--) | Contiene un valor de cadena que especifica el nombre de archivo de la plantilla a partir de la cual se creó el documento. |
+| [getTimeCreated()](#getTimeCreated--) | Contiene un valor de fecha y hora que indica cuándo se creó el documento. |
+| [getTimeEdited()](#getTimeEdited--) | Contiene un valor de fecha y hora que indica cuándo se editó por última vez el documento. |
+| [getTimePrinted()](#getTimePrinted--) | Contiene un valor de fecha y hora que indica cuándo se imprimió por última vez el documento. |
+| [getTimeSaved()](#getTimeSaved--) | Contiene un valor de fecha y hora que indica cuándo se guardó por última vez el documento. |
+| [getTitle()](#getTitle--) | Contiene una cadena de texto definida por el usuario que sirve como título descriptivo del documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | Para la descripción de esta propiedad, consulte [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | Para la descripción de esta propiedad, consulte [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | Para la descripción de esta propiedad, consulte [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) |
+| [setCompany(String value)](#setCompany-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) |
+| [setCreator(String value)](#setCreator-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) |
+| [setDesc(String value)](#setDesc-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | Para la descripción de esta propiedad, consulte [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | Para la descripción de esta propiedad, consulte [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | Para la descripción de esta propiedad, consulte [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) |
+| [setManager(String value)](#setManager-java.lang.String-) | Para la descripción de esta propiedad, consulte [getManager()](../../com.aspose.diagram/documentproperties\#getManager--) |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | Para la descripción de esta propiedad, consulte [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) |
+| [setSubject(String value)](#setSubject-java.lang.String-) | Para la descripción de esta propiedad, consulte [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--) |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--) |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+Especifica los nombres alternativos de un documento.
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+Contiene el número de compilación completo de la instancia utilizada para crear el documento.
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+Contiene el número de compilación de la instancia utilizada por última vez para editar el documento.
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Especifica el texto descriptivo para el tipo de dibujo, como diagrama de flujo o diseño de oficina. Este texto también puede ingresarse en la interfaz de usuario de Microsoft Visio en el cuadro Categoría del cuadro de diálogo Propiedades.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+Contiene información ingresada por el usuario que identifica la empresa que crea el dibujo o la empresa para la que se está creando el dibujo. La longitud máxima es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+Identifica quién creó o actualizó por última vez el archivo. La longitud máxima es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+Colección de CustomProp.
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+Contiene una cadena de texto descriptiva para un documento. Use este elemento para almacenar información importante sobre el documento, como su propósito, cambios recientes o cambios pendientes. La longitud máxima es de 191 caracteres.
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+Contiene la ruta que se utilizará para hipervínculos relativos (hipervínculos cuya ubicación del archivo enlazado se describe en relación con el diagrama de Microsoft Visio). De forma predeterminada, la ruta del hipervínculo es relativa al documento actual a menos que se especifique una ruta diferente en este elemento. La longitud máxima es de 256 caracteres.
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+Contiene una cadena de texto que identifica temas u otra información importante sobre el archivo, como el nombre del proyecto, el nombre del cliente o el número de versión. La longitud máxima de la cadena es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+Especifica el idioma
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+Contiene una cadena de texto ingresada por el usuario que identifica a la persona a cargo del proyecto o del departamento. La longitud máxima es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+Contiene un flujo de metafile que sirve como vista previa del documento.
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+Contiene una cadena de texto definida por el usuario que describe el contenido del documento. La longitud máxima es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+Contiene un valor de cadena que especifica el nombre de archivo de la plantilla a partir de la cual se creó el documento.
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+Contiene un valor de fecha y hora que indica cuándo se creó el documento.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+Contiene un valor de fecha y hora que indica cuándo se editó por última vez el documento.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+Contiene un valor de fecha y hora que indica cuándo se imprimió por última vez el documento.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+Contiene un valor de fecha y hora que indica cuándo se guardó por última vez el documento.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+Contiene una cadena de texto definida por el usuario que sirve como título descriptivo para el documento. La longitud máxima es de 63 caracteres.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/documentsettings/_index.md
+++ b/spanish/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican la configuración del documento.
+type: docs
+weight: 126
+url: /es/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+Contiene elementos que especifican la configuración del documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | Un archivo de interfaz de usuario de Microsoft Visio (VSU) codificado en MIME (Multipurpose Internet Mail Extensions) que representa barras de herramientas personalizadas. |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | Contiene el nombre del archivo de interfaz de usuario de Microsoft Visio (.vsu) que define menús personalizados y aceleradores para un documento. |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | Contiene el nombre del archivo de interfaz de usuario de Microsoft Visio (.vsu) que define barras de herramientas y barras de estado personalizadas para un documento. |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | Especifica el ID de un elemento StyleSheet. |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | Especifica el ID de un elemento StyleSheet. |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | Especifica el ID de un elemento StyleSheet. |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | Especifica el ID de un elemento StyleSheet. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Especifica si la función de cuadrícula dinámica está habilitada para un documento o ventana. |
+| [getGlueSettings()](#getGlueSettings--) | Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento. |
+| [getProtectBkgnds()](#getProtectBkgnds--) | Especifica si se impide al usuario eliminar o editar páginas de fondo. |
+| [getProtectMasters()](#getProtectMasters--) | Especifica si se impide al usuario crear, editar o eliminar maestros. |
+| [getProtectShapes()](#getProtectShapes--) | Especifica si se impide al usuario seleccionar formas que tengan su elemento LockSelect configurado en 1. |
+| [getProtectStyles()](#getProtectStyles--) | Especifica si se impide al usuario crear o editar estilos. |
+| [getSnapAngles()](#getSnapAngles--) | Contiene una colección de elementos SnapAngle. |
+| [getSnapExtensions()](#getSnapExtensions--) | Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa. |
+| [getSnapSettings()](#getSnapSettings--) | Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana. |
+| [getTopPage()](#getTopPage--) | Especifica el ID de la página que debe mostrarse cuando el documento es abierto por Microsoft Visio. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | Para la descripción de esta propiedad, consulte [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--) |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--) |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--) |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | Para la descripción de esta propiedad, consulte [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--) |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | Para la descripción de esta propiedad, consulte [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--) |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | Para la descripción de esta propiedad, consulte [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--) |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | Para la descripción de esta propiedad, consulte [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Para la descripción de esta propiedad, consulte [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Para la descripción de esta propiedad, consulte [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--) |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | Para la descripción de esta propiedad, consulte [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--) |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | Para la descripción de esta propiedad, consulte [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--) |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | Para la descripción de esta propiedad, consulte [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--) |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | Para la descripción de esta propiedad, consulte [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--) |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | Para la descripción de esta propiedad, consulte [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Para la descripción de esta propiedad, consulte [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Para la descripción de esta propiedad, consulte [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--) |
+| [setTopPage(int value)](#setTopPage-int-) | Para la descripción de esta propiedad, consulte [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+Un archivo de interfaz de usuario de Microsoft Visio (VSU) codificado en MIME (Multipurpose Internet Mail Extensions) que representa barras de herramientas personalizadas.
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+Contiene el nombre del archivo de interfaz de usuario de Microsoft Visio (.vsu) que define menús personalizados y aceleradores para un documento.
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+Contiene el nombre del archivo de interfaz de usuario de Microsoft Visio (.vsu) que define barras de herramientas y barras de estado personalizadas para un documento.
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+Especifica el ID de un elemento StyleSheet. La próxima vez que el usuario cree una forma usando una herramienta de dibujo, la forma heredará su estilo de relleno del elemento StyleSheet especificado.
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+Especifica el ID de un elemento StyleSheet. La próxima vez que el usuario cree una guía, la guía heredará su estilo de guía del elemento StyleSheet especificado.
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+Especifica el ID de un elemento StyleSheet. La próxima vez que el usuario cree una forma usando una herramienta de dibujo, la forma heredará su estilo de línea del elemento StyleSheet especificado.
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+Especifica el ID de un elemento StyleSheet. La próxima vez que el usuario cree una forma usando una herramienta de dibujo, la forma heredará su estilo de texto del elemento StyleSheet especificado.
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Especifica si la función de cuadrícula dinámica está habilitada para un documento o ventana.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento.
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+Especifica si se impide al usuario eliminar o editar páginas de fondo.
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+Especifica si el usuario está impedido de crear, editar o eliminar maestros. Independientemente de esta configuración, el usuario aún puede crear instancias de maestros.
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+Especifica si se impide al usuario seleccionar formas que tengan su elemento LockSelect configurado en 1.
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+Especifica si el usuario está impedido de crear o editar estilos. Sin embargo, independientemente de esta configuración, el usuario aún puede aplicar estilos.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Contiene una colección de elementos SnapAngle.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana.
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Especifica el ID de la página que debe mostrarse cuando el documento es abierto por Microsoft Visio.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/documentsheet/_index.md
+++ b/spanish/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica una estructura ShapeSheet de documento.
+type: docs
+weight: 127
+url: /es/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+Especifica la estructura ShapeSheet de un documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una colección de elementos ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una colección de elementos Connection. |
+| [getDocProps()](#getDocProps--) | Contiene elementos que controlan la calidad de vista previa del documento, el alcance y el formato de salida. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de relleno. |
+| [getForeign()](#getForeign--) | Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una colección de elementos Hyperlink. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de línea. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getProps()](#getProps--) | Contiene una colección de elementos Prop. |
+| [getReviewers()](#getReviewers--) | Contiene elementos que incluyen información de identificación sobre un revisor de documentos. |
+| [getScratchs()](#getScratchs--) | Contiene una colección de elementos Scratch. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de texto. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificador global único) que identifica la forma. |
+| [getUsers()](#getUsers--) | Contiene una colección de elementos User. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/documentsheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una colección de elementos ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una colección de elementos Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+Contiene elementos que controlan la calidad de vista previa del documento, el alcance y el formato de salida.
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de relleno.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento Microsoft Visio. También incluye elementos que especifican la distancia a la que la imagen del objeto se desplaza dentro de sus bordes.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una colección de elementos Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de línea.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una colección de elementos Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+Contiene elementos que incluyen información de identificación sobre un revisor de documentos.
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una colección de elementos Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de texto.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificador global único) que identifica la forma.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una colección de elementos User.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/documentsheet\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/doublevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor doble
+type: docs
+weight: 128
+url: /es/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Valor doble
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | Constructor. |
+| [DoubleValue()](#DoubleValue--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor doble. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--) |
+| [setValue(double value)](#setValue-double-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/doublevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+| unidad | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Valor doble.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/doublevalue\#isThemed--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/doublevalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/doublevalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+type: docs
+weight: 129
+url: /es/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+type: docs
+weight: 130
+url: /es/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | La página del dibujo se redimensiona automáticamente. |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | Si la página se redimensiona automáticamente depende del valor de la celda DrawingSizeType. |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | La página del dibujo no se redimensiona automáticamente. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+La página del dibujo se redimensiona automáticamente.
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+Si la página se redimensiona automáticamente depende del valor de la celda DrawingSizeType. Si DrawingSizeType = 0 (el tamaño de la página del dibujo es el mismo que el tamaño de la página impresa), la página se redimensiona automáticamente. Si el valor de DrawingSizeType es cualquier otro distinto de cero (0), la página no se redimensiona automáticamente.
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+La página del dibujo no se redimensiona automáticamente.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de escala de dibujo a usar para una página.
+type: docs
+weight: 131
+url: /es/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+Especifica el tipo de escala de dibujo a usar para una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de escala de dibujo a usar para una página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de escala de dibujo a usar para una página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/drawingscaletype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de escala de dibujo a usar para una página.
+type: docs
+weight: 132
+url: /es/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+Especifica el tipo de escala de dibujo a usar para una página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | Escala arquitectónica. |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | Escala de ingeniería civil. |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | Escala personalizada. |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | Escala de ingeniería mecánica. |
+| [METRIC_SCALE](#METRIC-SCALE) | Escala métrica. |
+| [NO_SCALE](#NO-SCALE) | Sin escala. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+Escala arquitectónica.
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+Escala de ingeniería civil.
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+Escala personalizada.
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+Escala de ingeniería mecánica.
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+Escala métrica.
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+Sin escala.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tamaño de dibujo de una página.
+type: docs
+weight: 133
+url: /es/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+Especifica el tamaño de dibujo de una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tamaño de dibujo de una página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tamaño de dibujo de una página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tamaño de dibujo de una página.
+type: docs
+weight: 134
+url: /es/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+Especifica el tamaño de dibujo de una página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI arquitectónico. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI de ingeniería. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | Tamaño de página personalizado. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | Tamaño de dibujo escalado personalizado. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | Ajustar página al contenido del dibujo. |
+| [METRIC_ISO](#METRIC-ISO) | Métrico (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Igual que la impresora. |
+| [STANDARD](#STANDARD) | Estándar. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI arquitectónico.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI de ingeniería.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+Tamaño de página personalizado.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+Tamaño de dibujo escalado personalizado.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+Ajustar página al contenido del dibujo.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+Métrico (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Igual que la impresora.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Estándar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/spanish/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el símbolo mostrado en el botón desplegable.
+type: docs
+weight: 135
+url: /es/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+Representa el símbolo mostrado en el botón desplegable.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ARROW](#ARROW) | Muestra un botón con una flecha hacia abajo. |
+| [ELLIPSIS](#ELLIPSIS) | Muestra un botón con una elipsis (...). |
+| [PLAIN](#PLAIN) | Muestra un botón sin símbolo. |
+| [REDUCE](#REDUCE) | Muestra un botón con una línea horizontal como el carácter de subrayado. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Muestra un botón con una flecha hacia abajo.
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+Muestra un botón con una elipsis (...).
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Muestra un botón sin símbolo.
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+Muestra un botón con una línea horizontal como el carácter de subrayado.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/spanish/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector.
+type: docs
+weight: 136
+url: /es/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. Cuando se suelta el botón del ratón, la forma del conector resultante no se ve afectada por esta configuración. Este elemento no se aplica a los conectores enrutables.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. Cuando se suelta el botón del ratón, la forma del conector resultante no se ve afectada por esta configuración. Este elemento no se aplica a los conectores enrutables.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector.
+type: docs
+weight: 137
+url: /es/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+Especifica el tipo de retroalimentación visual proporcionada a los usuarios cuando arrastran un conector. Cuando se suelta el botón del ratón, la forma del conector resultante no se ve afectada por esta configuración. Este elemento no se aplica a los conectores enrutables.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | Mantener recto (sin patas). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | Mostrar cinco patas al arrastrar. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | Mostrar tres patas al arrastrar. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+Mantener recto (sin patas).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+Mostrar cinco patas al arrastrar.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+Mostrar tres patas al arrastrar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ellipse/_index.md
+++ b/spanish/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: Elipse
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican las coordenadas x e y del punto central de la elipse y dos puntos en la elipse.
+type: docs
+weight: 138
+url: /es/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+Contiene elementos que especifican las coordenadas x e y del punto central de la elipse y dos puntos en la elipse.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | Crea una instancia de la clase [Ellipse](../../com.aspose.diagram/ellipse). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Una coordenada x de un punto en la elipse emparejada con la coordenada y representada por el elemento B. |
+| [getB()](#getB--) | Una coordenada y de un punto en una elipse emparejada con una coordenada x representada por el elemento A. |
+| [getC()](#getC--) | Una coordenada x de un punto en la elipse emparejada con la coordenada y representada por el elemento D. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Una coordenada y de un punto en la elipse emparejada con la coordenada x representada por el elemento C. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del centro de la elipse. |
+| [getY()](#getY--) | La coordenada y del centro de la elipse. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/ellipse\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/ellipse\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/ellipse\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/ellipse\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/ellipse\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/ellipse\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/ellipse\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/ellipse\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+Crea una instancia de la clase [Ellipse](../../com.aspose.diagram/ellipse).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Una coordenada x de un punto en la elipse emparejada con la coordenada y representada por el elemento B.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Una coordenada y de un punto en una elipse emparejada con una coordenada x representada por el elemento A.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Una coordenada x de un punto en la elipse emparejada con la coordenada y representada por el elemento D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Una coordenada y de un punto en la elipse emparejada con la coordenada x representada por el elemento C.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del centro de la elipse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del centro de la elipse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/ellipse\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/ellipse\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/ellipse\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/ellipse\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/ellipse\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/ellipse\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/ellipse\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/ellipse\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de elipses.
+type: docs
+weight: 139
+url: /es/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+Colección de elipses.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/spanish/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican información sobre un arco elíptico.
+type: docs
+weight: 140
+url: /es/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+Contiene elementos que especifican información sobre un arco elíptico.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | Crea una instancia de la clase [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordenada x del punto de control del arco. |
+| [getB()](#getB--) | La coordenada y del punto de control de un arco. |
+| [getC()](#getC--) | El ángulo del eje mayor de un arco relativo al eje x de su elemento padre. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | La proporción del eje mayor de un arco respecto a su eje menor. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de un arco elíptico. |
+| [getY()](#getY--) | La coordenada y del vértice final de un arco elíptico. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+Crea una instancia de la clase [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordenada x del punto de control del arco. El punto de control se ubica mejor aproximadamente a mitad de camino entre los vértices inicial y final del arco. De lo contrario, el arco puede crecer a un tamaño extremo para pasar por el punto de control, con resultados impredecibles.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordenada y del punto de control de un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+El ángulo del eje mayor de un arco relativo al eje x de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+La proporción del eje mayor de un arco respecto a su eje menor. A pesar del significado habitual de estas palabras, el eje mayor no tiene que ser mayor que el eje menor, por lo que esta proporción no tiene que ser mayor que 1. Establecer este elemento a un valor menor o igual a 0 o mayor que 1000 puede producir resultados impredecibles.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de un arco elíptico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de un arco elíptico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: EllipticalArcTo  colección.
+type: docs
+weight: 141
+url: /es/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+Colección EllipticalArcTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/spanish/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Configuración para renderizar metarchivo Emf.
+type: docs
+weight: 142
+url: /es/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Configuración para renderizar metarchivo Emf.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Solo renderizando registros Emf. |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | Preferir renderizar registros EmfPlus. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Solo renderizando registros Emf.
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+Preferir renderizar registros EmfPlus.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/encoding/_index.md
+++ b/spanish/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa una codificación de caracteres.
+type: docs
+weight: 143
+url: /es/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+Representa una codificación de caracteres.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | Determina si el objeto Encoding especificado es igual a la instancia actual. |
+| [equals(Object o)](#equals-java.lang.Object-) | Determina si el objeto especificado es igual a la instancia actual. |
+| [getASCII()](#getASCII--) | Obtiene una codificación para el conjunto de caracteres ASCII (7 bits). |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | Obtiene una codificación para el formato UTF-16 usando el orden de bytes big endian. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Obtiene una codificación para la página de códigos ANSI actual del sistema operativo. |
+| [getEncoding(int codePage)](#getEncoding-int-) | Devuelve la codificación asociada al identificador de página de códigos especificado. |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | Devuelve una codificación asociada al nombre de conjunto de caracteres especificado. |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | Devuelve una codificación asociada al objeto de conjunto de caracteres especificado. |
+| [getUTF7()](#getUTF7--) | Obtiene una codificación para el formato UTF-7. |
+| [getUTF8()](#getUTF8--) | Obtiene una codificación para el formato UTF-8. |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | Obtiene una codificación para el formato UTF-8 sin el identificador UTF-8. |
+| [getUnicode()](#getUnicode--) | Obtiene una codificación para el formato UTF-16 usando el orden de bytes little endian. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+Determina si el objeto Encoding especificado es igual a la instancia actual.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | El objeto Encoding para comparar con la instancia actual. |
+
+**Returns:**
+boolean - verdadero si el valor es igual a la instancia actual; de lo contrario, falso.
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+Determina si el objeto especificado es igual a la instancia actual.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | El objeto para comparar con la instancia actual. |
+
+**Returns:**
+boolean - verdadero si el valor es una instancia de Encoding y es igual a la instancia actual; de lo contrario, falso.
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+Obtiene una codificación para el conjunto de caracteres ASCII (7 bits).
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+Obtiene una codificación para el formato UTF-16 usando el orden de bytes big endian.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+Obtiene una codificación para la página de códigos ANSI actual del sistema operativo.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+Devuelve la codificación asociada al identificador de página de códigos especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| codePage | int | El identificador de página de códigos de la codificación preferida. -o- 0, para usar la codificación predeterminada. |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+Devuelve una codificación asociada al nombre de conjunto de caracteres especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charsetName | java.lang.String | nombre de conjunto de caracteres especificado |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+Devuelve una codificación asociada al objeto de conjunto de caracteres especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | objeto de conjunto de caracteres especificado |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+Obtiene una codificación para el formato UTF-7.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+Obtiene una codificación para el formato UTF-8.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+Obtiene una codificación para el formato UTF-8 sin el identificador UTF-8.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+Obtiene una codificación para el formato UTF-16 usando el orden de bytes little endian.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/event/_index.md
+++ b/spanish/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: Evento
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican fórmulas que controlan eventos de forma.
+type: docs
+weight: 144
+url: /es/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+Contiene elementos que especifican fórmulas que controlan eventos de forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getEventDblClick()](#getEventDblClick--) | Un elemento de evento que se evalúa cuando se hace doble clic en una forma. |
+| [getEventDrop()](#getEventDrop--) | Un elemento de evento que se evalúa cuando una forma se suelta en la página de dibujo, ya sea como una instancia o cuando una forma se duplica o pega. |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop. |
+| [getEventXFMod()](#getEventXFMod--) | Un elemento de evento que se evalúa cuando la posición u orientación de una forma en la página se transforma. |
+| [getTheData()](#getTheData--) | Reservado para uso futuro. |
+| [getTheText()](#getTheText--) | Un elemento de evento que se evalúa cuando el texto o la composición del texto de una forma cambia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/event\#getDel--) |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTheData()](../../com.aspose.diagram/event\#getTheData--) |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTheText()](../../com.aspose.diagram/event\#getTheText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+Un elemento de evento que se evalúa cuando se hace doble clic en una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+Un elemento de evento que se evalúa cuando una forma se suelta en la página de dibujo, ya sea como una instancia o cuando una forma se duplica o pega.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+Un elemento de evento que se evalúa cuando la posición u orientación de una forma en la página se transforma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+Reservado para uso futuro.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+Un elemento de evento que se evalúa cuando el texto o la composición del texto de una forma cambia.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/event\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTheData()](../../com.aspose.diagram/event\#getTheData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTheText()](../../com.aspose.diagram/event\#getTheText--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/eventitem/_index.md
+++ b/spanish/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Encapsula un código de evento.
+type: docs
+weight: 145
+url: /es/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+Encapsula un código de evento. Un elemento EventItem puede desencadenar dos tipos de acciones: puede ejecutar un complemento, o puede enviar una notificación del evento al programa que lo llama.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [EventItem()](#EventItem--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Especifica el código de acción del elemento EventItem padre. Para que un elemento EventItem se guarde en un archivo DatadiagramML, debe ser persistente. |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | Representa una bandera que indica si el evento está habilitado o deshabilitado. |
+| [getEventCode()](#getEventCode--) | Un código que indica el evento que desencadena el complemento. |
+| [getID()](#getID--) | El ID del evento. |
+| [getTarget()](#getTarget--) | Especifica el objetivo de un evento. |
+| [getTargetArgs()](#getTargetArgs--) | Especifica una cadena que contiene argumentos para ser enviados al objetivo de un evento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | Para la descripción de esta propiedad, consulte [getAction()](../../com.aspose.diagram/eventitem\#getAction--) |
+| [setEnabled(int value)](#setEnabled-int-) | Para la descripción de esta propiedad, consulte [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) |
+| [setEventCode(int value)](#setEventCode-int-) | Para la descripción de esta propiedad, consulte [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/eventitem\#getID--) |
+| [setTarget(String value)](#setTarget-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+Especifica el código de acción del elemento EventItem padre. Para que un elemento EventItem se guarde en un archivo DatadiagramML, debe ser persistente. Actualmente, el único código de acción válido que puede tener un evento persistente es 1 (ONEVENT\_ACT\_RUNADDON).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Representa una bandera que indica si el evento está habilitado o deshabilitado.
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+Un código que indica el evento que desencadena el complemento. Para obtener más información sobre los códigos de evento, consulte Códigos de Evento en la Referencia de Automatización de Microsoft Visio 2007.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID del evento.
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+Especifica el objetivo de un evento.
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+Especifica una cadena que contiene argumentos para ser enviados al objetivo de un evento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAction()](../../com.aspose.diagram/eventitem\#getAction--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/eventitem\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección EventItem.
+type: docs
+weight: 146
+url: /es/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+Colección EventItem.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | Agregue el eventItem a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | Elimine el eventItem de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+Constructor.
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+Agregue el eventItem a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+Elimine el eventItem de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/field/_index.md
+++ b/spanish/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: Campo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican funciones y fórmulas insertadas en el texto de las formas.
+type: docs
+weight: 147
+url: /es/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+Contiene elementos que especifican funciones y fórmulas insertadas en el texto de la forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Field()](#Field--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDisplayValue()](#getDisplayValue--) | Obtiene el valor de cadena formateada de este campo. |
+| [getEditMode()](#getEditMode--) | Reservado para uso futuro. |
+| [getFormat()](#getFormat--) | El elemento Format especifica el formato para un campo de texto que es una cadena, número, fecha u hora, duración o moneda. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getObjectKind()](#getObjectKind--) | Indica el tipo de campo de texto. |
+| [getType()](#getType--) | Tipo especifica un tipo de datos para el valor del campo de texto. |
+| [getUICat()](#getUICat--) | Especifica la categoría de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000. |
+| [getUICod()](#getUICod--) | Especifica el código de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000. |
+| [getUIFmt()](#getUIFmt--) | Especifica el formato de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000. |
+| [getValue()](#getValue--) | Contiene el valor para un campo de texto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/field\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/field\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+Obtiene el valor de cadena formateada de este campo.
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+Reservado para uso futuro.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+El elemento Format especifica el formato para un campo de texto que es una cadena, número, fecha o hora, duración o moneda. El tipo de campo de texto se especifica en el elemento Type correspondiente.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+Indica el tipo de campo de texto.
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Tipo especifica un tipo de datos para el valor del campo de texto.
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Especifica la categoría de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Especifica el código de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Especifica el formato de un campo insertado en versiones de Microsoft Visio anteriores a Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene el valor para un campo de texto.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/field\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/field\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de campos.
+type: docs
+weight: 148
+url: /es/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+Colección de campos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Agregue el objeto Field a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Elimine el objeto Field de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Agregue el objeto Field a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Elimine el objeto Field de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/filefontsource/_index.md
+++ b/spanish/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el único archivo de fuente TrueType almacenado en el sistema de archivos.
+type: docs
+weight: 149
+url: /es/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+Representa el único archivo de fuente TrueType almacenado en el sistema de archivos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | Ctor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | Ruta al archivo de fuente. |
+| [getType()](#getType--) | Devuelve el tipo del origen de fuentes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+Ctor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePath | java.lang.String | ruta al archivo de fuente |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Ruta al archivo de fuente.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Devuelve el tipo del origen de fuentes.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/spanish/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene datos devueltos por los métodos de detección de formato de archivo.
+type: docs
+weight: 150
+url: /es/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+Contiene datos devueltos por los métodos de detección de formato de archivo de [FileFormatUtil](../../com.aspose.diagram/fileformatutil).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | Obtiene el formato de archivo detectado. |
+| [getLoadFormat()](#getLoadFormat--) | Obtiene el formato de carga detectado. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+Obtiene el formato de archivo detectado.
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Obtiene el formato de carga detectado.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fileformattype/_index.md
+++ b/spanish/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Enumera los tipos de formato de archivo de hoja de cálculo
+type: docs
+weight: 151
+url: /es/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+Enumera los tipos de formato de archivo de hoja de cálculo
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CSV](#CSV) | Representa un archivo CSV. |
+| [DIF](#DIF) | Formato de Intercambio de Datos. |
+| [DOC](#DOC) | Representa un archivo doc. |
+| [DOCM](#DOCM) | Representa un archivo docm. |
+| [DOCX](#DOCX) | Representa un archivo docx. |
+| [DOTM](#DOTM) | Representa un archivo dotm. |
+| [DOTX](#DOTX) | Representa un archivo dotx. |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Representa un archivo xml de Excel 2003. |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Representa un archivo xls de Excel97-2003. |
+| [HTML](#HTML) | Representa un archivo html. |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | Representa un archivo de correo electrónico. |
+| [MS_EQUATION](#MS-EQUATION) | Representa el objeto MS Equation 3.0. |
+| [ODS](#ODS) | Representa un archivo ods. |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | Representa el objeto nativo incrustado. |
+| [OOXML](#OOXML) | Representa un archivo Office Open XML (como xlsx, docx, pptx, etc). |
+| [PDF](#PDF) | Representa un archivo PDF. |
+| [POTM](#POTM) | Representa un archivo Potm. |
+| [POTX](#POTX) | Representa un archivo Potx. |
+| [PPSM](#PPSM) | Representa un archivo ppsm. |
+| [PPSX](#PPSX) | Representa un archivo ppsx. |
+| [PPT](#PPT) | Representa un archivo ppt. |
+| [PPTM](#PPTM) | Representa un archivo pptm. |
+| [PPTX](#PPTX) | Representa un archivo pptx. |
+| [SLDX](#SLDX) | Representa un archivo sldx. |
+| [SVG](#SVG) | Representa un archivo svg. |
+| [TAB_DELIMITED](#TAB-DELIMITED) | Representa un archivo de texto delimitado por tabulaciones. |
+| [TIFF](#TIFF) | Representa un archivo TIFF. |
+| [UNKNOWN](#UNKNOWN) | Representa un formato no reconocido, no se puede cargar. |
+| [VDW](#VDW) | Formato de dibujo web VDW de MS Visio. |
+| [VDX](#VDX) | Formato XML VDX de MS Visio. |
+| [VSD](#VSD) | Formato binario VSD de MS Visio. |
+| [VSDM](#VSDM) | Formato de archivo VSDM de MS Visio 2013. |
+| [VSDX](#VSDX) | Formato de archivo VSDX de MS Visio 2013. |
+| [VSS](#VSS) | Formato de plantilla binaria VSS de MS Visio. |
+| [VSSM](#VSSM) | Formato de archivo VSSM de MS Visio 2013. |
+| [VSSX](#VSSX) | Formato de archivo VSSX de MS Visio 2013. |
+| [VST](#VST) | Formato binario de plantilla VST de MS Visio. |
+| [VSTM](#VSTM) | Formato de archivo VSTM de MS Visio 2013. |
+| [VSTX](#VSTX) | Formato de archivo de plantilla VSTX de MS Visio 2013. |
+| [VSX](#VSX) | Formato XML de plantilla VSX de MS Visio. |
+| [VTX](#VTX) | Formato XML de plantilla VTX de MS Visio. |
+| [XLAM](#XLAM) | Representa un archivo de plantilla xltm habilitado para add-in macro. |
+| [XLSB](#XLSB) | Representa un archivo xlsb. |
+| [XLSM](#XLSM) | Representa un archivo xlsm que habilita macros. |
+| [XLSX](#XLSX) | Representa un archivo xlsx. |
+| [XLTM](#XLTM) | Representa un archivo de plantilla xltm habilitado para macros. |
+| [XLTX](#XLTX) | Representa un archivo de plantilla xltx. |
+| [XML](#XML) | Representa un archivo XML simple. |
+| [XPS](#XPS) | Representa un archivo XPS. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+Representa un archivo CSV. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+Formato de Intercambio de Datos.
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+Representa un archivo doc. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+Representa un archivo docm. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+Representa un archivo docx. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+Representa un archivo dotm. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+Representa un archivo dotx. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Representa un archivo XML de Excel 2003. El formato de archivo no es compatible, solo para detectar el tipo de archivo.
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Representa un archivo Excel97-2003 xls. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Representa un archivo html.
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+Representa un archivo de correo electrónico. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+Representa el objeto MS Equation 3.0. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+Representa un archivo ods. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+Representa el objeto nativo incrustado. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+Representa un archivo office open xml (como xlsx, docx, pptx, etc). El formato de archivo no es compatible Solo para detectar el tipo de archivo. Si el archivo office open xml está cifrado, no se puede detectar como xlsx, docx, pptx, etc.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Representa un archivo PDF.
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Representa un archivo Potm. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Representa un archivo Potx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+Representa un archivo ppsm. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+Representa un archivo ppsx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+Representa un archivo ppt. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+Representa un archivo pptm. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+Representa un archivo pptx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+Representa un archivo sldx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Representa un archivo svg.
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+Representa un archivo de texto delimitado por tabulaciones. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Representa un archivo TIFF.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Representa un formato no reconocido, no se puede cargar.
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+Formato de dibujo web VDW de MS Visio.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato XML VDX de MS Visio.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+Formato binario VSD de MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato de archivo VSDM de MS Visio 2013.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato de archivo VSDX de MS Visio 2013.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+Formato de plantilla binaria VSS de MS Visio.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato de archivo VSSM de MS Visio 2013.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato de archivo VSSX de MS Visio 2013.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+Formato binario de plantilla VST de MS Visio.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato de archivo VSTM de MS Visio 2013.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato de archivo de plantilla VSTX de MS Visio 2013.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato XML de plantilla VSX de MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato XML de plantilla VTX de MS Visio.
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+Representa un archivo de plantilla xltm habilitado para addinMacro. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+Representa un archivo xlsb. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+Representa un archivo xlsm que permite macros. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+Representa un archivo xlsx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+Representa un archivo de plantilla xltm habilitado para macros. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+Representa un archivo de plantilla xltx. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+Representa un archivo xml simple. El formato de archivo no es compatible Solo para detectar el tipo de archivo.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Representa un archivo XPS.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/spanish/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Proporciona métodos utilitarios para convertir enumeraciones de formato de archivo a cadenas o extensiones de archivo y viceversa.
+type: docs
+weight: 152
+url: /es/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+Proporciona métodos utilitarios para convertir enumeraciones de formato de archivo a cadenas o extensiones de archivo y viceversa.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | Detecta y devuelve la información sobre el formato de un Visio almacenado en un flujo. |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | Detecta y devuelve la información sobre el formato de un Visio almacenado en un archivo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+Detecta y devuelve la información sobre el formato de un Visio almacenado en un flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | El flujo |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+Detecta y devuelve la información sobre el formato de un Visio almacenado en un archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| filePath | java.lang.String | La ruta del archivo. |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fill/_index.md
+++ b/spanish/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: Relleno
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene los valores actuales de formato de relleno para la forma y su sombra paralela, incluidos el color de primer plano del patrón y el color de fondo.
+type: docs
+weight: 153
+url: /es/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getFillBkgnd()](#getFillBkgnd--) | Especifica el color utilizado para el fondo del patrón de relleno de la forma. |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | Especifica el nivel de transparencia para el color de fondo (relleno) del patrón de relleno de la forma, de 0 (completamente opaco) a 1 (completamente transparente). |
+| [getFillForegnd()](#getFillForegnd--) | Especifica el color utilizado para el primer plano (trazo) del patrón de relleno de la forma. |
+| [getFillForegndTrans()](#getFillForegndTrans--) | Especifica el nivel de transparencia para el color de primer plano (relleno) del patrón de relleno de la forma, de 0 (completamente opaco) a 1 (completamente transparente). |
+| [getFillPattern()](#getFillPattern--) | Especifica el patrón de relleno para la forma. |
+| [getGradientFill()](#getGradientFill--) | Contiene los valores actuales de formato de relleno degradado para la forma |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | Especifica el tamaño de desenfoque de la sombra de una forma. |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | Especifica el ángulo de dirección oblicua de la sombra de una forma. |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | Determina la distancia en unidades de página que la sombra de una forma se desplaza horizontalmente respecto a la forma. |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | Determina la distancia en unidades de página que la sombra de una forma se desplaza verticalmente respecto a la forma. |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | Especifica el porcentaje en que la sombra de una forma puede ampliarse o reducirse. |
+| [getShapeShdwShow()](#getShapeShdwShow--) | Especifica el tipo de sombra para una forma. |
+| [getShapeShdwType()](#getShapeShdwType--) | Especifica el tipo de sombra para una forma. |
+| [getShdwBkgnd()](#getShdwBkgnd--) | Especifica el color utilizado para el fondo (relleno) del patrón de relleno de la sombra paralela de la forma. |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | Especifica el nivel de transparencia para el fondo (relleno) del patrón de relleno de la sombra paralela de la forma, de 0.0 (completamente opaco) a 1.0 (completamente transparente). |
+| [getShdwForegnd()](#getShdwForegnd--) | Especifica el color utilizado para el primer plano (trazo) del patrón de relleno de la sombra paralela de la forma. |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | Especifica el nivel de transparencia para el primer plano (trazo) del patrón de relleno de la sombra paralela de la forma, de 0.0 (completamente opaco) a 1.0 (completamente transparente). |
+| [getShdwPattern()](#getShdwPattern--) | Especifica el patrón de relleno para la sombra de una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/fill\#getDel--) |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--) |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--) |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--) |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--) |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--) |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--) |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--) |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | Para la descripción de esta propiedad, consulte [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | Para la descripción de esta propiedad, consulte [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+Especifica el color utilizado para el fondo del patrón de relleno de la forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+Especifica el nivel de transparencia para el color de fondo (relleno) del patrón de relleno de la forma, de 0 (completamente opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+Especifica el color utilizado para el primer plano (trazo) del patrón de relleno de la forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+Especifica el nivel de transparencia para el color de primer plano (relleno) del patrón de relleno de la forma, de 0 (completamente opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+Especifica el patrón de relleno para la forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+Contiene los valores actuales de formato de relleno degradado para la forma
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+Especifica el tamaño del desenfoque de sombra de una forma. No se puede dibujar desenfoque ahora, pero se puede analizar desde vsdx ahora.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+Especifica el ángulo de dirección oblicua de la sombra de una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+Determina la distancia en unidades de página que la sombra de una forma se desplaza horizontalmente respecto a la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+Determina la distancia en unidades de página que la sombra de una forma se desplaza verticalmente respecto a la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+Especifica el porcentaje en que la sombra de una forma puede ampliarse o reducirse.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+Especifica el tipo de sombra para una forma.
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+Especifica el tipo de sombra para una forma.
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+Especifica el color utilizado para el fondo (relleno) del patrón de relleno de la sombra paralela de la forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+Especifica el nivel de transparencia para el fondo (relleno) del patrón de relleno de la sombra paralela de la forma, de 0.0 (completamente opaco) a 1.0 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+Especifica el color utilizado para el primer plano (trazo) del patrón de relleno de la sombra paralela de la forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+Especifica el nivel de transparencia para el primer plano (trazo) del patrón de relleno de la sombra paralela de la forma, de 0.0 (completamente opaco) a 1.0 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+Especifica el patrón de relleno para la sombra de una forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/fill\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/filltype/_index.md
+++ b/spanish/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo de formato de relleno.
+type: docs
+weight: 154
+url: /es/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+Tipo de formato de relleno.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | Representa el tipo de formato automático. |
+| [GRADIENT](#GRADIENT) | Formato de relleno degradado. |
+| [NONE](#NONE) | Representa el tipo de formato ninguno. |
+| [PATTERN](#PATTERN) | Formato de relleno de patrón. |
+| [SOLID](#SOLID) | Formato de relleno sólido. |
+| [TEXTURE](#TEXTURE) | Formato de relleno de textura. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+Representa el tipo de formato automático.
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+Formato de relleno degradado.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Representa el tipo de formato ninguno.
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+Formato de relleno de patrón.
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+Formato de relleno sólido.
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+Formato de relleno de textura.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fld/_index.md
+++ b/spanish/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica un punto de inserción de campo de texto para el elemento Field correspondiente.
+type: docs
+weight: 155
+url: /es/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+Indica un punto de inserción de campo de texto para el elemento Field correspondiente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int | El índice basado en cero del elemento Field dentro de su elemento padre Shape. |
+| shape | [Shape](../../com.aspose.diagram/shape) | Forma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una colección de números de puntos de duplicación
+type: docs
+weight: 156
+url: /es/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+Contiene una colección de números de puntos de duplicación
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(double number)](#add-double-) | Agregar el número de punto doble a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | Eliminar el número de punto doble de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+Constructor.
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+Agregar el número de punto doble a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| número | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+Eliminar el número de punto doble de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| número | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/spanish/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la carpeta que contiene archivos de fuentes TrueType.
+type: docs
+weight: 157
+url: /es/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+Representa la carpeta que contiene archivos de fuentes TrueType.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | Ctor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | Ruta a la carpeta de fuentes. |
+| [getScanSubFolders()](#getScanSubFolders--) | Determina si se deben o no escanear las subcarpetas. |
+| [getType()](#getType--) | Devuelve el tipo del origen de fuentes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+Ctor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| folderPath | java.lang.String | ruta a la carpeta de fuentes |
+| scanSubfolders | boolean | Determina si se deben o no escanear subcarpetas. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+Ruta a la carpeta de fuentes.
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+Determina si se deben o no escanear las subcarpetas.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Devuelve el tipo del origen de fuentes.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/font/_index.md
+++ b/spanish/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: Fuente
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene información sobre una fuente.
+type: docs
+weight: 158
+url: /es/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+Contiene información sobre una fuente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Font()](#Font--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | Los conjuntos de caracteres compatibles de la fuente. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Indicadores que indican lo siguiente: fuente faltante, fuente predeterminada, fuente asiática, fuente compleja, fuente vertical y tipo de fuente. |
+| [getID()](#getID--) | El ID del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre de la fuente como una cadena Unicode UTF-16. |
+| [getPanos()](#getPanos--) | La firma panose de la fuente. |
+| [getUnicodeRanges()](#getUnicodeRanges--) | Los rangos Unicode compatibles de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCharSets()](../../com.aspose.diagram/font\#getCharSets--) |
+| [setFlags(int value)](#setFlags-int-) | Para la descripción de esta propiedad, consulte [getFlags()](../../com.aspose.diagram/font\#getFlags--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/font\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/font\#getName--) |
+| [setPanos(String value)](#setPanos-java.lang.String-) | Para la descripción de esta propiedad, consulte [getPanos()](../../com.aspose.diagram/font\#getPanos--) |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | Para la descripción de esta propiedad, consulte [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+Los conjuntos de caracteres compatibles de la fuente.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Indicadores que indican lo siguiente: fuente faltante, fuente predeterminada, fuente asiática, fuente compleja, fuente vertical y tipo de fuente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre de la fuente como una cadena Unicode UTF-16.
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+La firma panose de la fuente. Panose es un sistema de clasificación de tipografías que las categoriza según sus características visuales.
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+Los rangos Unicode compatibles de la fuente.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFlags()](../../com.aspose.diagram/font\#getFlags--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/font\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/font\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPanos()](../../com.aspose.diagram/font\#getPanos--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fontcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una colección de elementos Font.
+type: docs
+weight: 159
+url: /es/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Contiene una colección de elementos Font.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | Add the Font object in the collection. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getFont(int ID)](#getFont-int-) | Obtiene el elemento con el ID especificado. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | Remove the Font object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+Constructor.
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+Add the Font object in the collection.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int | intEl ID del elemento dentro de su elemento padre. |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+Remove the Font object from the collection.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/spanish/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la configuración de la fuente
+type: docs
+weight: 160
+url: /es/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+Especifica la configuración de la fuente
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | el nombre de fuente predeterminado. |
+| [getFontSources()](#getFontSources--) | Obtiene una copia del arreglo que contiene la lista de fuentes |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | Devuelve un arreglo que contiene nombres de fuentes sustitutas que se usarán si la fuente original no está presente. |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | Indica si se deben usar primero sustitutos de fuentes del sistema cuando una fuente no está presente y el sustituto de esa fuente no está configurado. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Establece la carpeta de fuentes |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Establece las carpetas de fuentes |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Establece los orígenes de fuentes. |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | Nombres de fuentes sustitutas para el nombre de fuente original dado. |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | Para la descripción de esta propiedad, consulte [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+el nombre de fuente predeterminado.
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+Obtiene una copia del arreglo que contiene la lista de fuentes
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+Devuelve un arreglo que contiene nombres de fuentes sustitutas que se usarán si la fuente original no está presente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - Una matriz que contiene nombres de sustitutos de fuentes que se usarán si la fuente original no está presente.
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+Indique si se deben usar primero los sustitutos de fuentes del sistema o no cuando una fuente no está presente y el sustituto de esa fuente no está configurado. Por ejemplo, en Ubuntu, la fuente "Arial" suele ser sustituida por "Liberation Sans". El valor predeterminado es false.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Establece la carpeta de fuentes
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontFolder | java.lang.String | La carpeta que contiene fuentes TrueType. |
+| recursivo | boolean | Determina si se deben o no escanear subcarpetas. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Establece las carpetas de fuentes
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Las carpetas que contienen fuentes TrueType. |
+| recursivo | boolean | Determina si se deben o no escanear subcarpetas. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+Establece los orígenes de fuentes.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Una matriz de fuentes que contienen fuentes TrueType. |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+Nombres de fuentes sustitutas para el nombre de fuente original dado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| originalFontName | java.lang.String | Nombre de la fuente original. |
+| substituteFontNames | java.lang.String[] | Lista de nombres de sustitutos de fuentes que se usarán si la fuente original no está presente. |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/spanish/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Esta es una clase base abstracta para las clases que permiten al usuario especificar varios orígenes de fuentes
+type: docs
+weight: 161
+url: /es/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+Esta es una clase base abstracta para las clases que permiten al usuario especificar varios orígenes de fuentes
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | Devuelve el tipo del origen de fuentes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Devuelve el tipo del origen de fuentes.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/spanish/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de un origen de fuente.
+type: docs
+weight: 162
+url: /es/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+Especifica el tipo de un origen de fuente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | representa una carpeta con archivos de fuentes. |
+| [FONT_FILE](#FONT-FILE) | representa un archivo de fuente único. |
+| [MEMORY_FONT](#MEMORY-FONT) | representa una fuente única en memoria. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+representa una carpeta con archivos de fuentes.
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+representa un archivo de fuente único.
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+representa una fuente única en memoria.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/foreign/_index.md
+++ b/spanish/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: Externo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio.
+type: docs
+weight: 163
+url: /es/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento Microsoft Visio. También incluye elementos que especifican la distancia a la que la imagen del objeto se desplaza dentro de sus bordes.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getImgHeight()](#getImgHeight--) | Determina la altura de la imagen del objeto dentro de su borde. |
+| [getImgOffsetX()](#getImgOffsetX--) | Determina la distancia a la que el objeto se desplaza horizontalmente desde el origen del borde del objeto. |
+| [getImgOffsetY()](#getImgOffsetY--) | Determina la distancia a la que el objeto se desplaza verticalmente desde el origen del borde del objeto. |
+| [getImgWidth()](#getImgWidth--) | Determina el ancho de la imagen del objeto dentro de su borde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/foreign\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+Determina la altura de la imagen del objeto dentro de su borde. La fórmula predeterminada es: F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+Determina la distancia a la que el objeto se desplaza horizontalmente desde el origen del borde del objeto. El valor predeterminado es 0; la fórmula predeterminada es F="ImgWidth\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+Determina la distancia a la que el objeto se desplaza verticalmente desde el origen del borde del objeto. El valor predeterminado es 0; la fórmula predeterminada es F="ImgHeight\*0".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+Determina el ancho de la imagen del objeto dentro de su borde. La fórmula predeterminada es: F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/foreign\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/foreigndata/_index.md
+++ b/spanish/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene un BLOB codificado en MIME Multipurpose Internet Mail Extensions de datos de imagen, como un mapa de bits de metarchivo de Windows o datos OLE.
+type: docs
+weight: 164
+url: /es/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. |
+| [getCompressionType()](#getCompressionType--) | Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. |
+| [getExtentX()](#getExtentX--) | Este atributo solo tiene sentido si los datos externos son un metarchivo. |
+| [getExtentY()](#getExtentY--) | Este atributo solo tiene sentido si los datos externos son un metarchivo. |
+| [getForeignType()](#getForeignType--) | Tipo de datos. |
+| [getImageData()](#getImageData--) | Representa la imagen del objeto OLE como una matriz de bytes. |
+| [getMappingMode()](#getMappingMode--) | Este atributo solo tiene sentido si los datos externos son un metarchivo. |
+| [getObjectData()](#getObjectData--) | Representa los datos del objeto OLE incrustado como una matriz de bytes. |
+| [getObjectHeight()](#getObjectHeight--) | Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2. |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | Devuelve el nombre completo de origen del archivo fuente para el objeto OLE vinculado. |
+| [getObjectType()](#getObjectType--) | Si el atributo ForeignType es "Object", el elemento ForeignData también debe tener un atributo ObjectType. |
+| [getObjectWidth()](#getObjectWidth--) | Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2. |
+| [getShowAsIcon()](#getShowAsIcon--) | Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2. |
+| [getValue()](#getValue--) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | Para la descripción de esta propiedad, consulte [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) |
+| [setCompressionType(int value)](#setCompressionType-int-) | Para la descripción de esta propiedad, consulte [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) |
+| [setExtentX(double value)](#setExtentX-double-) | Para la descripción de esta propiedad, consulte [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) |
+| [setExtentY(double value)](#setExtentY-double-) | Para la descripción de esta propiedad, consulte [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) |
+| [setForeignType(int value)](#setForeignType-int-) | Para la descripción de esta propiedad, consulte [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) |
+| [setImageData(byte[] value)](#setImageData-byte---) | Para la descripción de esta propiedad, consulte [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) |
+| [setMappingMode(int value)](#setMappingMode-int-) | Para la descripción de esta propiedad, consulte [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | Para la descripción de esta propiedad, consulte [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | Para la descripción de esta propiedad, consulte [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) |
+| [setObjectType(int value)](#setObjectType-int-) | Para la descripción de esta propiedad, consulte [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | Para la descripción de esta propiedad, consulte [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | Para la descripción de esta propiedad, consulte [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) |
+| [setValue(byte[] value)](#setValue-byte---) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/foreigndata\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. El valor indica el nivel de compresión aplicado al archivo. El nivel de compresión se mide en cientos de un por ciento.
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un objeto externo basado en raster, como un archivo DIB, JPG, PNG, TIFF o GIF. El valor indica el tipo de compresión aplicado al archivo.
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un metarchivo. El valor indica la extensión horizontal del metarchivo.
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un metarchivo. El valor indica la extensión vertical del metarchivo.
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+Tipo de datos.
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+Representa la imagen del objeto OLE como una matriz de bytes.
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un metarchivo. El valor indica el modo de mapeo del metarchivo.
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+Representa los datos del objeto OLE incrustado como una matriz de bytes.
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2. El valor expresa la altura del objeto en unidades de página.
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+Devuelve el nombre completo de origen del archivo fuente para el objeto OLE vinculado. Solo admite establecer el nombre completo de origen cuando el tipo de archivo es OleFileType.Unknown. Por ejemplo, archivos wav, avi, etc.
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+Si el atributo ForeignType es "Object", el elemento ForeignData también debe tener un atributo ObjectType.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2. El valor expresa el ancho del objeto en unidades de página.
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+Este atributo solo tiene sentido si los datos externos son un objeto incrustado OLE2.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/foreigntype/_index.md
+++ b/spanish/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo de datos.
+type: docs
+weight: 165
+url: /es/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+Tipo de datos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | Metarchivo mejorado. |
+| [INK](#INK) | Tinta. |
+| [METAFILE](#METAFILE) | Metarchivo. |
+| [OBJECT](#OBJECT) | Objeto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+Metarchivo mejorado.
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+Tinta.
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+Metarchivo.
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+Objeto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/formattxt/_index.md
+++ b/spanish/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Clase abstracta para el formato de texto
+type: docs
+weight: 166
+url: /es/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+Clase abstracta para el formato de texto
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección FormatTxt que contiene el texto de una forma.
+type: docs
+weight: 167
+url: /es/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+Colección FormatTxt que contiene el texto de una forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | Agregar el objeto FormatTxt a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getText()](#getText--) | Contiene el texto de una forma con formato. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | Eliminar el objeto FormatTxt de la colección. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | Establecer el texto de una forma sin formato. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+Agregar el objeto FormatTxt a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Contiene el texto de una forma con formato.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+Eliminar el objeto FormatTxt de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+Establecer el texto de una forma sin formato.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: La parte de una forma desde la cual se origina una conexión.
+type: docs
+weight: 168
+url: /es/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+La parte de una forma desde la cual se origina una conexión.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | Celda BeginX. |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | Punto BeginX/BeginY. |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | Celda BeginY. |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | Borde inferior. |
+| [CENTER_EDGE](#CENTER-EDGE) | Borde central. |
+| [CONTROL_POINT](#CONTROL-POINT) | Punto de control. |
+| [END_X_CELL](#END-X-CELL) | Celda EndX. |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | Punto EndX/EndY. |
+| [END_Y_CELL](#END-Y-CELL) | Celda EndY. |
+| [LEFT_EDGE](#LEFT-EDGE) | Borde izquierdo. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | Borde medio. |
+| [NONE](#NONE) | Ninguno. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | Borde derecho. |
+| [TOP_EDGE](#TOP-EDGE) | Borde superior. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+Celda BeginX.
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+Punto BeginX/BeginY.
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+Celda BeginY.
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+Borde inferior.
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+Borde central.
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+Punto de control.
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+Celda EndX.
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+Punto EndX/EndY.
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+Celda EndY.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+Borde izquierdo.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+Borde medio.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ninguno.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+Borde derecho.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+Borde superior.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/geom/_index.md
+++ b/spanish/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican las coordenadas de los vértices de las líneas y arcos que forman la forma.
+type: docs
+weight: 169
+url: /es/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+Contiene elementos que especifican las coordenadas de los vértices para las líneas y arcos que forman la forma. Si la forma tiene más de una ruta, hay un elemento Geom para cada ruta.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Geom()](#Geom--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | Colección de coordenadas. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | Devuelve el valor IX para el siguiente miembro de la colección de coordenadas de la forma. |
+| [getNoFill()](#getNoFill--) | Especifica si una ruta puede ser rellenada. |
+| [getNoLine()](#getNoLine--) | Especifica si se dibuja una línea alrededor del contorno de la ruta. |
+| [getNoQuickDrag()](#getNoQuickDrag--) | Determina si una forma puede ser seleccionada o arrastrada cuando el usuario hace clic en el área rellenada definida por la sección Geometry. |
+| [getNoShow()](#getNoShow--) | Especifica si una ruta se muestra en la página de dibujo. |
+| [getNoSnap()](#getNoSnap--) | Especifica si otras formas se ajustan a una ruta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/geom\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/geom\#getIX--) |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+Colección de coordenadas. Muestra una secuencia de coordenadas.
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+Devuelve el valor IX para el siguiente miembro de la colección de coordenadas de la forma.
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+Especifica si una ruta puede ser rellenada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+Especifica si se dibuja una línea alrededor del contorno de la ruta.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+Determina si una forma puede ser seleccionada o arrastrada cuando el usuario hace clic en el área rellenada definida por la sección Geometry.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+Especifica si una ruta se muestra en la página de dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+Especifica si otras formas se ajustan a una ruta.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/geom\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/geom\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/geomcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Geom.
+type: docs
+weight: 170
+url: /es/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Colección Geom.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | Añade el objeto Geom a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | Elimina el objeto Geom de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+Añade el objeto Geom a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+Elimina el objeto Geom de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gloweffect/_index.md
+++ b/spanish/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Esta clase especifica un efecto de resplandor en el que se agrega un contorno difuminado de color fuera de los bordes del objeto.
+type: docs
+weight: 171
+url: /es/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+Esta clase especifica un efecto de resplandor, en el que se agrega un contorno difuminado de color fuera de los bordes del objeto.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | el radio del resplandor, en unidades de puntos. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | Para la descripción de esta propiedad, consulte [getSize()](../../com.aspose.diagram/gloweffect\#getSize--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+el radio del resplandor, en unidades de puntos.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/spanish/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica constantes que identifican qué formas devolver según la dimensionalidad y direccionalidad de los puntos de conexión que están pegados a una forma particular pasada al método Shape.GluedShapes.
+type: docs
+weight: 176
+url: /es/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+Especifica constantes que identifican qué formas devolver, basándose en la dimensionalidad y direccionalidad de los puntos de conexión que están pegados a una forma particular; se pasan al método Shape.GluedShapes.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Devuelve los ID de todas las formas 1-D que están pegadas a esta forma. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Devuelve todas las formas 2-D que están pegadas a esta forma y todas las formas 2-D a las que esta forma está pegada. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Devuelve los ID de las formas 1-D cuyos puntos finales están pegados a esta forma. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | Si el objeto origen es una forma 1-D, devuelve los ID de la forma 2-D a la que está pegado el punto de inicio. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | Devuelve los IDs de las formas 1-D cuyos puntos iniciales están pegados a esta forma. |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | Si el objeto origen es una forma 1-D, devuelve los IDs de la forma 2-D a la que está pegado el punto final. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Devuelve los ID de todas las formas 1-D que están pegadas a esta forma.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Devuelve todas las formas 2-D que están pegadas a esta forma y todas las formas 2-D a las que esta forma está pegada.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Devuelve los ID de las formas 1-D cuyos puntos finales están pegados a esta forma.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+Si el objeto origen es una forma 1-D, devuelve los IDs de la forma 2-D a la que está pegado el punto inicial. Si el objeto origen es una forma 2-D, devuelve los IDs de las formas 2-D que están pegadas a esta forma.
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+Devuelve los IDs de las formas 1-D cuyos puntos iniciales están pegados a esta forma.
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+Si el objeto origen es una forma 1-D, devuelve los IDs de la forma 2-D a la que está pegado el punto final. Si el objeto origen es una forma 2-D, devuelve los IDs de las formas 2-D a las que está pegada esta forma.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gluesettings/_index.md
+++ b/spanish/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Los valores de bits indican que una configuración de pegamento específica está activada o desactivada.
+type: docs
+weight: 172
+url: /es/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+Los valores de bits indican que una configuración de pegamento específica está activada o desactivada. El valor puede ser una suma de los valores:
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Pegado a puntos de conexión. |
+| [DISABLED](#DISABLED) | El pegamento está desactivado |
+| [GEOMETRY](#GEOMETRY) | Pegado a la geometría. |
+| [GUIDES](#GUIDES) | Pegado a guías. |
+| [HANDLES](#HANDLES) | Pegado a manijas. |
+| [NONE](#NONE) | El pegado está habilitado, pero no hay otras configuraciones de pegado habilitadas. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VERTICES](#VERTICES) | Pegado a vértices. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Pegado a puntos de conexión.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+El pegamento está desactivado
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Pegado a la geometría.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Pegado a guías.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Pegado a manijas.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+El pegado está habilitado, pero no hay otras configuraciones de pegado habilitadas.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Pegado a vértices.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento.
+type: docs
+weight: 173
+url: /es/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | El pegado está desactivado. |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | El pegado está habilitado, pero no hay otras configuraciones de pegado habilitadas. |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | Pegado a puntos de conexión. |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | Pegado a la geometría. |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | Pegado a guías. |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | Pegado a manijas. |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | Pegado a vértices. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+El pegado está desactivado.
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+El pegado está habilitado, pero no hay otras configuraciones de pegado habilitadas.
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+Pegado a puntos de conexión.
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+Pegado a la geometría.
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+Pegado a guías.
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+Pegado a manijas.
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+Pegado a vértices.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gluetype/_index.md
+++ b/spanish/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si se permite el pegado dinámico de forma a forma al conectar a una forma.
+type: docs
+weight: 174
+url: /es/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/gluetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/gluetype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si se permite el pegado dinámico de forma a forma al conectar a una forma.
+type: docs
+weight: 175
+url: /es/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | Permitir pegado dinámico. |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | Permitir pegado dinámico (obsoleto en Microsoft Visio 2002). |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | Predeterminado. |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | No permitir que esta forma 2D se conecte usando pegado dinámico. |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | No permitir pegado dinámico. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+Permitir pegado dinámico.
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+Permitir pegado dinámico (obsoleto en Microsoft Visio 2002).
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+Predeterminado. Permitir pegado dinámico solo para el conector dinámico; de lo contrario, usar pegado estático.
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+No permitir que esta forma 2D se conecte usando pegado dinámico.
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+No permitir pegado dinámico.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa todos los tipos de dirección del degradado.
+type: docs
+weight: 177
+url: /es/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+Representa todos los tipos de dirección del degradado.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | Desconocido |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Desconocido
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientfill/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el relleno de degradado.
+type: docs
+weight: 178
+url: /es/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+Representa el relleno de degradado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | Especifica la orientación del degradado de color de relleno |
+| [getGradientDir()](#getGradientDir--) | Especifica el tipo de degradado de color de relleno |
+| [getGradientEnabled()](#getGradientEnabled--) | Especifica si el degradado de color de relleno es visible. |
+| [getGradientStops()](#getGradientStops--) | Representa la colección de puntos de parada del degradado. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, por favor vea [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, por favor vea [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, por favor vea [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+Especifica la orientación del degradado de color de relleno
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+Especifica el tipo de degradado de color de relleno
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+Especifica si el degradado de color de relleno es visible.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+Representa la colección de puntos de parada del degradado.
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de degradado de color de relleno de una forma
+type: docs
+weight: 179
+url: /es/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+Especifica el tipo de degradado de color de relleno de una forma
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [LINEAR](#LINEAR) | Especifica un degradado de color de relleno lineal. |
+| [PATH](#PATH) | Especifica que el degradado de color de relleno de la forma está en modo de ruta |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina inferior izquierda de la forma |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina inferior derecha de la forma |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro de la forma. |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro del borde inferior de la forma. |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro del borde superior de la forma |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina superior izquierda de la forma |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina superior derecha de la forma |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina inferior izquierda de la forma |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina inferior derecha de la forma |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | Especifica que el degradado de color de relleno de la forma está en modo rectangular desde el centro de la forma. |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina superior izquierda de la forma |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina superior derecha de la forma |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Especifica un degradado de color de relleno lineal.
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo de ruta
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina inferior izquierda de la forma
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina inferior derecha de la forma
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro de la forma.
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro del borde inferior de la forma.
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde el centro del borde superior de la forma
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina superior izquierda de la forma
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo radial desde la esquina superior derecha de la forma
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina inferior izquierda de la forma
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina inferior derecha de la forma
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo rectangular desde el centro de la forma.
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina superior izquierda de la forma
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+Especifica que el degradado de color de relleno de la forma está en modo rectangular desde la esquina superior derecha de la forma
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa todos los tipos de relleno de degradado.
+type: docs
+weight: 180
+url: /es/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+Representa todos los tipos de relleno de degradado.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [LINEAR](#LINEAR) | Linear |
+| [PATH](#PATH) | Path |
+| [RADIAL](#RADIAL) | Radial |
+| [RECTANGLE](#RECTANGLE) | Rectangle |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Path
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+Rectangle
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientstop/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el punto de parada del degradado.
+type: docs
+weight: 181
+url: /es/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+Representa el punto de parada del degradado.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Obtiene el color de esta parada de degradado. |
+| [getPosition()](#getPosition--) | La posición de la parada. |
+| [getTransparency()](#getTransparency--) | Devuelve o establece el grado de transparencia del área como un valor de 0.0 (opaco) a 1.0 (claro). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/gradientstop\#getColor--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Obtiene el color de esta parada de degradado.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+La posición de la parada.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Devuelve o establece el grado de transparencia del área como un valor de 0.0 (opaco) a 1.0 (claro).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la colección de puntos de parada del degradado.
+type: docs
+weight: 182
+url: /es/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+Representa la colección de puntos de parada del degradado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | Agregar una parada de degradado. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene la parada de degradado por el índice. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+Agregar una parada de degradado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | La posición de la parada,en unidad de porcentaje. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | El color de la parada. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+Obtiene la parada de degradado por el índice.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | El índice. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/spanish/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el estilo de sombreado del degradado.
+type: docs
+weight: 183
+url: /es/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+Representa el estilo de sombreado del degradado.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | Estilo de sombreado diagonal descendente |
+| [DIAGONAL_UP](#DIAGONAL-UP) | Estilo de sombreado diagonal ascendente |
+| [FROM_CENTER](#FROM-CENTER) | Estilo de sombreado desde el centro |
+| [FROM_CORNER](#FROM-CORNER) | Estilo de sombreado desde la esquina |
+| [HORIZONTAL](#HORIZONTAL) | Estilo de sombreado horizontal |
+| [UNKNOWN](#UNKNOWN) | Estilo de sombreado desconocido. Solo para el estilo de sombreado (que no corresponde a ningún miembro de GradientStyleType) en el archivo de plantilla. |
+| [VERTICAL](#VERTICAL) | Estilo de sombreado vertical |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+Estilo de sombreado diagonal descendente
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+Estilo de sombreado diagonal ascendente
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+Estilo de sombreado desde el centro
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+Estilo de sombreado desde la esquina
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Estilo de sombreado horizontal
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Estilo de sombreado desconocido. Solo para el estilo de sombreado (que no corresponde a ningún miembro de GradientStyleType) en el archivo de plantilla.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Estilo de sombreado vertical
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/griddensity/_index.md
+++ b/spanish/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de cuadrícula horizontal/vertical a usar para una página.
+type: docs
+weight: 184
+url: /es/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+Especifica el tipo de cuadrícula horizontal/vertical a usar para una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de cuadrícula horizontal/vertical a usar para una página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/griddensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de cuadrícula horizontal/vertical a usar para una página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/griddensity\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de cuadrícula horizontal/vertical a usar para una página.
+type: docs
+weight: 185
+url: /es/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+Especifica el tipo de cuadrícula horizontal/vertical a usar para una página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [COARSE](#COARSE) | Grueso. |
+| [FINE](#FINE) | Fino |
+| [FIXED](#FIXED) | Fijo. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grueso.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fino
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+Fijo.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal. Predeterminado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/group/_index.md
+++ b/spanish/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Grupo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan cómo agrega formas a un grupo, mueve miembros de un grupo y selecciona grupos.
+type: docs
+weight: 186
+url: /es/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDisplayMode()](#getDisplayMode--) | Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros. |
+| [getDontMoveChildren()](#getDontMoveChildren--) | Especifica si puede arrastrar formas en un grupo usando el ratón. |
+| [getSelectMode()](#getSelectMode--) | Especifica cómo el usuario selecciona una forma de grupo y sus miembros. |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | Especifica si el grupo permite que se añada una forma cuando la forma se suelta sobre el grupo. |
+| [isSnapTarget()](#isSnapTarget--) | Especifica si el ajuste a un grupo o a formas dentro del grupo está habilitado. |
+| [isTextEditTarget()](#isTextEditTarget--) | Especifica cómo asignar texto a un grupo. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/group\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+Cuando está contenido en un elemento Group, el elemento DisplayMode especifica cómo se muestra una forma de grupo y sus miembros.
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+Especifica si puede arrastrar formas en un grupo usando el ratón.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+Especifica si el grupo permite que se añada una forma cuando la forma se suelta sobre el grupo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+Especifica si el ajuste a un grupo o a formas dentro del grupo está habilitado.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+Especifica cómo asignar texto a un grupo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/group\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/headerfooter/_index.md
+++ b/spanish/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos para el encabezado y pie de página de un documento.
+type: docs
+weight: 188
+url: /es/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+Contiene elementos para el encabezado y pie de página de un documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | Contiene la cadena de texto que aparece en la parte central del pie de página de un documento. |
+| [getFooterLeft()](#getFooterLeft--) | Contiene la cadena de texto que aparece en la parte izquierda del pie de página de un documento. |
+| [getFooterMargin()](#getFooterMargin--) | Especifica el margen del pie de página de un documento. |
+| [getFooterRight()](#getFooterRight--) | Contiene la cadena de texto que aparece en la parte derecha del pie de página de un documento. |
+| [getHeaderCenter()](#getHeaderCenter--) | Contiene la cadena de texto que aparece en la parte central del encabezado de un documento. |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | El valor RGB del color del texto para el encabezado y pie de página. |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | Especifica la fuente utilizada para el texto del encabezado y pie de página. |
+| [getHeaderLeft()](#getHeaderLeft--) | Contiene la cadena de texto que aparece en la parte izquierda del encabezado de un documento. |
+| [getHeaderMargin()](#getHeaderMargin--) | Especifica el margen del pie de página de un documento. |
+| [getHeaderRight()](#getHeaderRight--) | Contiene la cadena de texto que aparece en la parte derecha del encabezado de un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--) |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--) |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | Para la descripción de esta propiedad, consulte [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--) |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--) |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | Para la descripción de esta propiedad, consulte [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--) |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | Para la descripción de esta propiedad, consulte [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--) |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | Para la descripción de esta propiedad, consulte [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--) |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | Para la descripción de esta propiedad, consulte [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--) |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | Para la descripción de esta propiedad, consulte [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+Contiene la cadena de texto que aparece en la parte central del pie de página de un documento.
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+Contiene la cadena de texto que aparece en la parte izquierda del pie de página de un documento.
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+Especifica el margen del pie de página de un documento.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+Contiene la cadena de texto que aparece en la parte derecha del pie de página de un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+Contiene la cadena de texto que aparece en la parte central del encabezado de un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+El valor RGB del color del texto para el encabezado y pie de página.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+Especifica la fuente utilizada para el texto del encabezado y pie de página.
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+Contiene la cadena de texto que aparece en la parte izquierda del encabezado de un documento.
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+Especifica el margen del pie de página de un documento.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+Contiene la cadena de texto que aparece en la parte derecha del encabezado de un documento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/spanish/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la fuente utilizada para el texto del encabezado y pie de página.
+type: docs
+weight: 189
+url: /es/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+Especifica la fuente utilizada para el texto del encabezado y pie de página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Especifica el conjunto de caracteres de la fuente. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Especifica la precisión de recorte de la fuente. |
+| [getEscapement()](#getEscapement--) | Especifica el atributo de escapamiento de la fuente. |
+| [getFaceName()](#getFaceName--) | Especifica el atributo del nombre de la tipografía de la fuente. |
+| [getHeight()](#getHeight--) | Especifica la altura de la fuente. |
+| [getItalic()](#getItalic--) | Especifica el peso de la fuente. |
+| [getOrientation()](#getOrientation--) | Especifica la orientación de la fuente. |
+| [getOutPrecision()](#getOutPrecision--) | Especifica el atributo de precisión de salida de la fuente. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Especifica el paso y la familia de la fuente. |
+| [getQuality()](#getQuality--) | Especifica la calidad de salida de la fuente. |
+| [getStrikeOut()](#getStrikeOut--) | Especifica si la fuente tiene tachado. |
+| [getUnderline()](#getUnderline--) | Especifica si la fuente está subrayada. |
+| [getWeight()](#getWeight--) | Especifica el peso de la fuente. |
+| [getWidth()](#getWidth--) | Especifica el ancho de la fuente. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | Para la descripción de esta propiedad, consulte [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | Para la descripción de esta propiedad, consulte [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) |
+| [setOrientation(int value)](#setOrientation-int-) | Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} |
+| [setQuality(long value)](#setQuality-long-) | Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | Para la descripción de esta propiedad, consulte [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) |
+| [setUnderline(int value)](#setUnderline-int-) | Para la descripción de esta propiedad, consulte [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) |
+| [setWeight(int value)](#setWeight-int-) | Para la descripción de esta propiedad, consulte [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) |
+| [setWidth(int value)](#setWidth-int-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+Especifica el conjunto de caracteres de la fuente. Equivalente al campo GDI LOGFONT lfCharSet.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+Especifica la precisión de recorte de la fuente. Equivalente al campo GDI LOGFONT lfClipPrecision.
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+Especifica el atributo de escapamiento de la fuente. Equivalente al campo GDI LOGFONT lfEscapement.
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+Especifica el atributo del nombre de la tipografía. Equivalente al campo GDI LOGFONT lfFaceName.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+Especifica la altura de la fuente. Equivalente al campo GDI LOGFONT lfHeight.
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+Especifica el peso de la fuente. Equivalente al campo GDI LOGFONT lfWeight.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+Especifica la orientación de la fuente. Equivalente al campo GDI LOGFONT lfOrientation.
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+Especifica el atributo de precisión de salida de la fuente. Equivalente al campo GDI LOGFONT lfOutPrecision.
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+Especifica el paso y la familia de la fuente. Equivalente al campo GDI LOGFONT lfPitchAndFamily.
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+Especifica la calidad de salida de la fuente. Equivalente al campo GDI LOGFONT lfQuality.
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+Especifica si la fuente tiene tachado. Equivalente al campo GDI LOGFONT lfStrikeOut.
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+Especifica si la fuente está subrayada. Equivalente al campo GDI LOGFONT lfUnderline.
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+Especifica el peso de la fuente. Equivalente al campo GDI LOGFONT lfWeight.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+Especifica el ancho de la fuente. Equivalente al campo GDI LOGFONT lfWidth.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/help/_index.md
+++ b/spanish/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: Ayuda
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican el tema del archivo de ayuda de los elementos Shape y la información de derechos de autor.
+type: docs
+weight: 190
+url: /es/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | Contiene una cadena que representa una declaración de derechos de autor legible por humanos. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getHelpTopic()](#getHelpTopic--) | Especifica el ID del tema de ayuda del elemento Shape. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/help\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+Contiene una cadena que representa una declaración de derechos de autor legible por humanos.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Especifica el ID del tema de ayuda del elemento Shape.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/help\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/horzalign/_index.md
+++ b/spanish/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación horizontal del texto en el bloque de texto de las formas.
+type: docs
+weight: 191
+url: /es/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+Especifica la alineación horizontal del texto en el bloque de texto de la forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la alineación horizontal del texto en el bloque de texto de la forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/horzalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la alineación horizontal del texto en el bloque de texto de la forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/horzalign\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación horizontal del texto en el bloque de texto de las formas.
+type: docs
+weight: 192
+url: /es/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+Especifica la alineación horizontal del texto en el bloque de texto de la forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CENTER](#CENTER) | Centro. |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | Justificar forzado. |
+| [JUSTIFY](#JUSTIFY) | Justificar. |
+| [LEFT_ALIGN](#LEFT-ALIGN) | Alinear a la izquierda. |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | Alinear a la derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro.
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+Justificar forzado.
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+Justificar.
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+Alinear a la izquierda.
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+Alinear a la derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagramas a HTML.
+type: docs
+weight: 187
+url: /es/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagramas a HTML.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Define si es necesario exportar la página oculta o no. |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar en HTML. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la primera página a renderizar. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getResolution()](#getResolution--) | la resolución para el HTML generado, en puntos por pulgada. |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | Indica si se guarda el HTML como un solo archivo. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si todas las páginas se guardarán en una imagen o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getSaveTitle()](#getSaveTitle--) | Define si es necesario exportar el título o no. |
+| [getSaveToolBar()](#getSaveToolBar--) | Especifica si se guarda la barra de herramientas. El valor predeterminado es true. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getStreamProvider()](#getStreamProvider--) | el IStreamProvider para exportar objetos. |
+| [getTitle()](#getTitle--) | el título del diagrama a renderizar en HTML. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setResolution(int value)](#setResolution-int-) | Para la descripción de esta propiedad, consulte [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--) |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | Para la descripción de esta propiedad, consulte [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--) |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | Para la descripción de esta propiedad, consulte [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--) |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | Para la descripción de esta propiedad, consulte [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Para la descripción de esta propiedad, consulte [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Define si es necesario exportar la página oculta o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar en HTML. El valor predeterminado es MaxValue, lo que significa que se renderizarán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la primera página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+la resolución para el html generado, en puntos por pulgada. Esta propiedad tiene efecto solo al guardar en html. El valor predeterminado es 96.
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+Indica si se guarda el html como un solo archivo. El valor predeterminado es false. Si hay varias páginas, esas páginas y otros recursos deben guardarse en archivos separados. En algunos escenarios, el usuario puede necesitar obtener solo un archivo resultante, por conveniencia de la transferencia. Si es así, el usuario puede establecer esta propiedad como true.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si todas las páginas se guardarán en la imagen o solo el primer plano. Si es true, se renderizan solo las páginas de primer plano (con fondo si está presente). Si es false, se renderizan las páginas de primer plano (con fondo si está presente) y luego esas páginas de fondo vacías. Solo puede devolver true cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. Solo puede ser Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+Define si es necesario exportar el título o no. El valor predeterminado es true.
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+Especifica si se guarda la barra de herramientas. El valor predeterminado es true.
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+el IStreamProvider para exportar objetos.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+el título del diagrama a renderizar en HTML. Si Title es nulo, se utilizará Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties) como Título. Si Diagram.DocumentProperties.Title es nulo o está vacío, se usará el nombre de archivo del Diagrama como Título.
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/hyperlink/_index.md
+++ b/spanish/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hipervínculo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos para crear múltiples saltos entre una forma o página de dibujo y otra página de dibujo, otro archivo o un sitio web.
+type: docs
+weight: 193
+url: /es/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+Contiene elementos para crear múltiples saltos entre una forma o página de dibujo y otra página de dibujo, otro archivo o un sitio web.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | Especifica una dirección URL, un nombre de archivo DOS o una ruta UNC a la que saltar. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Especifica el hipervínculo predeterminado para una forma o página. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDescription()](#getDescription--) | El elemento Description contiene una cadena de texto que describe el hipervínculo. |
+| [getExtraInfo()](#getExtraInfo--) | Contiene información que se utilizará para resolver una URL, como las coordenadas de un mapa de imagen. |
+| [getFrame()](#getFrame--) | Contiene el nombre de un marco al que dirigirse cuando Microsoft Visio está abierto como documento activo en una aplicación contenedora. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getInvisible()](#getInvisible--) | El elemento Invisible indica si un hipervínculo aparece en el menú contextual de una forma o página. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getNewWindow()](#getNewWindow--) | Especifica si Microsoft Visio abre una ventana en una nueva ubicación cuando sigue un hipervínculo para abrir una página web u otro documento de Visio. |
+| [getSortKey()](#getSortKey--) | El elemento Invisible indica si un hipervínculo aparece en el menú contextual de una forma o página. |
+| [getSubAddress()](#getSubAddress--) | Especifica una ubicación dentro del documento de destino a la que enlazar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/hyperlink\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/hyperlink\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/hyperlink\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+Especifica una dirección URL, un nombre de archivo DOS o una ruta UNC a la que saltar.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+Especifica el hipervínculo predeterminado para una forma o página.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+El elemento Description contiene una cadena de texto que describe el hipervínculo.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+Contiene información que se utilizará para resolver una URL, como las coordenadas de un mapa de imagen. Por ejemplo, x=41 y=7 especificaría las coordenadas de un mapa de imagen.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Contiene el nombre de un marco al que dirigirse cuando Microsoft Visio está abierto como documento activo en una aplicación contenedora. El valor predeterminado es una cadena vacía.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+El elemento Invisible indica si un hipervínculo aparece en el menú contextual de una forma o página.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+Especifica si Microsoft Visio abre una ventana en una nueva ubicación cuando sigue un hipervínculo para abrir una página web u otro documento de Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+El elemento Invisible indica si un hipervínculo aparece en el menú contextual de una forma o página.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+Especifica una ubicación dentro del documento de destino a la que enlazar.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/hyperlink\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/hyperlink\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de hipervínculos.
+type: docs
+weight: 194
+url: /es/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+Colección de hipervínculos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | Agregue el objeto Hyperlink a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | Elimine el objeto Hyperlink de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+Agregue el objeto Hyperlink a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+Elimine el objeto Hyperlink de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Entero opcional.
+type: docs
+weight: 195
+url: /es/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+Entero opcional. El tamaño del ícono del elemento.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double. |
+| [NORMAL](#NORMAL) | Normal. |
+| [TALL](#TALL) | Alto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [WIDE](#WIDE) | Ancho. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+Alto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+Ancho.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/image/_index.md
+++ b/spanish/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: Imagen
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits.
+type: docs
+weight: 196
+url: /es/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | Desenfoca o suaviza una imagen de mapa de bits. |
+| [getBrightness()](#getBrightness--) | Ajusta el brillo de una imagen de mapa de bits. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | Especifica el contraste de una imagen de mapa de bits. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDenoise()](#getDenoise--) | Elimina el ruido (píxeles que tienen niveles de color distribuidos aleatoriamente) de una imagen de mapa de bits. |
+| [getGamma()](#getGamma--) | Ajusta o corrige la intensidad de una imagen para un dispositivo de salida particular, como un monitor o escáner. |
+| [getSharpen()](#getSharpen--) | Especifica la cantidad de nitidez a aplicar a una imagen de mapa de bits. |
+| [getTransparency()](#getTransparency--) | Especifica el nivel de transparencia para un color de capa, de 0 (opaco) a 1 (completamente transparente). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, por favor vea [getDel()](../../com.aspose.diagram/image\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+Desenfoca o suaviza una imagen de mapa de bits. El elemento Blur contiene un valor entre 0 y 1; el valor predeterminado es 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+Ajusta el brillo de una imagen de mapa de bits. El elemento Brightness contiene un valor entre 0 y 1; el valor predeterminado es 0.5.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+Especifica el contraste de una imagen de mapa de bits. El elemento Contrast contiene un valor entre 0 y 1.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+Elimina el ruido (píxeles que tienen niveles de color distribuidos aleatoriamente) de una imagen de mapa de bits.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+Ajusta o corrige la intensidad de una imagen para un dispositivo de salida particular, como un monitor o escáner. El valor predeterminado es 1 (sin corrección.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+Especifica la cantidad de nitidez a aplicar a una imagen de mapa de bits. Enfocar una imagen aumenta el contraste de los píxeles adyacentes.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Especifica el nivel de transparencia para un color de capa, de 0 (opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getDel()](../../com.aspose.diagram/image\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control de imagen.
+type: docs
+weight: 197
+url: /es/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+Representa el control de imagen.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | el color OLE del fondo. |
+| [getBorderStyle()](#getBorderStyle--) | el tipo de borde utilizado por el control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPictureAlignment()](#getPictureAlignment--) | la alineación de la imagen dentro del Form o Image. |
+| [getPictureSizeMode()](#getPictureSizeMode--) | cómo mostrar la imagen. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTiled()](#isTiled--) | Indica si la imagen está en mosaico en el fondo. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--) |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | Para la descripción de esta propiedad, consulte [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | Para la descripción de esta propiedad, consulte [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) |
+| [setTiled(boolean value)](#setTiled-boolean-) | Para la descripción de esta propiedad, consulte [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+el tipo de borde utilizado por el control.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+la alineación de la imagen dentro del Form o Image.
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+cómo mostrar la imagen.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+Indica si la imagen está en mosaico en el fondo.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/spanish/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el modo de color para las imágenes generadas de las páginas del documento.
+type: docs
+weight: 198
+url: /es/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+Especifica el modo de color para las imágenes generadas de las páginas del documento.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | Las páginas del documento se renderizarán como imágenes en blanco y negro. |
+| [GRAYSCALE](#GRAYSCALE) | Las páginas del documento se renderizarán como imágenes en escala de grises. |
+| [NONE](#NONE) | Las páginas del documento se renderizarán como imágenes en color. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+Las páginas del documento se renderizarán como imágenes en blanco y negro.
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+Las páginas del documento se renderizarán como imágenes en escala de grises.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Las páginas del documento se renderizarán como imágenes en color.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/imageformat/_index.md
+++ b/spanish/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el formato de archivo de la imagen.
+type: docs
+weight: 199
+url: /es/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+Especifica el formato de archivo de la imagen.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Devuelve un valor que indica si el objeto especificado es un objeto ImageFormat que es equivalente a este objeto ImageFormat. |
+| [getBmp()](#getBmp--) | Obtiene el formato de imagen bitmap (BMP). |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | Obtiene el formato de imagen de metarchivo mejorado (EMF). |
+| [getExif()](#getExif--) | Obtiene el formato Exchangeable Image File (Exif). |
+| [getGif()](#getGif--) | Obtiene el formato de imagen Graphics Interchange Format (GIF). |
+| [getIcon()](#getIcon--) | Obtiene el formato de imagen de icono de Windows. |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | Obtiene el formato de imagen según el nombre del sufijo |
+| [getJpeg()](#getJpeg--) | Obtiene el formato de imagen Joint Photographic Experts Group (JPEG). |
+| [getMemoryBmp()](#getMemoryBmp--) | Obtiene un formato de imagen bitmap en memoria. |
+| [getName()](#getName--) | Obtiene el nombre de cadena de esta instancia ImageFormat |
+| [getPng()](#getPng--) | Obtiene el formato de imagen W3C Portable Network Graphics (PNG). |
+| [getTiff()](#getTiff--) | Obtiene el formato de imagen Tagged Image File Format (TIFF). |
+| [getWmf()](#getWmf--) | Obtiene el formato de imagen Windows metafile (WMF). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Devuelve un valor que indica si el objeto especificado es un objeto ImageFormat que es equivalente a este objeto ImageFormat.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object | El objeto a probar. |
+
+**Returns:**
+boolean - true si o es un objeto ImageFormat que es equivalente a este objeto ImageFormat; de lo contrario, false.
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+Obtiene el formato de imagen bitmap (BMP).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+Obtiene el formato de imagen de metarchivo mejorado (EMF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+Obtiene el formato Exchangeable Image File (Exif).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+Obtiene el formato de imagen Graphics Interchange Format (GIF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Obtiene el formato de imagen de icono de Windows.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+Obtiene el formato de imagen según el nombre del sufijo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | nombre del sufijo |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Obtiene el formato de imagen Joint Photographic Experts Group (JPEG).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+Obtiene un formato de imagen bitmap en memoria.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Obtiene el nombre de cadena de esta instancia ImageFormat
+
+**Returns:**
+java.lang.String - El nombre de cadena de esta instancia ImageFormat
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+Obtiene el formato de imagen W3C Portable Network Graphics (PNG).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+Obtiene el formato de imagen Tagged Image File Format (TIFF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Obtiene el formato de imagen Windows metafile (WMF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagramas a imágenes.
+type: docs
+weight: 200
+url: /es/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagramas a imágenes.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | Inicializa una nueva instancia de esta clase que puede usarse para guardar imágenes renderizadas en los formatos Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | Especifica el nivel de calidad a usar durante la composición. |
+| [getContentZoom()](#getContentZoom--) | Este parámetro es similar a la escala, pero no afecta el tamaño de la imagen generada. |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Define si es necesario exportar la página oculta o no. |
+| [getImageBrightness()](#getImageBrightness--) | el brillo de las imágenes generadas. |
+| [getImageColorMode()](#getImageColorMode--) | el modo de color de las imágenes generadas. |
+| [getImageContrast()](#getImageContrast--) | el contraste de las imágenes generadas. |
+| [getInterpolationMode()](#getInterpolationMode--) | Especifica el algoritmo que se utiliza cuando las imágenes se escalan o rotan. |
+| [getJpegQuality()](#getJpegQuality--) | un valor que determina la calidad de las imágenes JPEG generadas. |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar al guardar en un archivo TIFF multipágina. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la primera página a renderizar. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | un valor que especifica cómo se desplazan los píxeles durante el renderizado. |
+| [getResolution()](#getResolution--) | la resolución de las imágenes generadas, en puntos por pulgada. |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | Especifica si el área de guardado es la misma que el PDF. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si todas las páginas se guardarán en una imagen o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getScale()](#getScale--) | el factor de zoom para las imágenes generadas. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getSmoothingMode()](#getSmoothingMode--) | Especifica si el suavizado (antialiasing) se aplica a líneas y curvas y a los bordes de áreas rellenas. |
+| [getTiffCompression()](#getTiffCompression--) | el tipo de compresión a aplicar al guardar imágenes generadas en formato TIFF. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | Para la descripción de esta propiedad, consulte [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) |
+| [setContentZoom(float value)](#setContentZoom-float-) | Para la descripción de esta propiedad, consulte [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | Para la descripción de esta propiedad, consulte [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | Para la descripción de esta propiedad, consulte [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) |
+| [setImageContrast(float value)](#setImageContrast-float-) | Para la descripción de esta propiedad, consulte [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | Para la descripción de esta propiedad, consulte [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Para la descripción de esta propiedad, consulte [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | Para la descripción de esta propiedad, consulte [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) |
+| [setResolution(float value)](#setResolution-float-) | Para la descripción de esta propiedad, consulte [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | Para la descripción de esta propiedad, consulte [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) |
+| [setScale(float value)](#setScale-float-) | Para la descripción de esta propiedad, consulte [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | Para la descripción de esta propiedad, consulte [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | Para la descripción de esta propiedad, consulte [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar imágenes renderizadas en los formatos Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | Puede ser Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat. |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+Especifica el nivel de calidad a usar durante la composición. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es Aspose.Diagram.Saving.CompositingQuality.
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+Este parámetro es similar a la escala, pero no afecta el tamaño de la imagen generada. El valor predeterminado es 1.0. El valor debe ser mayor que 0.
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Define si es necesario exportar la página oculta o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+el brillo de las imágenes generadas. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es 0.5. El valor debe estar en el rango entre 0 y 1.
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+el modo de color de las imágenes generadas. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es Aspose.Diagram.Saving.ImageColorMode.
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+el contraste de las imágenes generadas. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es 0.5. El valor debe estar en el rango entre 0 y 1.
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+Especifica el algoritmo que se utiliza cuando las imágenes se escalan o rotan. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es Aspose.Diagram.Saving.InterpolationMode.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+un valor que determina la calidad de las imágenes JPEG generadas. Tiene efecto solo al guardar en JPEG. Utilice esta propiedad para obtener o establecer la calidad de las imágenes generadas al guardar en formato JPEG. El valor puede variar de 0 a 100 donde 0 significa la peor calidad pero máxima compresión y 100 significa la mejor calidad pero mínima compresión. El valor predeterminado es 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar al guardar en un archivo TIFF multipágina. El valor predeterminado es MaxValue, lo que significa que se renderizarán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la primera página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+un valor que especifica cómo se desplazan los píxeles durante el renderizado. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es Aspose.Diagram.Saving.PixelOffsetMode.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+la resolución de las imágenes generadas, en puntos por pulgada. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es 96.
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+Especifica si el área de guardado es la misma que el PDF. Si es verdadero, el área renderizada es la misma que el PDF. Si es falso, el área renderizada es la predeterminada. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si todas las páginas se guardarán en la imagen o solo el primer plano. Si es true, se renderizan solo las páginas de primer plano (con fondo si está presente). Si es false, se renderizan las páginas de primer plano (con fondo si está presente) y luego esas páginas de fondo vacías. Solo puede devolver true cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. Puede ser Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat o Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+el factor de zoom de las imágenes generadas. El valor predeterminado es 1.0. El valor debe ser mayor que 0.
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+Especifica si se aplica suavizado (antialiasing) a líneas y curvas y a los bordes de áreas rellenas. Esta propiedad tiene efecto solo al guardar en formatos de imagen raster. El valor predeterminado es Aspose.Diagram.Saving.SmoothingMode.
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+el tipo de compresión a aplicar al guardar imágenes generadas en formato TIFF. Tiene efecto solo al guardar en TIFF. El valor predeterminado es Aspose.Diagram.Saving.TiffCompression.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/spanish/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Configuraciones de fuente para cada objeto.
+type: docs
+weight: 201
+url: /es/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+Configuraciones de fuente para cada objeto [Diagram](../../com.aspose.diagram/diagram).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | Ctor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | Obtiene una copia del arreglo que contiene la lista de fuentes |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Establece la carpeta de fuentes |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Establece las carpetas de fuentes |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Establece los orígenes de fuentes. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+Ctor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+Obtiene una copia del arreglo que contiene la lista de fuentes
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Establece la carpeta de fuentes
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontFolder | java.lang.String | La carpeta que contiene fuentes TrueType. |
+| recursivo | boolean | Determina si se deben o no escanear subcarpetas. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Establece las carpetas de fuentes
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Las carpetas que contienen fuentes TrueType. |
+| recursivo | boolean | Determina si se deben o no escanear subcarpetas. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+Establece los orígenes de fuentes.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | Una matriz de fuentes que contienen fuentes TrueType. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/infiniteline/_index.md
+++ b/spanish/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican las coordenadas x e y de dos puntos en una línea infinita.
+type: docs
+weight: 202
+url: /es/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+Contiene elementos que especifican las coordenadas x e y de dos puntos en una línea infinita. Los elementos X y Y especifican las coordenadas x e y del primer punto, y los elementos A y B especifican las coordenadas x e y del segundo punto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | Crea una instancia de la clase [InfiniteLine](../../com.aspose.diagram/infiniteline). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Una coordenada x de un punto en la línea infinita emparejada con la coordenada y representada por el elemento B. |
+| [getB()](#getB--) | Una coordenada y de un punto en una línea infinita emparejada con una coordenada x representada por el elemento A. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | Una coordenada x de un punto en la línea infinita. |
+| [getY()](#getY--) | Una coordenada y de un punto en la línea infinita. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/infiniteline\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/infiniteline\#getB--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/infiniteline\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/infiniteline\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/infiniteline\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/infiniteline\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+Crea una instancia de la clase [InfiniteLine](../../com.aspose.diagram/infiniteline).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Una coordenada x de un punto en la línea infinita emparejada con la coordenada y representada por el elemento B.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Una coordenada y de un punto en una línea infinita emparejada con una coordenada x representada por el elemento A.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Una coordenada x de un punto en la línea infinita.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Una coordenada y de un punto en la línea infinita.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/infiniteline\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/infiniteline\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/infiniteline\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/infiniteline\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección InfiniteLine.
+type: docs
+weight: 203
+url: /es/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+Colección InfiniteLine.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/spanish/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el modo de ejecución predeterminado del Editor de Métodos de Entrada.
+type: docs
+weight: 204
+url: /es/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+Representa el modo de ejecución predeterminado del Editor de Métodos de Entrada.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALPHA](#ALPHA) | IME activado con modo alfanumérico de media anchura. |
+| [ALPHA_FULL](#ALPHA-FULL) | IME activado con modo alfanumérico de anchura completa. |
+| [DISABLE](#DISABLE) | IME desactivado. El usuario no puede activar IME mediante el teclado. |
+| [HANGUL](#HANGUL) | IME activado con modo hangul de media anchura. |
+| [HANGUL_FULL](#HANGUL-FULL) | IME activado con modo hangul de anchura completa. |
+| [HANZI](#HANZI) | IME activado con modo hanzi de media anchura. |
+| [HANZI_FULL](#HANZI-FULL) | IME activado con modo hanzi de anchura completa. |
+| [HIRAGANA](#HIRAGANA) | IME activado con modo hiragana de anchura completa. |
+| [KATAKANA](#KATAKANA) | IME activado con modo katakana de anchura completa. |
+| [KATAKANA_HALF](#KATAKANA-HALF) | IME activado con modo katakana de media anchura. |
+| [NO_CONTROL](#NO-CONTROL) | No controla IME. |
+| [OFF](#OFF) | IME desactivado. |
+| [ON](#ON) | IME activado. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+IME activado con modo alfanumérico de media anchura.
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+IME activado con modo alfanumérico de anchura completa.
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IME desactivado. El usuario no puede activar IME mediante el teclado.
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+IME activado con modo hangul de media anchura.
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+IME activado con modo hangul de anchura completa.
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+IME activado con modo hanzi de media anchura.
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+IME activado con modo hanzi de anchura completa.
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+IME activado con modo hiragana de anchura completa.
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+IME activado con modo katakana de anchura completa.
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+IME activado con modo katakana de media anchura.
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+No controla IME.
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IME desactivado. Modo inglés.
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IME activado.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/spanish/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: La enumeración InterpolationMode especifica el algoritmo que se utiliza cuando las imágenes se escalan o rotan.
+type: docs
+weight: 206
+url: /es/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+La enumeración InterpolationMode especifica el algoritmo que se utiliza cuando las imágenes se escalan o rotan.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | Especifica interpolación bicúbica. |
+| [BILINEAR](#BILINEAR) | Especifica interpolación bilineal. |
+| [DEFAULT](#DEFAULT) | Especifica el modo predeterminado. |
+| [HIGH](#HIGH) | Especifica interpolación de alta calidad. |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | Especifica interpolación bicúbica de alta calidad. |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | Especifica interpolación bilineal de alta calidad. |
+| [INVALID](#INVALID) | Equivalente al elemento Invalid de la enumeración QualityMode. |
+| [LOW](#LOW) | Especifica interpolación de baja calidad. |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | Especifica interpolación del vecino más cercano. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+Especifica interpolación bicúbica. No se realiza prefiltrado. Este modo no es adecuado para reducir una imagen por debajo del 25 % de su tamaño original.
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+Especifica interpolación bilineal. No se realiza prefiltrado. Este modo no es adecuado para reducir una imagen por debajo del 50 % de su tamaño original.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Especifica el modo predeterminado.
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+Especifica interpolación de alta calidad.
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+Especifica interpolación bicúbica de alta calidad. Se realiza prefiltrado para garantizar una reducción de alta calidad. Este modo produce las imágenes transformadas de mayor calidad.
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+Especifica interpolación bilineal de alta calidad. Se realiza prefiltrado para garantizar una reducción de alta calidad.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Equivalente al elemento Invalid de la enumeración QualityMode.
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+Especifica interpolación de baja calidad.
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+Especifica interpolación del vecino más cercano.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/spanish/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa todos los operadores sobre la interrupción.
+type: docs
+weight: 207
+url: /es/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+Representa todos los operadores sobre la interrupción.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | Interrumpir el operador actual. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Marcar el monitor como solicitando interrupción |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+Interrumpir el operador actual.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+Marcar el monitor como solicitando interrupción
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/intvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor entero
+type: docs
+weight: 205
+url: /es/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+Valor entero
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor entero. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/intvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+| unidad | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Valor entero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/intvalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/spanish/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Controlar/Indicar el progreso del proceso de guardado de la página.
+type: docs
+weight: 456
+url: /es/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Controlar/Indicar el progreso del proceso de guardado de la página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Control/Indicar que una página finaliza para ser salida. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Control/Indicar que una página comienza para ser salida. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Control/Indicar que una página finaliza para ser salida.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | Información para una página finaliza el proceso de guardado. |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Control/Indicar que una página comienza para ser salida.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | Información para una página inicia el proceso de guardado. |
+

--- a/spanish/java/com.aspose.diagram/issue/_index.md
+++ b/spanish/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un único problema de validación en el documento.
+type: docs
+weight: 208
+url: /es/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+Representa un único problema de validación en el documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Issue()](#Issue--) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Especifica el identificador único del problema de validación. |
+| [getIgnored()](#getIgnored--) | Especifica si el problema de validación está actualmente ignorado. |
+| [getIssueTarget()](#getIssueTarget--) | Según el objetivo del problema de validación principal, especifica ya sea la página, o tanto la página como la forma, con la que está asociado el problema de validación principal. |
+| [getRuleInfo()](#getRuleInfo--) | Especifica información sobre la regla de validación a la que se refiere el problema de validación principal. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/issue\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Para la descripción de esta propiedad, consulte [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+Constructor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Especifica el identificador único del problema de validación.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Especifica si el problema de validación está actualmente ignorado. El valor predeterminado es False.
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+Dependiendo del objetivo del problema de validación principal, especifica ya sea la página o tanto la página como la forma con la que está asociado el problema de validación principal. Si el objetivo del problema de validación principal es un documento, IssueTarget no especifica ni una página ni una forma.
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+Especifica información sobre la regla de validación a la que se refiere el problema de validación principal.
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/issue\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/issuecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de problemas.
+type: docs
+weight: 209
+url: /es/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Colección de problemas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | Agregar la incidencia a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | Eliminar la incidencia de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+Agregar la incidencia a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+Eliminar la incidencia de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/issuetarget/_index.md
+++ b/spanish/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Dependiendo del objetivo del problema de validación principal, especifica ya sea la página o tanto la página como la forma con la que está asociado el problema de validación principal.
+type: docs
+weight: 210
+url: /es/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+Dependiendo del objetivo del problema de validación principal, especifica ya sea la página o tanto la página como la forma con la que está asociado el problema de validación principal. Si el objetivo del problema de validación principal es un documento, IssueTarget no especifica ni una página ni una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | Especifica el identificador único de la página que está asociada con el problema de validación principal. |
+| [getShapeId()](#getShapeId--) | Especifica el identificador único de la forma que está asociada con el problema de validación principal. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | Para la descripción de esta propiedad, consulte [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--) |
+| [setShapeId(long value)](#setShapeId-long-) | Para la descripción de esta propiedad, consulte [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+Especifica el identificador único de la página que está asociada con el problema de validación principal. Si el objetivo es el documento, el valor de PageID puede ser 0xFFFFFFFF.
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+Especifica el identificador único de la forma que está asociada con el problema de validación principal. Si el objetivo es el documento o una página, el valor de ShapeID puede ser 0xFFFFFFFF.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/spanish/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el proveedor de flujo exportado.
+type: docs
+weight: 457
+url: /es/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+Representa el proveedor de flujo exportado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | Cierra el flujo. |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | Obtiene el flujo. |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+Cierra el flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+Obtiene el flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/spanish/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/spanish/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Interfaz de devolución de llamada de advertencia.
+type: docs
+weight: 458
+url: /es/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+Interfaz de devolución de llamada de advertencia.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | Nuestro callback solo necesita implementar el método "Warning". |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+Nuestro callback solo necesita implementar el método "Warning".
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | información de advertencia |
+

--- a/spanish/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control ActiveX de etiqueta.
+type: docs
+weight: 211
+url: /es/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+Representa el control ActiveX de etiqueta.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | la tecla de acceso rápido para el control. |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | el color OLE del fondo. |
+| [getBorderStyle()](#getBorderStyle--) | el tipo de borde utilizado por el control. |
+| [getCaption()](#getCaption--) | el texto descriptivo que aparece en un control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPicturePosition()](#getPicturePosition--) | la ubicación de la imagen del control relativa a su leyenda. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica si el contenido del control se ajusta automáticamente al final de una línea. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+la tecla de acceso rápido para el control.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+el tipo de borde utilizado por el control.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+el texto descriptivo que aparece en un control.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la ubicación de la imagen del control relativa a su leyenda.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica si el contenido del control se ajusta automáticamente al final de una línea.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layer/_index.md
+++ b/spanish/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Layer
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que definen una única capa y sus propiedades para una página.
+type: docs
+weight: 212
+url: /es/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+Contiene elementos que definen una única capa y sus propiedades para una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Layer()](#Layer--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | Especifica si una capa está activa. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | El índice del color en la tabla de colores utilizado para mostrar la capa o un valor RGB que especifica un color personalizado que no está en la tabla de colores (por ejemplo, \#ff9900). |
+| [getColorTrans()](#getColorTrans--) | Determina el grado de transparencia del color del texto de una capa o forma, de 0 (completamente opaco) a 1 (completamente transparente). |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getGlue()](#getGlue--) | Especifica si las formas pertenecientes a la capa pueden ser pegadas. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getLock()](#getLock--) | Especifica si las formas pertenecientes a la capa están bloqueadas para ser seleccionadas o editadas. |
+| [getName()](#getName--) | El elemento Name especifica el nombre de una capa. |
+| [getNameUniv()](#getNameUniv--) | Especifica el nombre universal de una capa. |
+| [getPrint()](#getPrint--) | Especifica si las formas pertenecientes a la capa se imprimen cuando se imprime el dibujo. |
+| [getSnap()](#getSnap--) | Especifica si otras formas pueden ajustarse a las formas asignadas a la capa. |
+| [getStatus()](#getStatus--) | Especifica si la capa es una capa válida para un documento. |
+| [getVisible()](#getVisible--) | Especifica si las formas pertenecientes a la capa son visibles en la página del dibujo. |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | Una bandera que indica si el elemento ha sido verificado localmente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | Para la descripción de esta propiedad, consulte [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/layer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+Especifica si una capa está activa. Las formas que no están preasignadas a capas se asignan a la(s) capa(s) activa(s) cuando se sueltan en la página del dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+El índice del color en la tabla de colores utilizado para mostrar la capa o un valor RGB que especifica un color personalizado que no está en la tabla de colores (por ejemplo, \#ff9900).
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Determina el grado de transparencia del color del texto de una capa o forma, de 0 (completamente opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+Especifica si las formas pertenecientes a la capa pueden ser pegadas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+Especifica si las formas pertenecientes a la capa están bloqueadas para ser seleccionadas o editadas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+El elemento Name especifica el nombre de una capa.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+Especifica el nombre universal de una capa.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+Especifica si las formas pertenecientes a la capa se imprimen cuando se imprime el dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+Especifica si otras formas pueden ajustarse a las formas asignadas a la capa. Las formas asignadas a la capa pueden ajustarse a otras formas, pero otras formas no pueden ajustarse a ellas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+Especifica si la capa es una capa válida para un documento.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+Especifica si las formas pertenecientes a la capa son visibles en la página del dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+Una bandera que indica si el elemento ha sido verificado localmente. Un valor de 1 indica que el elemento fue verificado localmente.
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layer\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/layer\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layercollection/_index.md
+++ b/spanish/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de capas.
+type: docs
+weight: 213
+url: /es/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Colección de capas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | Agregue el objeto Layer a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | Elimine el objeto Layer de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+Agregue el objeto Layer a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+Elimine el objeto Layer de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layermem/_index.md
+++ b/spanish/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene el elemento LayerMember que especifica cada capa a la que se asigna la forma.
+type: docs
+weight: 214
+url: /es/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+Contiene el elemento LayerMember, que especifica cada capa a la que se asigna la forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getLayerMember()](#getLayerMember--) | Especifica la capa o capas a la que se asigna la forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layermem\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+Especifica la capa o capas a la que se asigna la forma. La asignación de capa se especifica en función del índice basado en cero de las capas para la página. Si una forma se asigna a más de una capa, cada índice de capa aparece separado por un punto y coma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layermem\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layout/_index.md
+++ b/spanish/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: Diseño
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores.
+type: docs
+weight: 215
+url: /es/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | Determina cuándo se redirige un conector. |
+| [getConLineJumpCode()](#getConLineJumpCode--) | Determina si un conector salta cuando dos conectores se cruzan, |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico. |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico. |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | Determina el estilo de salto de línea para saltos de línea en un conector dinámico. |
+| [getConLineRouteExt()](#getConLineRouteExt--) | Determina la apariencia de un conector. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDisplayLevel()](#getDisplayLevel--) | Determina la banda de nivel de visualización (el rango relativo de agrupación por orden Z) para la forma. |
+| [getRelationships()](#getRelationships--) | Almacena las relaciones entre contenedores, listas, anotaciones y formas. |
+| [getShapeFixedCode()](#getShapeFixedCode--) | Especifica el comportamiento de colocación para una forma colocable. |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | Especifica si las formas colocables pueden situarse encima de una forma cuando el usuario selecciona Organizar Formas (menú Formas). |
+| [getShapePermeableX()](#getShapePermeableX--) | Especifica si un conector puede enrutar horizontalmente a través de una forma. |
+| [getShapePermeableY()](#getShapePermeableY--) | Especifica si un conector puede enrutar verticalmente a través de una forma. |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes). |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | Determina el estilo de colocación para los hijos. |
+| [getShapePlowCode()](#getShapePlowCode--) | Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo. |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo. |
+| [getShapeSplit()](#getShapeSplit--) | Determina si esta forma puede dividir formas que son divisibles. |
+| [getShapeSplittable()](#getShapeSplittable--) | Determina si esta forma 1-D puede dividirse. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layout\#getDel--) |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | Para la descripción de esta propiedad, consulte [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+Determina cuándo se redirige un conector.
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+Determina si un conector salta cuando dos conectores se cruzan,
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento horizontal de un conector dinámico.
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+Determina la dirección del salto de línea para saltos de línea que ocurren en un segmento vertical de un conector dinámico.
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+Determina el estilo de salto de línea para saltos de línea en un conector dinámico.
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+Determina la apariencia de un conector.
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+Determina la banda de nivel de visualización (el rango relativo de agrupación por orden Z) para la forma.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+Almacena las relaciones entre contenedores, listas, anotaciones y formas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+Especifica el comportamiento de colocación para una forma colocable.
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+Especifica si las formas colocables pueden situarse encima de una forma cuando el usuario selecciona Organizar Formas (menú Formas).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+Especifica si un conector puede enrutar horizontalmente a través de una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+Especifica si un conector puede enrutar verticalmente a través de una forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes).
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+Determina el estilo de colocación para los hijos.
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+Determina si esta forma puede dividir formas que son divisibles.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+Determina si esta forma 1-D puede dividirse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/layout\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/spanish/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Se utiliza para establecer la dirección del diseño.
+type: docs
+weight: 216
+url: /es/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+Se utiliza para establecer la dirección del diseño.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Coloca la forma de abajo hacia arriba. |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | Coloca las formas primero hacia abajo y luego a la izquierda. |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | Coloca las formas primero hacia abajo y luego a la derecha. |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | Coloca las formas primero a la izquierda y luego hacia abajo. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Coloca la forma de izquierda a derecha . |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | Coloca las formas primero a la derecha y luego hacia abajo. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Coloca la forma de derecha a izquierda. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Coloca la forma de arriba a abajo. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Coloca la forma de abajo a arriba. Solo tiene sentido cuando se elige el estilo Diagrama de flujo.
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+Coloca las formas primero hacia abajo y luego a la izquierda. Solo tiene sentido cuando se elige el estilo CompactTree.
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+Coloca las formas primero hacia abajo y luego a la derecha. Solo tiene sentido cuando se elige el estilo CompactTree.
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+Coloca las formas primero a la izquierda y luego hacia abajo. Solo tiene sentido cuando se elige el estilo CompactTree.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Coloca la forma de izquierda a derecha. Solo tiene sentido cuando se elige el estilo Flowchart.
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+Coloca las formas primero a la derecha y luego hacia abajo. Solo tiene sentido cuando se elige el estilo CompactTree.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Coloca la forma de derecha a izquierda. Solo tiene sentido cuando se elige el estilo Flowchart.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Coloca la forma de arriba a abajo. Solo tiene sentido cuando se elige el estilo Flowchart.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Se usa para especificar el estilo y opciones adicionales del layout de formas para realizar el Re-Layout de páginas.
+type: docs
+weight: 217
+url: /es/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+Se utiliza para especificar el estilo y opciones adicionales del diseño de formas para realizar el Re-Diseño de la(s) página(s).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | Inicializa una nueva instancia de LayoutOptions. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | Se usa para establecer la dirección del layout de formas. |
+| [getEnlargePage()](#getEnlargePage--) | Define si es necesario ampliar la página para ajustar el dibujo o no. |
+| [getLayoutStyle()](#getLayoutStyle--) | Se utiliza para especificar el estilo del diseño. |
+| [getSpaceShapes()](#getSpaceShapes--) | Define el espaciado entre las formas en pulgadas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | Para la descripción de esta propiedad, consulte [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | Para la descripción de esta propiedad, consulte [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | Para la descripción de esta propiedad, consulte [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+Inicializa una nueva instancia de LayoutOptions.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+Se usa para establecer la dirección del layout de formas. El valor predeterminado es TopToBottom.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Define si es necesario ampliar la página para ajustar el dibujo o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+Se usa para especificar el estilo del layout. El valor predeterminado es FlowChart.
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+Define el espaciado entre las formas en pulgadas. Valor predeterminado 0.3 pulgada ~ 7.5 mm.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/spanish/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Se utiliza para especificar el estilo del diseño.
+type: docs
+weight: 218
+url: /es/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+Se utiliza para especificar el estilo del diseño.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | Estilo circular. |
+| [COMPACT_TREE](#COMPACT-TREE) | Estilo de árbol. |
+| [FLOW_CHART](#FLOW-CHART) | Estilo de diagrama de flujo. |
+| [RADIAL](#RADIAL) | Estilo radial. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Estilo circular.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+Estilo de árbol.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+Estilo de diagrama de flujo.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Estilo radial.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/license/_index.md
+++ b/spanish/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: Licencia
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Proporciona métodos para licenciar el componente.
+type: docs
+weight: 219
+url: /es/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Proporciona métodos para licenciar el componente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [License()](#License--) | Inicializa una nueva instancia de esta clase. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licencia el componente. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licencia el componente. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Inicializa una nueva instancia de esta clase.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licencia el componente.
+
+Utilice este método para cargar una licencia desde un flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | Un flujo que contiene la licencia. |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licencia el componente.
+
+Intenta encontrar la licencia en las siguientes ubicaciones:
+
+1. Ruta explícita.
+
+2. La carpeta del ensamblado del componente.
+
+3. La carpeta del ensamblado de llamada del cliente.
+
+4. La carpeta del ensamblado de entrada.
+
+5. Un recurso incrustado en el ensamblado de llamada del cliente.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Ruta explícita.
+
+2. Un recurso incrustado en el ensamblado de llamada del cliente.
+
+2. La carpeta del archivo jar del componente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/spanish/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de dirección del rig de luz.
+type: docs
+weight: 220
+url: /es/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+Representa el tipo de dirección del rig de luz.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Inferior |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Inferior izquierda. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Inferior derecha. |
+| [LEFT](#LEFT) | Izquierda. |
+| [RIGHT](#RIGHT) | Derecha. |
+| [TOP](#TOP) | Superior. |
+| [TOP_LEFT](#TOP-LEFT) | Superior izquierda. |
+| [TOP_RIGHT](#TOP-RIGHT) | Superior derecha. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Inferior
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Inferior izquierda.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Inferior derecha.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Superior.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Superior izquierda.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Superior derecha.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/line/_index.md
+++ b/spanish/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican información general de posicionamiento sobre una forma.
+type: docs
+weight: 221
+url: /es/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+Contiene elementos que especifican información general de posicionamiento sobre una forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | Indica si una línea tiene una punta de flecha u otro formato de extremo de línea en su primer vértice. |
+| [getBeginArrowSize()](#getBeginArrowSize--) | Determina el tamaño de la punta de flecha al inicio de la línea. |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | Especifica el CompoundType de línea de la forma. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getEndArrow()](#getEndArrow--) | Indica si una línea tiene una punta de flecha u otro formato de extremo de línea en su último vértice. |
+| [getEndArrowSize()](#getEndArrowSize--) | Especifica el tamaño de la punta de flecha al final de la línea. |
+| [getGradientLine()](#getGradientLine--) | Contiene los valores actuales de formato de línea degradada para la forma |
+| [getLineCap()](#getLineCap--) | Especifica si una línea tiene extremos de línea redondeados o cuadrados. |
+| [getLineColor()](#getLineColor--) | Especifica el color de línea de la forma. |
+| [getLineColorTrans()](#getLineColorTrans--) | Especifica el nivel de transparencia del color de línea de una forma, de 0 (opaco) a 1 (completamente transparente). |
+| [getLinePattern()](#getLinePattern--) | Especifica el patrón de línea de la forma |
+| [getLineWeight()](#getLineWeight--) | Especifica el grosor de línea de una forma. |
+| [getRounding()](#getRounding--) | Especifica el radio del arco de redondeo aplicado donde se encuentran dos segmentos contiguos de una ruta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | Para la descripción de esta propiedad, consulte [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | Para la descripción de esta propiedad, consulte [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/line\#getDel--) |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | Para la descripción de esta propiedad, consulte [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getLineCap()](../../com.aspose.diagram/line\#getLineCap--) |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getLineColor()](../../com.aspose.diagram/line\#getLineColor--) |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getRounding()](../../com.aspose.diagram/line\#getRounding--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+Indica si una línea tiene una punta de flecha u otro formato de extremo de línea en su primer vértice. Introduzca un número de 0 a 45 o la función USE con el nombre de un extremo de línea personalizado.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+Determina el tamaño de la punta de flecha al inicio de la línea. Introduzca un número del 0 al 6.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+Especifica el CompoundType de línea de la forma.
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+Indica si una línea tiene una punta de flecha u otro formato de extremo de línea en su último vértice.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+Especifica el tamaño de la punta de flecha al final de la línea.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+Contiene los valores actuales de formato de línea degradada para la forma
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+Especifica si una línea tiene extremos de línea redondeados o cuadrados.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+Especifica el color de línea de la forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+Especifica el nivel de transparencia del color de línea de una forma, de 0 (opaco) a 1 (completamente transparente). El valor predeterminado es 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+Especifica el patrón de línea de la forma
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+Especifica el grosor de línea de una forma. El grosor de línea es independiente de la escala del dibujo. Si el dibujo se escala, el grosor de línea permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+Especifica el radio del arco de redondeo aplicado donde se encuentran dos segmentos contiguos de una ruta. Por ejemplo, el redondeo puede usarse para dar a un rectángulo esquinas redondeadas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/line\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRounding()](../../com.aspose.diagram/line\#getRounding--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/spanish/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: AjusteLíneaDesde
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+type: docs
+weight: 222
+url: /es/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica qué conectores dinámicos separar si se enrutan uno sobre otro. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+type: docs
+weight: 223
+url: /es/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | Todas las líneas. |
+| [NO_LINES](#NO-LINES) | Sin líneas. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Estilo de enrutamiento predeterminado. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | Líneas no relacionadas. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+Todas las líneas.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Sin líneas.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Estilo de enrutamiento predeterminado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+Líneas no relacionadas.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/spanish/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+type: docs
+weight: 224
+url: /es/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/spanish/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustToValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+type: docs
+weight: 225
+url: /es/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | Todas las líneas que están cerca unas de otras. |
+| [NO_LINES](#NO-LINES) | Sin líneas. |
+| [RELATEDLINES](#RELATEDLINES) | Líneas relacionadas. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Estilo de enrutamiento predeterminado. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+Todas las líneas que están cerca unas de otras.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Sin líneas.
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+Líneas relacionadas.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Estilo de enrutamiento predeterminado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/spanish/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina los conectores dinámicos a los que desea agregar saltos.
+type: docs
+weight: 226
+url: /es/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+Determina los conectores dinámicos a los que desea agregar saltos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina los conectores dinámicos a los que desea agregar saltos. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linejumpcode#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina los conectores dinámicos a los que desea agregar saltos.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linejumpcode#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina los conectores dinámicos a los que desea agregar saltos.
+type: docs
+weight: 227
+url: /es/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+Determina los conectores dinámicos a los que desea agregar saltos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | Primera línea mostrada (forma inferior en el orden de visualización). |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | Líneas horizontales. |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | Última línea mostrada (forma superior en el orden de visualización). |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | Última línea enrutada. |
+| [NONE](#NONE) | Ninguno. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | Líneas verticales. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+Primera línea mostrada (forma inferior en el orden de visualización).
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+Líneas horizontales.
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+Última línea mostrada (forma superior en el orden de visualización).
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+Última línea enrutada.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ninguno.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+Líneas verticales.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/spanish/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+type: docs
+weight: 228
+url: /es/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+type: docs
+weight: 229
+url: /es/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ARC](#ARC) | Arco. |
+| [DEFAULT](#DEFAULT) | Predeterminado. |
+| [GAP](#GAP) | Espacio. |
+| [SIDES_2](#SIDES-2) | 2 Lados. |
+| [SIDES_3](#SIDES-3) | 3 Lados. |
+| [SIDES_4](#SIDES-4) | 4 Lados. |
+| [SIDES_5](#SIDES-5) | 5 Lados. |
+| [SIDES_6](#SIDES-6) | 6 Lados. |
+| [SIDES_7](#SIDES-7) | 7 Lados. |
+| [SQUARE](#SQUARE) | Cuadrado. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Arco.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Predeterminado.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Espacio.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2 Lados.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3 Lados.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4 Lados.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5 Lados.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6 Lados.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7 Lados.
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Cuadrado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linerouteext/_index.md
+++ b/spanish/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la apariencia predeterminada para todos los conectores en una página.
+type: docs
+weight: 230
+url: /es/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+Especifica la apariencia predeterminada para todos los conectores en una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la apariencia predeterminada para todos los conectores en una página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la apariencia predeterminada para todos los conectores en una página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la apariencia predeterminada para todos los conectores en una página.
+type: docs
+weight: 231
+url: /es/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+Especifica la apariencia predeterminada para todos los conectores en una página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CURVED](#CURVED) | Curvado. |
+| [DEFAULT](#DEFAULT) | Predeterminado. |
+| [STRAIGHT](#STRAIGHT) | Recto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Curvado.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Predeterminado.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Recto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/lineto/_index.md
+++ b/spanish/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del vértice final de un segmento de línea recta.
+type: docs
+weight: 232
+url: /es/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+Contiene las coordenadas x e y del vértice final de un segmento de línea recta. Estas coordenadas se encuentran en los elementos X y Y, respectivamente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LineTo()](#LineTo--) | Crea una instancia de la clase [LineTo](../../com.aspose.diagram/lineto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de un segmento de línea recta. |
+| [getY()](#getY--) | La coordenada y del vértice final de un segmento de línea recta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/lineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/lineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/lineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/lineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+Crea una instancia de la clase [LineTo](../../com.aspose.diagram/lineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de un segmento de línea recta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de un segmento de línea recta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/lineto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/lineto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/lineto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/lineto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/linetocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección LineTo.
+type: docs
+weight: 233
+url: /es/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+Colección LineTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX ListBox.
+type: docs
+weight: 234
+url: /es/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+Representa un control ActiveX ListBox.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | el color OLE del fondo. |
+| [getBorderStyle()](#getBorderStyle--) | el tipo de borde utilizado por el control. |
+| [getBoundColumn()](#getBoundColumn--) | Representa cómo se determina la propiedad Value para un ComboBox o ListBox cuando el valor de la propiedad MultiSelect (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Representa el número de columnas a mostrar en un ComboBox o ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | el ancho de la columna. |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indica si el control solo mostrará líneas completas de texto sin mostrar líneas parciales. |
+| [getListStyle()](#getListStyle--) | la apariencia visual. |
+| [getListWidth()](#getListWidth--) | el ancho en unidades de puntos. |
+| [getMatchEntry()](#getMatchEntry--) | Indica cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getScrollBars()](#getScrollBars--) | Indica si el control tiene barras de desplazamiento verticales, horizontales, ambas o ninguna. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indica si se muestran los encabezados de columna. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getTextColumn()](#getTextColumn--) | Representa la columna en un ComboBox o ListBox que se mostrará al usuario. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getValue()](#getValue--) | el valor del control. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | Para la descripción de esta propiedad, consulte [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | Para la descripción de esta propiedad, consulte [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | Para la descripción de esta propiedad, consulte [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Para la descripción de esta propiedad, consulte [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--) |
+| [setListStyle(int value)](#setListStyle-int-) | Para la descripción de esta propiedad, consulte [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | Para la descripción de esta propiedad, consulte [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | Para la descripción de esta propiedad, consulte [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Para la descripción de esta propiedad, consulte [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | Para la descripción de esta propiedad, consulte [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | Para la descripción de esta propiedad, consulte [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+el tipo de borde utilizado por el control.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Representa cómo se determina la propiedad Value para un ComboBox o ListBox cuando el valor de la propiedad MultiSelect (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Representa el número de columnas a mostrar en un ComboBox o ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+el ancho de la columna.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indica si el control solo mostrará líneas completas de texto sin mostrar líneas parciales.
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+la apariencia visual.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+el ancho en unidades de puntos.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indica cómo un ListBox o ComboBox busca en su lista mientras el usuario escribe.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indica si el control tiene barras de desplazamiento verticales, horizontales, ambas o ninguna.
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indica si se muestran los encabezados de columna.
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Representa la columna en un ComboBox o ListBox que se mostrará al usuario.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+el valor del control.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/spanish/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Enumeración para la selección del formato de carga del diagrama.
+type: docs
+weight: 235
+url: /es/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+Enumeración para la selección del formato de carga del diagrama.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [VDW](#VDW) | Formato de dibujo web Vdw de MS Visio. |
+| [VDX](#VDX) | Formato XML VDX de MS Visio. |
+| [VSD](#VSD) | Formato binario Vsd de MS Visio. |
+| [VSDM](#VSDM) | Formato de archivo Vsdm de MS Visio que permite macros. |
+| [VSDX](#VSDX) | Formato de archivo Vsdx de MS Visio 2013. |
+| [VSS](#VSS) | Formato de plantilla binaria Vss de MS Visio. |
+| [VSSM](#VSSM) | Formato de archivo Vssm de MS Visio que permite macros. |
+| [VSSX](#VSSX) | Formato de archivo Vssx de MS Visio 2013. |
+| [VST](#VST) | Formato de plantilla binaria Vst de MS Visio. |
+| [VSTM](#VSTM) | Formato de archivo Vstm de MS Visio que permite macros. |
+| [VSTX](#VSTX) | Formato de archivo de plantilla Vstx de MS Visio 2013. |
+| [VSX](#VSX) | Formato de plantilla xml Vsx de MS Visio. |
+| [VTX](#VTX) | Formato de plantilla XML Vtx de MS Visio. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+Formato de dibujo web Vdw de MS Visio.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato XML VDX de MS Visio.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+Formato binario Vsd de MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato de archivo Vsdm de MS Visio que permite macros.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato de archivo Vsdx de MS Visio 2013.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+Formato de plantilla binaria Vss de MS Visio.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato de archivo Vssm de MS Visio que permite macros.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato de archivo Vssx de MS Visio 2013.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+Formato de plantilla binaria Vst de MS Visio.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato de archivo Vstm de MS Visio que permite macros.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato de archivo de plantilla Vstx de MS Visio 2013.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato de plantilla xml Vsx de MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato de plantilla XML Vtx de MS Visio.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/loadoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al cargar un diagrama en un objeto Diagram.
+type: docs
+weight: 236
+url: /es/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Permite especificar opciones adicionales al cargar un diagrama en un objeto Diagram.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | Inicializa una nueva instancia de esta clase con valores predeterminados. |
+| [LoadOptions(int format)](#LoadOptions-int-) | Inicializa una nueva instancia de esta clase con el formato especificado. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | el monitor de interrupciones. |
+| [getLoadFormat()](#getLoadFormat--) | Especifica el formato del diagrama que se cargará. |
+| [getLocale()](#getLocale--) | la configuración regional utilizada para el diagrama en el momento en que se cargó el archivo. |
+| [getPages()](#getPages--) | Especifica el índice de las páginas que se cargarán. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | Para la descripción de esta propiedad, consulte [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | Para la descripción de esta propiedad, consulte [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | Para la descripción de esta propiedad, consulte [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | Para la descripción de esta propiedad, consulte [getPages()](../../com.aspose.diagram/loadoptions\#getPages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase con valores predeterminados. El formato de archivo predeterminado se establece como Aspose.Diagram.LoadFileFormat.
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+Inicializa una nueva instancia de esta clase con el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| formato | int | Aspose.Diagram.LoadFileFormat formato de archivo de carga. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+el monitor de interrupciones.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Especifica el formato del diagrama que se cargará. El valor predeterminado es Aspose.Diagram.LoadFileFormat. Lectura/escritura Aspose.Diagram.LoadFileFormat.
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+la configuración regional utilizada para el diagrama en el momento en que se cargó el archivo.
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+Especifica el índice de las páginas que se cargarán.
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/localizefont/_index.md
+++ b/spanish/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si el texto de la forma debe ser localizado y traducido a otro idioma.
+type: docs
+weight: 237
+url: /es/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+Especifica si el texto de la forma debe localizarse (traducirse a otro idioma).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si el texto de la forma debe localizarse (traducirse a otro idioma). |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/localizefont\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si el texto de la forma debe localizarse (traducirse a otro idioma).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/localizefont\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si el texto de la forma debe ser localizado y traducido a otro idioma.
+type: docs
+weight: 238
+url: /es/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+Especifica si el texto de la forma debe localizarse (traducirse a otro idioma).
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | Siempre localizar la fuente. |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | Localizar la fuente solo si es Arial o Symbol (el predeterminado). |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | Nunca localizar la fuente. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+Siempre localizar la fuente.
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+Localizar la fuente solo si es Arial o Symbol (el predeterminado).
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+Nunca localizar la fuente.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/margin/_index.md
+++ b/spanish/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el margen.
+type: docs
+weight: 239
+url: /es/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+Especifica el margen.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | Representa una unidad de medida. |
+| [getValue()](#getValue--) | Especifica el margen. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/margin\#getUnit--) |
+| [setValue(double value)](#setValue-double-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/margin\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+| unidad | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Representa una unidad de medida. El valor predeterminado es DP.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Especifica el margen.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/margin\#getUnit--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/margin\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/master/_index.md
+++ b/spanish/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que definen una plantilla maestra para el documento.
+type: docs
+weight: 240
+url: /es/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+Contiene elementos que definen un master para el documento. Un master es una forma en una plantilla que se usa repetidamente para crear dibujos. Cuando arrastras una forma de una plantilla a la página de dibujo, la forma se convierte en una instancia de ese master, y una copia local del master se incluye en el documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Master()](#Master--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [dispose()](#dispose--) | Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Especifica si el texto del master en la ventana de plantilla está alineado a la izquierda, a la derecha o al centro. |
+| [getBaseID()](#getBaseID--) | Un GUID (identificador global único) que identifica el master entre documentos. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Contiene un elemento Connect para cada conexión entre dos formas en un dibujo. |
+| [getHidden()](#getHidden--) | Especifica si el master está oculto en la interfaz de usuario. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIcon()](#getIcon--) | Especifica un icono binario codificado en MIME (Multipurpose Internet Mail Extensions) (en formato .ico) para un elemento Master o MasterShortcut en un documento. |
+| [getIconSize()](#getIconSize--) | El tamaño del icono del elemento. |
+| [getIconUpdate()](#getIconUpdate--) | Especifica si el icono se genera automáticamente a partir del propio master. |
+| [getMatchByName()](#getMatchByName--) | El atributo MatchByName determina cómo Microsoft Visio decide si un master de documento ya está presente cuando se suelta una instancia de un master en la página de dibujo. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPageSheet()](#getPageSheet--) | Contiene elementos que definen la hoja de página para un elemento Página o Maestro. |
+| [getPatternFlags()](#getPatternFlags--) | El atributo PatternFlags determina si un master se comporta como un patrón personalizado. |
+| [getPrompt()](#getPrompt--) | La barra de estado y la información sobre herramientas solicitan al elemento. |
+| [getShapes()](#getShapes--) | Colección de objetos Shape. |
+| [getUniqueID()](#getUniqueID--) | Un GUID que identifica el master dentro del documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Para la descripción de esta propiedad, consulte [getAlignName()](../../com.aspose.diagram/master\#getAlignName--) |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | Para la descripción de esta propiedad, consulte [getBaseID()](../../com.aspose.diagram/master\#getBaseID--) |
+| [setHidden(int value)](#setHidden-int-) | Para la descripción de esta propiedad, consulte [getHidden()](../../com.aspose.diagram/master\#getHidden--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/master\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Para la descripción de esta propiedad, consulte [getIcon()](../../com.aspose.diagram/master\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Para la descripción de esta propiedad, consulte [getIconSize()](../../com.aspose.diagram/master\#getIconSize--) |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | Para la descripción de esta propiedad, consulte [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) |
+| [setMatchByName(int value)](#setMatchByName-int-) | Para la descripción de esta propiedad, consulte [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/master\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/master\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Para la descripción de esta propiedad, consulte [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/master\#getPrompt--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Especifica si el texto del master en la ventana de plantilla está alineado a la izquierda, a la derecha o al centro.
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+Un GUID (identificador global único) que identifica el master entre documentos.
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Contiene un elemento Connect para cada conexión entre dos formas en un dibujo.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+Especifica si el master está oculto en la interfaz de usuario.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Especifica un icono binario codificado en MIME (Multipurpose Internet Mail Extensions) (en formato .ico) para un elemento Master o MasterShortcut en un documento.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+El tamaño del icono del elemento.
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+Especifica si el icono se genera automáticamente a partir del propio master.
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+El atributo MatchByName determina cómo Microsoft Visio decide si un master de documento ya está presente cuando se suelta una instancia de un master en la página de dibujo. Permite que los cambios realizados en un master de documento se apliquen a nuevas instancias del master, incluso si las instancias se arrastran desde un archivo de plantilla independiente.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Contiene elementos que definen la hoja de página para un elemento Página o Maestro.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+El atributo PatternFlags determina si un master se comporta como un patrón personalizado.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+La barra de estado y la información sobre herramientas solicitan al elemento.
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Colección de objetos Shape.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID que identifica el master dentro del documento.
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHidden()](../../com.aspose.diagram/master\#getHidden--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/master\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIcon()](../../com.aspose.diagram/master\#getIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/master\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/master\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/mastercollection/_index.md
+++ b/spanish/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Master.
+type: docs
+weight: 241
+url: /es/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+Colección Master.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | Agregar el objeto Master a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getMaster(int ID)](#getMaster-int-) | Obtiene el elemento con el ID especificado. |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | Obtener el master por nombre. |
+| [getMasterShortcuts()](#getMasterShortcuts--) | Colección MasterShortcut. |
+| [getMaxRelID()](#getMaxRelID--) | obtener el id rel máximo en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [isExist(String name)](#isExist-java.lang.String-) | Existe master en la colección. |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | Existe el id rel del master en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | Eliminar el objeto Master de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+Agregar el objeto Master a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+Obtener el master por nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+Colección MasterShortcut.
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+obtener el id rel máximo en la colección.
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+Existe master en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+Existe el id rel del master en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+Eliminar el objeto Master de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/spanish/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica un acceso directo maestro definido en el documento.
+type: docs
+weight: 242
+url: /es/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+Especifica un acceso directo maestro definido en el documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Especifica si el texto del elemento en la ventana de plantillas está alineado a la izquierda, a la derecha o al centro. |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIcon()](#getIcon--) | Especifica un icono binario codificado en MIME (Multipurpose Internet Mail Extensions) (en formato .ico) para un elemento Master o MasterShortcut en un documento. |
+| [getIconSize()](#getIconSize--) | El tamaño del icono del elemento. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPatternFlags()](#getPatternFlags--) | Determina si un master se comporta como un patrón personalizado. |
+| [getPrompt()](#getPrompt--) | La barra de estado y la información sobre herramientas solicitan al elemento. |
+| [getShortcutHelp()](#getShortcutHelp--) | Una cadena de ayuda para el elemento. |
+| [getShortcutURL()](#getShortcutURL--) | Una URL a un elemento MasterShortcut. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | Para la descripción de esta propiedad, consulte [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/mastershortcut\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | Para la descripción de esta propiedad, consulte [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | Para la descripción de esta propiedad, consulte [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/mastershortcut\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | Para la descripción de esta propiedad, consulte [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | Para la descripción de esta propiedad, consulte [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | Para la descripción de esta propiedad, consulte [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Especifica si el texto del elemento en la ventana de plantillas está alineado a la izquierda, a la derecha o al centro.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Especifica un icono binario codificado en MIME (Multipurpose Internet Mail Extensions) (en formato .ico) para un elemento Master o MasterShortcut en un documento.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+El tamaño del icono del elemento.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+Determina si un master se comporta como un patrón personalizado.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+La barra de estado y la información sobre herramientas solicitan al elemento.
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+Una cadena de ayuda para el elemento.
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+Una URL a un elemento MasterShortcut. Si este atributo está presente, este elemento MasterShortcut es un acceso directo.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/mastershortcut\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/mastershortcut\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección MasterShortcut.
+type: docs
+weight: 243
+url: /es/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+Colección MasterShortcut.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | Agregar el objeto Master a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | Elimina el objeto MasterShortcut de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+Agregar el objeto Master a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+Elimina el objeto MasterShortcut de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/measureconst/_index.md
+++ b/spanish/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Unidades de medida.
+type: docs
+weight: 244
+url: /es/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+Unidades de\\ medida.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [AC](#AC) | Acre. |
+| [AD](#AD) | Grados. |
+| [AM](#AM) | Minutos. |
+| [AS](#AS) | Segundos. |
+| [BOOL](#BOOL) | Booleano. |
+| [C](#C) | Ciceros. |
+| [CM](#CM) | Centímetros. |
+| [COLOR](#COLOR) | Un valor de color. |
+| [CY](#CY) | Moneda. |
+| [C_D](#C-D) | Ciceros/didits. |
+| [D](#D) | Didots. |
+| [DA](#DA) | Unidades de ángulo predeterminadas. |
+| [DATE](#DATE) | Fecha y hora. |
+| [DE](#DE) | Unidades de duración predeterminadas. |
+| [DEG](#DEG) | Grado fraccionario. |
+| [DL](#DL) | Unidades de longitud predeterminadas. |
+| [DP](#DP) | Unidades de página predeterminadas. |
+| [DT](#DT) | Unidades de tipo predeterminadas. |
+| [ED](#ED) | Días transcurridos. |
+| [EH](#EH) | Horas transcurridas. |
+| [EM](#EM) | Minutos transcurridos. |
+| [ES](#ES) | Segundos transcurridos. |
+| [EW](#EW) | Semanas transcurridas. |
+| [FT](#FT) | Feet. |
+| [F_I](#F-I) | Feet/inch. |
+| [GUID](#GUID) | A global unique identifier. |
+| [HA](#HA) | Hectare. |
+| [IN](#IN) | Inches. |
+| [IN_F](#IN-F) | Inches fractional. |
+| [KM](#KM) | Kilometres. |
+| [M](#M) | Metres. |
+| [MI](#MI) | Miles. |
+| [MI_F](#MI-F) | Milest fractional. |
+| [MM](#MM) | Milimetres. |
+| [MULTIDIM](#MULTIDIM) | Multidimential value. |
+| [NM](#NM) | Nautical miles. |
+| [NUM](#NUM) | Número. |
+| [NURBS](#NURBS) | Nurbs curve data. |
+| [P](#P) | Picas. |
+| [PER](#PER) | Percent. |
+| [PNT](#PNT) | 2-D coordinate. |
+| [POLYLINE](#POLYLINE) | Polyline point data. |
+| [PT](#PT) | Points. |
+| [P_PT](#P-PT) | Picas/points. |
+| [RAD](#RAD) | Radians. |
+| [STR](#STR) | Cadena. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [YD](#YD) | Yards. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+Acre.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+Grados.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+Minutos.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+Segundos.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Booleano.
+
+### C {#C}
+```
+public static final int C
+```
+
+
+Ciceros.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+Centímetros.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+Un valor de color.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+Moneda.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+Ciceros/didits.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+Didots.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+Unidades de ángulo predeterminadas.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Fecha y hora.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+Unidades de duración predeterminadas.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+Grado fraccionario.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Unidades de longitud predeterminadas.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+Unidades de página predeterminadas.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+Unidades de tipo predeterminadas.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+Días transcurridos.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+Horas transcurridas.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+Minutos transcurridos.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+Segundos transcurridos.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+Semanas transcurridas.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+Feet.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+Feet/inch.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+A global unique identifier.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+Hectare.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+Inches.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+Inches fractional.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+Kilometres.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+Metres.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+Miles.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+Milest fractional.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+Milimetres.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+Multidimential value.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+Nautical miles.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+Número.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Nurbs curve data.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+Picas.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+Percent.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+2-D coordinate.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+Polyline point data.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+Points.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+Picas/points.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+Radians.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+Cadena.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+Yards.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/spanish/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el único archivo de fuente TrueType almacenado en memoria.
+type: docs
+weight: 245
+url: /es/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+Representa el único archivo de fuente TrueType almacenado en memoria.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | Ctor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | Datos binarios de fuente. |
+| [getType()](#getType--) | Devuelve el tipo del origen de fuentes. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+Ctor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fontData | byte[] | Datos binarios de fuente. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+Datos binarios de fuente.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Devuelve el tipo del origen de fuentes.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/spanish/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Referencia de API de Aspose.Diagram para Java
+description: MilestoneHelper para establecer la propiedad de la forma de hito.
+type: docs
+weight: 246
+url: /es/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+MilestoneHelper para establecer la propiedad de la forma de hito.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | Fecha del hito |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | Actualizar hito |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | si se actualizan los datos de los marcadores (hitos, intervalos) a medida que se mueven en la línea de tiempo |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | Formato de fecha de la forma /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | Cadena de formato de fecha de la forma |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | Tipo de forma |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+Fecha del hito
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+Actualizar hito
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+si se actualizan los datos de los marcadores (hitos, intervalos) a medida que se mueven en la línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+Formato de fecha de la forma ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+Cadena de formato de fecha de la forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Tipo de forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/misc/_index.md
+++ b/spanish/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: Varios
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene varios elementos de formas y grupos, como los que controlan el resaltado de selección y la visibilidad.
+type: docs
+weight: 247
+url: /es/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+Contiene varios elementos de formas y grupos, como los que controlan el resaltado de selección y la visibilidad.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Contiene una fórmula de activación generada por Microsoft Visio que determina si mover el punto inicial de una forma 1-D para mantener su conexión con otra forma. |
+| [getCalendar()](#getCalendar--) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Contiene el texto del comentario en formato de cadena para una forma. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDropOnPageScale()](#getDropOnPageScale--) | Determina el porcentaje en que se escala una forma cuando se suelta en la página de dibujo. |
+| [getDynFeedback()](#getDynFeedback--) | Especifica el tipo de retroalimentación visual que se brinda a los usuarios cuando arrastran un conector. |
+| [getEndTrigger()](#getEndTrigger--) | Contiene una fórmula de activación generada por Microsoft Visio. |
+| [getGlueType()](#getGlueType--) | Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma. |
+| [getHideText()](#getHideText--) | Oculta el texto de una forma. |
+| [getLangID()](#getLangID--) | Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario. |
+| [getLocalizeMerge()](#getLocalizeMerge--) | Determina si las formas se localizan (si su elemento LangID se restablece) cuando se copian entre documentos. |
+| [getNoAlignBox()](#getNoAlignBox--) | Especifica si se muestra el rectángulo de selección cuando la forma está seleccionada. |
+| [getNoCtlHandles()](#getNoCtlHandles--) | Especifica si se muestran los manejadores de control cuando la forma está seleccionada. |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | Especifica si una forma cambia de tamaño o rota dinámicamente mientras el usuario la manipula. |
+| [getNoObjHandles()](#getNoObjHandles--) | Especifica si se muestran los manejadores de selección cuando la forma está seleccionada. |
+| [getNonPrinting()](#getNonPrinting--) | Especifica si una forma seleccionada puede imprimirse. |
+| [getObjType()](#getObjType--) | Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo. |
+| [getShapeKeywords()](#getShapeKeywords--) | Contiene palabras clave de búsqueda que se han asignado a formas maestras personalizadas. |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | Especifica si recalcular el rectángulo de selección de una forma cada vez que se mueve un manejador de control. |
+| [getWalkPreference()](#getWalkPreference--) | Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua. |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | Especifica si la forma puede añadirse a un grupo soltándola sobre el grupo. |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | Indica si los valores de celdas especificadas en una forma maestra sobrescriben los valores (incluidos los locales) de una forma que se está reemplazando durante una operación de sustitución de forma. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/misc\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Contiene una fórmula de activación generada por Microsoft Visio que determina si mover el punto inicial de una forma 1-D para mantener su conexión con otra forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Contiene el texto del comentario en formato de cadena para una forma.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+Determina el porcentaje en que se escala una forma cuando se suelta en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+Especifica el tipo de retroalimentación visual que se brinda a los usuarios cuando arrastran un conector.
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Contiene una fórmula de activación generada por Microsoft Visio. Esta fórmula de activación determina si mover el punto final de una forma 1-D para mantener su conexión con otra forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+Especifica si se permite el pegado dinámico (forma a forma) al conectar con una forma.
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+Oculta el texto de una forma. Puedes ver el texto, editar propiedades y aplicar estilos al texto en el bloque de texto, aunque los cambios no aparecerán hasta que especifiques el elemento HideText como 0.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+Determina si las formas se localizan (si su elemento LangID se restablece) cuando se copian entre documentos.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+Especifica si se muestra el rectángulo de selección cuando la forma está seleccionada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+Especifica si se muestran los manejadores de control cuando la forma está seleccionada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+Especifica si una forma cambia de tamaño o rota dinámicamente mientras el usuario la manipula.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+Especifica si se muestran los manejadores de selección cuando la forma está seleccionada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+Especifica si una forma seleccionada puede imprimirse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+Contiene palabras clave de búsqueda que se han asignado a formas maestras personalizadas.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+Especifica si recalcular el rectángulo de selección de una forma cada vez que se mueve un manejador de control.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua.
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+Especifica si la forma puede añadirse a un grupo soltándola sobre el grupo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+Indica si los valores de celdas especificadas en una forma maestra sobrescriben los valores (incluidos los locales) de una forma que se está reemplazando durante una operación de sustitución de forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/misc\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/moveto/_index.md
+++ b/spanish/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del primer vértice de una forma o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta.
+type: docs
+weight: 248
+url: /es/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | Crea una instancia de la clase [MoveTo](../../com.aspose.diagram/moveto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | El elemento X representa la coordenada x del primer vértice de una ruta. |
+| [getY()](#getY--) | El elemento Y representa la coordenada y del primer vértice de una ruta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/moveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/moveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/moveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/moveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+Crea una instancia de la clase [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+El elemento X representa la coordenada x del primer vértice de una ruta. Si el elemento MoveTo aparece entre dos elementos, el elemento X representa la coordenada x del primer vértice después de la interrupción en la ruta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+El elemento Y representa la coordenada y del primer vértice de una ruta. Si el elemento MoveTo aparece entre dos elementos, el elemento Y representa la coordenada y del primer vértice después de la interrupción en la ruta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/moveto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/moveto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/moveto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/moveto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/movetocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección MoveTo.
+type: docs
+weight: 249
+url: /es/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+Colección MoveTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/nurbsto/_index.md
+++ b/spanish/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene la posición de las coordenadas x e y del penúltimo nudo, la posición del último peso, la posición del primer nudo, la posición del primer peso y la fórmula de una B-spline racional no uniforme (NURBS).
+type: docs
+weight: 250
+url: /es/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+Contiene las coordenadas x e y, la posición del penúltimo nudo, la posición del último peso, la posición del primer nudo, la posición del primer peso y la fórmula de una B-spline racional no uniforme (NURBS). Esta información se especifica en los elementos X, Y, A, B, C, D y E, respectivamente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | Crea una instancia de la clase [NURBSTo](../../com.aspose.diagram/nurbsto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | El penúltimo nudo de la B-spline racional no uniforme (NURBS). |
+| [getB()](#getB--) | El último peso de la B-spline racional no uniforme (NURBS). |
+| [getC()](#getC--) | El primer nudo de la B-spline racional no uniforme (NURBS). |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | El primer peso de la B-spline racional no uniforme (NURBS) |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getE()](#getE--) | Contiene una fórmula de B-spline racional no uniforme (NURBS). |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del último punto de control de una B-spline racional no uniforme (NURBS). |
+| [getY()](#getY--) | La coordenada y del último punto de control de una B-spline racional no uniforme (NURBS). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/nurbsto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/nurbsto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/nurbsto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/nurbsto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/nurbsto\#getDel--) |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getE()](../../com.aspose.diagram/nurbsto\#getE--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/nurbsto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/nurbsto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/nurbsto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+Crea una instancia de la clase [NURBSTo](../../com.aspose.diagram/nurbsto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+El penúltimo nudo de la B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+El último peso de la B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+El primer nudo de la B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+El primer peso de la B-spline racional no uniforme (NURBS)
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+Contiene una fórmula de B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del último punto de control de una B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del último punto de control de una B-spline racional no uniforme (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/nurbsto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/nurbsto\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/nurbsto\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/nurbsto\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getE()](../../com.aspose.diagram/nurbsto\#getE--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/nurbsto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/nurbsto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección NURBSTo.
+type: docs
+weight: 251
+url: /es/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+Colección NURBSTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/objectkind/_index.md
+++ b/spanish/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica el tipo de campo de texto.
+type: docs
+weight: 254
+url: /es/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+Indica el tipo de campo de texto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Indica el tipo de campo de texto. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/objectkind\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica el tipo de campo de texto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/objectkind\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica el tipo de campo de texto.
+type: docs
+weight: 255
+url: /es/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+Indica el tipo de campo de texto.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | Horizontal en vertical. |
+| [STANDARD](#STANDARD) | Estándar. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+Horizontal en vertical.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Estándar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/objecttype/_index.md
+++ b/spanish/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Si el atributo ForeignType es Object, el elemento ForeignData también debe tener un atributo ObjectType.
+type: docs
+weight: 256
+url: /es/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+Si el atributo ForeignType es "Object", el elemento ForeignData también debe tener un atributo ObjectType.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CONTROL](#CONTROL) | Control. |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | Objeto incrustado. |
+| [LINKED_OBJECT](#LINKED-OBJECT) | Objeto vinculado. |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 con nombre. |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | Objeto OLE2. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Control.
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+Objeto incrustado.
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+Objeto vinculado.
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 con nombre.
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+Objeto OLE2.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/objtype/_index.md
+++ b/spanish/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+type: docs
+weight: 252
+url: /es/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+type: docs
+weight: 253
+url: /es/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Especifica si los objetos son colocables o enrutables en diagramas cuando utilizas Microsoft Visio para organizar formas en la página de dibujo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio decide en función del contexto del dibujo. |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | La forma no es ubicable, no es enrutable. |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | La forma es ubicable. |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | El grupo contiene formas ubicables/enrutable. |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape es enrutable. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio decide en función del contexto del dibujo.
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+La forma no es ubicable, no es enrutable.
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+La forma es ubicable.
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+El grupo contiene formas ubicables/enrutable.
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape es enrutable.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Entero sin signo opcional.
+type: docs
+weight: 257
+url: /es/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+Entero sin signo opcional. Opciones para aplicar al conjunto de datos. Los valores posibles pueden ser cualquier combinación de uno o más de los mostrados en la tabla siguiente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | No ejecuta la consulta de cadena de comandos hasta la próxima vez que se actualice el conjunto de datos. |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | Limita el control que los usuarios tienen sobre cómo se actualiza el conjunto de datos en el cuadro de diálogo Configurar actualización del conjunto de datos. |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | Impide que los datos del conjunto de datos se muestren en la ventana de Datos externos. |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | No copia los enlaces de datos de forma al portapapeles cuando las formas se copian o recortan. |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | Impide que el conjunto de datos se muestre en el cuadro de diálogo Actualizar datos. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+No ejecuta la consulta de cadena de comandos hasta la próxima vez que se actualice el conjunto de datos.
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+Limita el control que los usuarios tienen sobre cómo se actualiza el conjunto de datos en el cuadro de diálogo Configurar actualización del conjunto de datos. En particular, los usuarios no pueden cambiar la clave primaria ni especificar cuándo se deben sobrescribir los datos de forma; sin embargo, pueden establecer el intervalo de actualización y cambiar la fuente de datos.
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+Impide que los datos del conjunto de datos se muestren en la ventana de Datos externos.
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+No copia los enlaces de datos de forma al portapapeles cuando las formas se copian o recortan.
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+Impide que el conjunto de datos se muestre en el cuadro de diálogo Actualizar datos.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/outputformat/_index.md
+++ b/spanish/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el formato de salida para un dibujo.
+type: docs
+weight: 258
+url: /es/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+Especifica el formato de salida para un dibujo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el formato de salida para un dibujo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/outputformat\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el formato de salida para un dibujo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/outputformat\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el formato de salida para un dibujo.
+type: docs
+weight: 259
+url: /es/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+Especifica el formato de salida para un dibujo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | Predeterminado. |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | Salida HTML o GIF. |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | Presentación de diapositivas de PowerPoint. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+Predeterminado. Imprimir.
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+Salida HTML o GIF.
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+Presentación de diapositivas de PowerPoint.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/page/_index.md
+++ b/spanish/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: Página
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que definen una página en el documento.
+type: docs
+weight: 260
+url: /es/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+Contiene elementos que definen una página en el documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Page()](#Page--) | Constructor. |
+| [Page(int ID)](#Page-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Crea un control Activex. |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | Añade un comentario a una forma. |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | Añade un comentario con PinX y PinY definidos. |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | Añade un comentario a una forma con el id de la forma. |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | Añade una forma creada por el maestro a una página específica. |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | Añade una forma creada por el maestro en la página con PinX, PinY, Width y Height definidos. |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | Añade una forma creada por el maestro en la página con PinX y PinY definidos. |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | Añade texto con PinX y PinY definidos. |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | Añade texto con PinX y PinY definidos. |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | Aplica estilo para la página completa. |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | Espaciado automático de formas |
+| [bringForward(long shapeId)](#bringForward-long-) | Mueve una forma, definida por ID, una posición hacia adelante en el orden Z. |
+| [bringToFront(long shapeId)](#bringToFront-long-) | Mueve una forma, definida por ID, al frente del orden Z. |
+| [centerDrawing()](#centerDrawing--) | Centra las formas de una página con respecto a la extensión de la página. |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Conecta formas mediante un conector. |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | Conecta formas mediante un conector. |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | Conecta formas mediante un conector. |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Conecta formas mediante el índice del conector. |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | Conecta formas mediante el índice del conector. |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados. |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | El proceso de dibujar una elipse. |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | El proceso de dibujar una sola línea. |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | El proceso de dibujar una línea. |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | El proceso de dibujar una polilínea. |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | El proceso de dibujar un rectángulo. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | El ID de la página de dibujo original que fue anotada en superposiciones de anotaciones separadas por revisores del dibujo. |
+| [getBackPage()](#getBackPage--) | La página de fondo de la página. |
+| [getBackground()](#getBackground--) | Una bandera que indica si la página es una página de fondo. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Contiene un elemento Connect para cada conexión entre dos formas en un dibujo. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPageSheet()](#getPageSheet--) | Contiene elementos que definen la hoja de página para un elemento Página o Maestro. |
+| [getPages()](#getPages--) | Colección de páginas. |
+| [getReviewerID()](#getReviewerID--) | El ID del revisor asociado con la superposición de anotaciones. |
+| [getShapes()](#getShapes--) | Colección de formas. |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX y ViewCenterY especifican un punto central en una página que una nueva vista (ventana) asume cuando se abre inicialmente. |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX y ViewCenterY especifican un punto central en una página que una nueva vista (ventana) asume cuando se abre inicialmente. |
+| [getViewScale()](#getViewScale--) | El factor de magnificación predeterminado a usar cuando se abre una nueva vista (ventana) de la página. |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | Unir forma al BeginX del Conector |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | Unir forma al EndX del Conector |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Unir formas. |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | Unir formas |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | Unir formas en el contenedor |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | Unir formas en el contenedor usando el nombre de conexión |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | Unir formas por ID de conexión en el contenedor |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Distribuye las formas y/o redirige los conectores para la página. |
+| [moveTo(int index)](#moveTo-int-) | Mueve la página a otra ubicación en las páginas. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | Mueve una forma,definida por ID, una posición atrás en el orden Z. |
+| [sendToBack(long shapeId)](#sendToBack-long-) | Mueve una forma,definida por ID, al fondo del orden Z. |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | Para la descripción de esta propiedad, consulte [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | Para la descripción de esta propiedad, consulte [getBackPage()](../../com.aspose.diagram/page\#getBackPage--) |
+| [setBackground(int value)](#setBackground-int-) | Para la descripción de esta propiedad, consulte [getBackground()](../../com.aspose.diagram/page\#getBackground--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/page\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/page\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/page\#getNameU--) |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | Para la descripción de esta propiedad, consulte [getPages()](../../com.aspose.diagram/page\#getPages--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Aplicar un tema preestablecido a esta página |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Aplicar una variante de tema preestablecido estilo rápido a esta página |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Aplicar una variante de tema preestablecido a esta página |
+| [setReviewerID(int value)](#setReviewerID-int-) | Para la descripción de esta propiedad, consulte [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Para la descripción de esta propiedad, consulte [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Para la descripción de esta propiedad, consulte [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Para la descripción de esta propiedad, consulte [getViewScale()](../../com.aspose.diagram/page\#getViewScale--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+Constructor.
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Crea un control Activex.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| tipo | int | El tipo del control. |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma en pulgadas. |
+| height | double | Especifica la altura de la forma en pulgadas. |
+
+**Returns:**
+long -
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+Añade un comentario a una forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | Especifica la forma que está añadiendo el comentario. |
+| comment | java.lang.String | Cadena del comentario. |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+Añade un comentario con PinX y PinY definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin del comentario (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin del comentario (centro de rotación) en relación con la página. |
+| comment | java.lang.String | Cadena del comentario. |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+Añade un comentario a una forma con el id de la forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeID | long |  |
+| comment | java.lang.String | Cadena del comentario. |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+Añade una forma creada por el maestro a una página específica.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nuevo objeto de forma[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Nombre del maestro. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| flujo | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| width | double |  |
+| height | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+Añade una forma creada por el maestro en la página con PinX, PinY, Width y Height definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma en pulgadas. |
+| height | double | Especifica la altura de la forma en pulgadas. |
+| masterName | java.lang.String | Nombre del maestro. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+Añade una forma creada por el maestro en la página con PinX y PinY definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| masterName | java.lang.String | Nombre del maestro. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+Añade texto con PinX y PinY definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del punto de anclaje del texto (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del punto de anclaje del texto (centro de rotación) en relación con la página. |
+| width | double |  |
+| height | double |  |
+| text | java.lang.String | cadena de texto. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+Añade texto con PinX y PinY definidos.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del punto de anclaje del texto (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del punto de anclaje del texto (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho del texto. |
+| height | double | Especifica la altura del texto. |
+| text | java.lang.String | cadena de texto. |
+| fontName | java.lang.String | nombre de la fuente del texto. |
+| fontColor | java.lang.String | color de la fuente del texto. |
+| size | double | tamaño de la fuente del texto. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+Aplica estilo para la página completa. El valor predeterminado es -1.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| textStyle | int | identificador de estilo de texto. |
+| lineStyle | int | identificador de estilo de línea. |
+| fillStyle | int | identificador de estilo de relleno. |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+Espaciado automático de formas
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | Especifica que las formas se espacien automáticamente. |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+Mueve una forma, definida por ID, una posición hacia adelante en el orden Z.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeId | long | ID de shape.long |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+Mueve una forma, definida por ID, al frente del orden Z.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeId | long | ID de shape.long |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centra las formas de una página respecto a la extensión de la página. Centrar las formas no cambia su posición relativa entre sí.
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+Conecta formas mediante un conector.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | La ubicación en la primera forma donde se conectará el conector Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La ubicación en la segunda forma donde se conectará el conector Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connector | [Shape](../../com.aspose.diagram/shape) | La forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+Conecta formas mediante un conector.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | La ubicación en la primera forma donde se conectará el conector Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | El ID de la forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La ubicación en la segunda forma donde se conectará el conector Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connectorId | long | El ID de la forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+Conecta formas mediante un conector.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| fromConnectionName | java.lang.String | El nombre de la conexión en la primera forma donde se conectará el conector. |
+| shapeToId | long | El ID de la forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| toConnectionName | java.lang.String | El nombre de la conexión en la segunda forma donde se conectará el conector. |
+| connectorId | long | El ID de la forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+Conecta formas mediante el índice del conector.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | El índice de la conexión en la primera forma |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | El índice de la conexión en la segunda forma |
+| connector | [Shape](../../com.aspose.diagram/shape) | La forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+Conecta formas mediante el índice del conector.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | El índice de la conexión en la primera forma |
+| shapeToId | long | El ID de la forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | El índice de la conexión en la segunda forma |
+| connectorId | long | El ID de la forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados.
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+El proceso de dibujar una elipse.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma |
+| height | double | Especifica la altura de la forma |
+
+**Returns:**
+long -
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+El proceso de dibujar una sola línea.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| beginX | double | Especifica la coordenada x inicial de la posición de la forma en relación con la página. |
+| beginY | double | Especifica la coordenada y inicial de la posición de la forma en relación con la página. |
+| endX | double | Especifica la coordenada x final de la posición de la forma en relación con la página. |
+| endY | double | Especifica la coordenada y final de la posición de la forma en relación con la página. |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+El proceso de dibujar una línea.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma |
+| height | double | Especifica la altura de la forma |
+| xyArray | double[] | Una matriz de valores x e y alternados que define los puntos en la nueva forma |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+El proceso de dibujar una polilínea.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma |
+| height | double | Especifica la altura de la forma |
+| xyArray | double[] | Una matriz de valores x e y alternados que define los puntos en la nueva forma |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+El proceso de dibujar un rectángulo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pinX | double | Especifica la coordenada x del pin de la forma (centro de rotación) en relación con la página. |
+| pinY | double | Especifica la coordenada y del pin de la forma (centro de rotación) en relación con la página. |
+| width | double | Especifica el ancho de la forma |
+| height | double | Especifica la altura de la forma |
+
+**Returns:**
+long - El ID único de la forma dentro de la colección de formas en la página especificada.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+El ID de la página de dibujo original que fue anotada en superposiciones de anotaciones separadas por revisores del dibujo.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+La página de fondo de la página.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+Una bandera que indica si la página es una página de fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Contiene un elemento Connect para cada conexión entre dos formas en un dibujo.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Contiene elementos que definen la hoja de página para un elemento Página o Maestro.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Colección de páginas.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+El ID del revisor asociado con la superposición de anotaciones.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Colección de formas.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX y ViewCenterY especifican un punto central en una página que una nueva vista (ventana) asume cuando se abre inicialmente.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX y ViewCenterY especifican un punto central en una página que una nueva vista (ventana) asume cuando se abre inicialmente.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+El factor de ampliación predeterminado que se usa cuando se abre una nueva vista (ventana) de la página. Por ejemplo, 1 = 100%; 1.5 = 150%, etc.
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+Unir forma al BeginX del Conector
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma donde comienza el conector [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | El nombre de la conexión en la forma donde se conectará el conector. |
+| connectorId | long | El ID de la forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+Unir forma al EndX del Conector
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeToId | long | El ID de la forma donde termina el conector [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | El nombre de la conexión en la segunda forma donde se conectará el conector. |
+| connectorId | long | El ID de la forma con tipo Dynamic connector [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+Unir formas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | La forma que se pega desde [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La ubicación en la primera forma donde pegar Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | La forma donde pegar a [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+Unir formas
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma que se pega desde [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | La ubicación en la primera forma donde pegar Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | El ID de la forma donde pegar a [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+Unir formas en el contenedor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma que se pega desde [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionIndex | int | La ubicación en el índice de conexión inicial donde pegar. |
+| shapeToEndConnectionIndex | int | La ubicación en el índice de conexión final donde pegar. |
+| shapeToId | long | El ID de la forma donde pegar a [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+Unir formas en el contenedor usando el nombre de conexión
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma que se pega desde [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionName | java.lang.String | La ubicación en el nombre de conexión inicial donde pegar. |
+| shapeToEndConnectionName | java.lang.String | La ubicación en el nombre de conexión final donde pegar. |
+| shapeToId | long | El ID de la forma donde pegar a [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+Unir formas por ID de conexión en el contenedor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeFromId | long | El ID de la forma que se pega desde [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionID | int | La ubicación en el ID de conexión inicial donde pegar. |
+| shapeToEndConnectionID | int | La ubicación en el ID de conexión final donde pegar. |
+| shapeToId | long | El ID de la forma donde pegar a [Shape](../../com.aspose.diagram/shape). |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Distribuye las formas y/o redirige los conectores para la página.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Usando [LayoutOptions](../../com.aspose.diagram/layoutoptions) para configurar las opciones de diseño. |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+Mueve la página a otra ubicación en las páginas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | Índice de página de destino. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+Mueve una forma,definida por ID, una posición atrás en el orden Z.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeId | long | ID de shape.long |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+Mueve una forma,definida por ID, al fondo del orden Z.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shapeId | long | ID de shape.long |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackground()](../../com.aspose.diagram/page\#getBackground--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/page\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/page\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/page\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPages()](../../com.aspose.diagram/page\#getPages--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Aplicar un tema preestablecido a esta página
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Aplicar una variante de tema preestablecido estilo rápido a esta página
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Aplicar una variante de tema preestablecido a esta página
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de páginas.
+type: docs
+weight: 261
+url: /es/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+Colección de páginas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Agregar la página a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [dispose()](#dispose--) | Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getPage(int ID)](#getPage-int-) | Obtiene el elemento con el ID especificado. |
+| [getPage(String name)](#getPage-java.lang.String-) | Obtiene el elemento con el nombre especificado. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Eliminar la página de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Agregar la página a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Realiza tareas definidas por la aplicación asociadas con la liberación, el lanzamiento o el restablecimiento de recursos no administrados.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+Obtiene el elemento con el nombre especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Eliminar la página de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/spanish/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Información para una página finaliza el proceso de guardado.
+type: docs
+weight: 262
+url: /es/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+Información para una página finaliza el proceso de guardado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Recuento total de páginas. |
+| [getPageIndex()](#getPageIndex--) | Índice de página actual, basado en cero. |
+| [hasMorePages()](#hasMorePages--) | un valor que indica si hay más páginas para generar. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | Para la descripción de esta propiedad, consulte [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Recuento total de páginas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Índice de página actual, basado en cero.
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+un valor que indica si hay más páginas para generar. El valor predeterminado es true.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagelayout/_index.md
+++ b/spanish/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene celdas que controlan la configuración del diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página.
+type: docs
+weight: 263
+url: /es/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+Contiene celdas que controlan la configuración del diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Determina la cantidad de espacio vertical entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo. |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Determina la cantidad de espacio vertical entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo. |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma). |
+| [getBlockSizeX()](#getBlockSizeX--) | Determina el tamaño del bloque vertical, el área en la que cada una de sus formas debe encajar en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo. |
+| [getBlockSizeY()](#getBlockSizeY--) | Determina la cantidad de espacio horizontal entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo. |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | Determina cuál forma es la principal al usar formas mediante manejadores de control. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDynamicsOff()](#getDynamicsOff--) | Especifica si las formas colocables se mueven y los conectores se redirigen alrededor de otras formas y conectores en la página de dibujo. |
+| [getEnableGrid()](#getEnableGrid--) | Especifica si Microsoft Visio organiza las formas basándose en una cuadrícula interna de página cuando el usuario selecciona Organizar Formas (menú Forma). |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | Especifica qué conectores dinámicos separar si se enrutan uno sobre otro. |
+| [getLineAdjustTo()](#getLineAdjustTo--) | Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos. |
+| [getLineJumpCode()](#getLineJumpCode--) | Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local. |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | Especifica el tamaño de los saltos de línea en los segmentos horizontales de los conectores dinámicos en la página, como un porcentaje del valor del elemento LineToLineX (que especifica el espacio horizontal entre todos los conectores en la página de dibujo). |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | Especifica el tamaño de los saltos de línea en los segmentos verticales de los conectores dinámicos en la página, como un porcentaje del valor del elemento LineToLineY (que especifica el espacio vertical entre todos los conectores en la página de dibujo). |
+| [getLineJumpStyle()](#getLineJumpStyle--) | Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [getLineRouteExt()](#getLineRouteExt--) | Especifica la apariencia predeterminada para todos los conectores en una página. |
+| [getLineToLineX()](#getLineToLineX--) | Especifica el espacio horizontal mínimo entre conectores dinámicos en la página de dibujo. |
+| [getLineToLineY()](#getLineToLineY--) | Especifica el espacio vertical mínimo entre conectores dinámicos en la página de dibujo. |
+| [getLineToNodeX()](#getLineToNodeX--) | Especifica el espacio vertical mínimo entre conectores dinámicos y formas en la página de dibujo. |
+| [getLineToNodeY()](#getLineToNodeY--) | Determina el tamaño del bloque horizontal, el área en la que cada una de sus formas debe encajar en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo. |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | Especifica el espacio horizontal mínimo entre conectores dinámicos y formas en la página de dibujo. |
+| [getPageShapeSplit()](#getPageShapeSplit--) | Indica si las formas en la página pueden dividirse automáticamente. |
+| [getPlaceDepth()](#getPlaceDepth--) | Especifica si las formas colocables se alejan cuando el usuario arrastra una forma colocable cerca de otra forma colocable en la página de dibujo. |
+| [getPlaceFlip()](#getPlaceFlip--) | Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio. |
+| [getPlaceStyle()](#getPlaceStyle--) | Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local. |
+| [getPlowCode()](#getPlowCode--) | Determina los conectores dinámicos a los que desea agregar saltos. |
+| [getResizePage()](#getResizePage--) | Especifica si se debe ampliar la página para encerrar el dibujo después de que el usuario seleccione Organizar Formas (menú Formas). |
+| [getRouteStyle()](#getRouteStyle--) | Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/pagelayout\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Determina la cantidad de espacio vertical entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Determina la cantidad de espacio vertical entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Determina el tamaño del bloque vertical, el área en la que cada una de sus formas debe encajar en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Determina la cantidad de espacio horizontal entre formas en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+Determina cuál forma es la principal al usar formas mediante manejadores de control. Este elemento establece el comportamiento de todas las formas en la página de dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+Especifica si las formas colocables se mueven y los conectores se redirigen alrededor de otras formas y conectores en la página de dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+Especifica si Microsoft Visio organiza las formas basándose en una cuadrícula interna de página cuando el usuario selecciona Organizar Formas (menú Forma).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+Especifica qué conectores dinámicos separar si se enrutan uno sobre otro.
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+Especifica qué conectores dinámicos alinear uno sobre otro si se enrutan sobre sí mismos.
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+Especifica el estilo de salto de línea para todos los conectores en la página de dibujo que no tienen un estilo de salto de línea local.
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+Especifica el tamaño de los saltos de línea en los segmentos horizontales de los conectores dinámicos en la página, como un porcentaje del valor del elemento LineToLineX (que especifica el espacio horizontal entre todos los conectores en la página de dibujo). El valor de este elemento varía de 0 a 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+Especifica el tamaño de los saltos de línea en los segmentos verticales de los conectores dinámicos en la página, como un porcentaje del valor del elemento LineToLineY (que especifica el espacio vertical entre todos los conectores en la página de dibujo). Este elemento puede contener un valor de 0 a 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local.
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+Especifica la apariencia predeterminada para todos los conectores en una página.
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+Especifica el espacio horizontal mínimo entre conectores dinámicos en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+Especifica el espacio vertical mínimo entre conectores dinámicos en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+Especifica el espacio vertical mínimo entre conectores dinámicos y formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Determina el tamaño del bloque horizontal, el área en la que cada una de sus formas debe encajar en la página de dibujo cuando utiliza Microsoft Visio para organizar las formas en la página de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local.
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+Especifica el espacio horizontal mínimo entre conectores dinámicos y formas en la página de dibujo.
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+Indica si las formas en la página pueden dividirse automáticamente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+Especifica si las formas colocables se alejan cuando el usuario arrastra una forma colocable cerca de otra forma colocable en la página de dibujo.
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Lay Out Shapes en Microsoft Visio. Se permiten los siguientes valores hexadecimales.
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+Determina los conectores dinámicos a los que desea agregar saltos.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+Especifica si se debe ampliar la página para encerrar el dibujo después de que el usuario seleccione Organizar Formas (menú Formas).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/pagelayout\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/spanish/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no ha aplicado una dirección de salto local.
+type: docs
+weight: 264
+url: /es/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no ha aplicado una dirección de salto local.
+type: docs
+weight: 265
+url: /es/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+Especifica la dirección de los saltos de línea en los segmentos horizontales de conectores dinámicos en la página de dibujo para los que no has aplicado una dirección de salto local.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | Predeterminado Arriba. |
+| [DOWN](#DOWN) | Abajo |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [UP](#UP) | Arriba. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+Predeterminado Arriba.
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Abajo
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Arriba.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/spanish/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los saltos de línea en conectores dinámicos verticales en la página de dibujo para los que no ha aplicado una dirección de salto local.
+type: docs
+weight: 266
+url: /es/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los saltos de línea en conectores dinámicos verticales en la página de dibujo para los que no ha aplicado una dirección de salto local.
+type: docs
+weight: 267
+url: /es/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+Especifica la dirección de los saltos de línea en los conectores dinámicos verticales en la página de dibujo para los que no has aplicado una dirección de salto local.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | Izquierda por defecto. |
+| [LEFT](#LEFT) | Izquierda. |
+| [RIGHT](#RIGHT) | Derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+Izquierda por defecto.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pageprops/_index.md
+++ b/spanish/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene celdas que controlan los atributos de la página, como el ancho, la altura y la escala de la página.
+type: docs
+weight: 268
+url: /es/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+Contiene celdas que controlan los atributos de la página, como el ancho, la altura y la escala de la página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDrawingResizeType()](#getDrawingResizeType--) | Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama. |
+| [getDrawingScale()](#getDrawingScale--) | Representa el valor de la unidad de dibujo en la escala de dibujo actual. |
+| [getDrawingScaleType()](#getDrawingScaleType--) | Especifica el tipo de escala de dibujo a usar para una página. |
+| [getDrawingSizeType()](#getDrawingSizeType--) | Especifica el tamaño de dibujo de una página. |
+| [getInhibitSnap()](#getInhibitSnap--) | Especifica si las formas en una página de primer plano se ajustan a otros objetos en la página y a formas en la página de fondo. |
+| [getPageHeight()](#getPageHeight--) | Especifica la altura de la página en unidades de dibujo. |
+| [getPageScale()](#getPageScale--) | Especifica el valor de la unidad de página predeterminada en la escala de dibujo actual. |
+| [getPageWidth()](#getPageWidth--) | Especifica el ancho de la página en unidades de dibujo. |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | Contiene un número que especifica el ángulo de dirección oblicua cuando se aplica el tipo de sombra de página predeterminado. |
+| [getShdwOffsetX()](#getShdwOffsetX--) | Especifica la distancia en unidades de página que la sombra paralela de una forma se desplaza horizontalmente respecto a la forma. |
+| [getShdwOffsetY()](#getShdwOffsetY--) | Especifica la distancia en unidades de página que la sombra paralela de una forma se desplaza verticalmente respecto a la forma. |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | Especifica el porcentaje para ampliar o reducir la sombra de una forma. |
+| [getShdwType()](#getShdwType--) | Indica el tipo de sombra predeterminado para una página. |
+| [getUIVisibility()](#getUIVisibility--) | Determina si el nombre de la página se muestra en la interfaz de usuario (UI). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, por favor consulta [getDel()](../../com.aspose.diagram/pageprops\\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+Determina si la página de dibujo se redimensiona automáticamente para ajustarse al diagrama.
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+Representa el valor de la unidad de dibujo en la escala de dibujo actual. La escala de dibujo para la página es la proporción de la unidad de página contenida en el elemento PageScale a la unidad de dibujo. Las unidades de este elemento determinan las unidades de longitud predeterminada (DL) para la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+Especifica el tipo de escala de dibujo a usar para una página.
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+Especifica el tamaño de dibujo de una página.
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+Especifica si las formas en una página de primer plano se ajustan a otros objetos en la página y a formas en la página de fondo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+Especifica la altura de la página en unidades de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+Especifica el valor de la unidad de página predeterminada en la escala de dibujo actual. La escala de dibujo para la página es la proporción de la unidad de página en el elemento PageScale a la unidad de dibujo mostrada en el elemento DrawingScale.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+Especifica el ancho de la página en unidades de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+Contiene un número que especifica el ángulo de dirección oblicua cuando se aplica el tipo de sombra de página predeterminado.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+Especifica la distancia en unidades de página que la sombra paralela de una forma se desplaza horizontalmente respecto a la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+Especifica la distancia en unidades de página que la sombra paralela de una forma se desplaza verticalmente respecto a la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+Especifica el porcentaje para ampliar o reducir la sombra de una forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+Indica el tipo de sombra predeterminado para una página.
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+Determina si el nombre de la página se muestra en la interfaz de usuario (UI). Un valor de uno indica que la página no es visible; un valor de cero indica que la página es visible.
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, por favor consulta [getDel()](../../com.aspose.diagram/pageprops\\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/spanish/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Información para un proceso de guardado de página.
+type: docs
+weight: 269
+url: /es/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+Información para un proceso de guardado de página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Recuento total de páginas. |
+| [getPageIndex()](#getPageIndex--) | Índice de página actual, basado en cero. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Recuento total de páginas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Índice de página actual, basado en cero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagesheet/_index.md
+++ b/spanish/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que definen la hoja de página para un elemento Página o Maestro.
+type: docs
+weight: 270
+url: /es/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+Contiene elementos que definen la hoja de página para un elemento Página o Maestro.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | Copia la pagesheet de un objeto fuente. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Contiene una colección de elementos Act. |
+| [getAnnotations()](#getAnnotations--) | Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una colección de elementos ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una colección de elementos Connection. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet del cual PageSheet hereda el formato de relleno. |
+| [getForeign()](#getForeign--) | Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una colección de elementos Hyperlink. |
+| [getLayers()](#getLayers--) | Contiene una colección de elementos Layer. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet del cual PageSheet hereda el formato de línea. |
+| [getPageLayout()](#getPageLayout--) | Contiene Diagram que controla la configuración de diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página. |
+| [getPageProps()](#getPageProps--) | Contiene Diagram que controla los atributos de la página, como el ancho, la altura y la escala. |
+| [getPrintProps()](#getPrintProps--) | Contiene elementos que controlan cómo se formatea (aparece) la página de dibujo en la página de la impresora. |
+| [getProps()](#getProps--) | Contiene una colección de elementos Prop. |
+| [getRulerGrid()](#getRulerGrid--) | Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página. |
+| [getScratchs()](#getScratchs--) | Contiene una colección de elementos Scratch. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Contiene una colección de elementos SmartTagDef. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet del cual PageSheet hereda el formato de texto. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificador único global) para el elemento. |
+| [getUsers()](#getUsers--) | Contiene una colección de elementos User. |
+| [getXForm()](#getXForm--) | Contiene elementos que especifican información general de posicionamiento sobre una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/pagesheet\\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/pagesheet\\#getLineStyle--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+Copia la pagesheet de un objeto fuente.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | hoja de página de origen. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Contiene una colección de elementos Act.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Contiene elementos que incluyen información sobre los comentarios insertados en una página del documento.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una colección de elementos ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una colección de elementos Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet del cual PageSheet hereda el formato de relleno.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento Microsoft Visio. También incluye elementos que especifican la distancia a la que la imagen del objeto se desplaza dentro de sus bordes.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una colección de elementos Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Contiene una colección de elementos Layer.
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet del cual PageSheet hereda el formato de línea.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Contiene Diagram que controla la configuración de diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+Contiene Diagram que controla los atributos de la página, como el ancho, la altura y la escala.
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+Contiene elementos que controlan cómo se formatea (aparece) la página de dibujo en la página de la impresora.
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una colección de elementos Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una colección de elementos Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Contiene una colección de elementos SmartTagDef.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet del cual PageSheet hereda el formato de texto.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificador único global) para el elemento.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una colección de elementos User.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Contiene elementos que especifican información general de posicionamiento sobre una forma.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/pagesheet\\#getFillStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/pagesheet\\#getLineStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagesize/_index.md
+++ b/spanish/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene información sobre el tamaño de página para las imágenes generadas.
+type: docs
+weight: 271
+url: /es/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+Contiene información sobre el tamaño de página para las imágenes generadas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | Inicializa una nueva instancia de esta clase que puede usarse para establecer el tamaño de página de las imágenes generadas. |
+| [PageSize(float width, float height)](#PageSize-float-float-) | Inicializa una nueva instancia de esta clase que puede usarse para establecer el tamaño de página de las imágenes generadas. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | la altura de página en puntos para las imágenes generadas. |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | el formato de tamaño de papel para las imágenes generadas. |
+| [getWidth()](#getWidth--) | el ancho de página en puntos para las imágenes generadas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--) |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | Para la descripción de esta propiedad, consulte [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--) |
+| [setWidth(float value)](#setWidth-float-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para establecer el tamaño de página de las imágenes generadas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| paperSizeFormat | int | Puede ser Aspose.Diagram.Saving.PaperSizeFormat. |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para establecer el tamaño de página de las imágenes generadas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| width | float | Ancho de página en puntos para las imágenes generadas. |
+| height | float | Altura de página en puntos para las imágenes generadas. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+la altura de página en puntos para las imágenes generadas. El valor debe ser > 0. Si Height está configurado,Width debe estar configurado también.
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+el formato de tamaño de papel para las imágenes generadas. Puede ser Aspose.Diagram.Saving.PaperSizeFormat.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+la anchura de página en puntos para las imágenes generadas. El valor debe ser > 0. Si Width está configurado, Height también debe estar configurado.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/spanish/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Información para una página inicia el proceso de guardado.
+type: docs
+weight: 272
+url: /es/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+Información para una página inicia el proceso de guardado.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Recuento total de páginas. |
+| [getPageIndex()](#getPageIndex--) | Índice de página actual, basado en cero. |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | un valor que indica si la página debe ser exportada. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | Para la descripción de esta propiedad, consulte [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Recuento total de páginas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Índice de página actual, basado en cero.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+un valor que indica si la página debe ser exportada. El valor predeterminado es true.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/spanish/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Enumeración para la selección del formato de tamaño de papel al guardar.
+type: docs
+weight: 273
+url: /es/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+Enumeración para la selección del formato de tamaño de papel al guardar.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [A_0](#A-0) | Formato de tamaño de papel A0 (841 mm x 1189 mm). |
+| [A_1](#A-1) | Formato de tamaño de papel A1 (594 mm x 841 mm). |
+| [A_2](#A-2) | Formato de tamaño de papel A2 (420 mm x 594 mm). |
+| [A_3](#A-3) | Formato de tamaño de papel A3 (297 mm x 420 mm). |
+| [A_4](#A-4) | Formato de tamaño de papel A4 (210 mm x 297 mm). |
+| [A_5](#A-5) | Formato de tamaño de papel A5 (148 mm x 210 mm). |
+| [A_6](#A-6) | Formato de tamaño de papel A6 (105 mm x 148 mm). |
+| [A_7](#A-7) | Formato de tamaño de papel A7 (74 mm x 105 mm). |
+| [B_0](#B-0) | Formato de tamaño de papel B0 (1000 mm x 1414 mm). |
+| [B_1](#B-1) | Formato de tamaño de papel B1 (707 mm x 1000 mm). |
+| [B_2](#B-2) | Formato de tamaño de papel B2 (500 mm x 707 mm). |
+| [B_3](#B-3) | Formato de tamaño de papel B3(353mm x 500mm). |
+| [B_4](#B-4) | Formato de tamaño de papel B4(250mm x 353mm). |
+| [B_5](#B-5) | Formato de tamaño de papel B5(176mm x 250mm). |
+| [B_6](#B-6) | Formato de tamaño de papel B6(125mm x 176mm). |
+| [B_7](#B-7) | Formato de tamaño de papel B7(88mm x 125mm). |
+| [COM_10](#COM-10) | Formato de tamaño de papel COM10(104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | Formato de tamaño de papel COM9(98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | Formato de tamaño de papel personalizado. |
+| [C_0](#C-0) | Formato de tamaño de papel C0(917mm x 1297mm). |
+| [C_1](#C-1) | Formato de tamaño de papel C1(648mm x 917mm). |
+| [C_2](#C-2) | Formato de tamaño de papel C2(458mm x 648mm). |
+| [C_3](#C-3) | Formato de tamaño de papel C3(324mm x 458mm). |
+| [C_4](#C-4) | Formato de tamaño de papel C4(229mm x 324mm). |
+| [C_5](#C-5) | Formato de tamaño de papel C5(162mm x 229mm). |
+| [C_6](#C-6) | Formato de tamaño de papel C6(114mm x 162mm). |
+| [C_7](#C-7) | Formato de tamaño de papel C7(81mm x 114mm). |
+| [DL](#DL) | Formato de tamaño de papel DL(110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Formato de tamaño de papel Executive(184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Formato de tamaño de papel Legal(215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Formato de tamaño de papel Legal13(215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Formato de tamaño de papel Letter(215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Formato de tamaño de papel Monarch(98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Formato de tamaño de papel Tabloid(279.4mm x 431.8mm). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+Formato de tamaño de papel A0 (841 mm x 1189 mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+Formato de tamaño de papel A1 (594 mm x 841 mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+Formato de tamaño de papel A2 (420 mm x 594 mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+Formato de tamaño de papel A3 (297 mm x 420 mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+Formato de tamaño de papel A4 (210 mm x 297 mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+Formato de tamaño de papel A5 (148 mm x 210 mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+Formato de tamaño de papel A6 (105 mm x 148 mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+Formato de tamaño de papel A7 (74 mm x 105 mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+Formato de tamaño de papel B0 (1000 mm x 1414 mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+Formato de tamaño de papel B1 (707 mm x 1000 mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+Formato de tamaño de papel B2 (500 mm x 707 mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+Formato de tamaño de papel B3(353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+Formato de tamaño de papel B4(250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+Formato de tamaño de papel B5(176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+Formato de tamaño de papel B6(125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+Formato de tamaño de papel B7(88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+Formato de tamaño de papel COM10(104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+Formato de tamaño de papel COM9(98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Formato de tamaño de papel personalizado.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+Formato de tamaño de papel C0(917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+Formato de tamaño de papel C1(648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+Formato de tamaño de papel C2(458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+Formato de tamaño de papel C3(324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+Formato de tamaño de papel C4(229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+Formato de tamaño de papel C5(162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+Formato de tamaño de papel C6(114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+Formato de tamaño de papel C7(81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Formato de tamaño de papel DL(110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Formato de tamaño de papel Executive(184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Formato de tamaño de papel Legal(215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Formato de tamaño de papel Legal13(215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Formato de tamaño de papel Letter(215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Formato de tamaño de papel Monarch(98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Formato de tamaño de papel Tabloid(279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/para/_index.md
+++ b/spanish/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene los elementos de formato de párrafo para el texto de las formas, como sangrías, interlineado, viñetas y alineación horizontal de los párrafos.
+type: docs
+weight: 274
+url: /es/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+Contiene los elementos de formato de párrafo para el texto de la forma, como sangrías, interlineado, viñetas y alineación horizontal de los párrafos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Para()](#Para--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | Determina el estilo de viñeta. |
+| [getBulletFont()](#getBulletFont--) | Representa el número de la fuente utilizada para formatear el texto cuando se especifica una cadena de viñeta personalizada y el valor en el elemento Bullet no es cero. |
+| [getBulletFontSize()](#getBulletFontSize--) | Especifica el tamaño de una viñeta. |
+| [getBulletStr()](#getBulletStr--) | "Utilizado para crear un estilo de viñeta personalizado. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getFlags()](#getFlags--) | Indica si la dirección del texto es de izquierda a derecha o de derecha a izquierda. |
+| [getHorzAlign()](#getHorzAlign--) | Especifica la alineación horizontal del texto en el bloque de texto de la forma. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getIndFirst()](#getIndFirst--) | Especifica la distancia a la que la primera línea de cada párrafo en el bloque de texto de la forma está sangrada desde la sangría izquierda del párrafo. |
+| [getIndLeft()](#getIndLeft--) | Especifica la distancia a la que todas las líneas de texto en un párrafo están sangradas desde el margen izquierdo del bloque de texto. |
+| [getIndRight()](#getIndRight--) | Especifica la distancia a la que todas las líneas de texto en un párrafo están sangradas desde el margen derecho del bloque de texto. |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | Especifica si la fuente de viñeta debe localizarse (traducirse a otro idioma). |
+| [getSpAfter()](#getSpAfter--) | Especifica la cantidad de espacio insertado después de cada párrafo en el bloque de texto de la forma. |
+| [getSpBefore()](#getSpBefore--) | Especifica la cantidad de espacio insertado antes de cada párrafo en el bloque de texto de la forma. |
+| [getSpLine()](#getSpLine--) | Especifica la distancia entre una línea de texto y la siguiente, donde el 100 % es la altura de una línea de texto. |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | Representa la distancia entre la primera línea del párrafo y la viñeta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | Para la descripción de esta propiedad, consulte [getBullet()](../../com.aspose.diagram/para\#getBullet--) |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | Para la descripción de esta propiedad, consulte [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/para\#getDel--) |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getFlags()](../../com.aspose.diagram/para\#getFlags--) |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | Para la descripción de esta propiedad, consulte [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/para\#getIX--) |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getIndRight()](../../com.aspose.diagram/para\#getIndRight--) |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | Para la descripción de esta propiedad, consulte [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getSpLine()](../../com.aspose.diagram/para\#getSpLine--) |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+Determina el estilo de viñeta.
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+Representa el número de la fuente utilizada para formatear el texto cuando se especifica una cadena de viñeta personalizada y el valor en el elemento Bullet no es cero.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+Especifica el tamaño de una viñeta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+"Utilizado para crear un estilo de viñeta personalizado. Introduzca el estilo como una cadena (entre comillas). Por ejemplo, podría introducir la cadena, ""ooo."""
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+Indica si la dirección del texto es de izquierda a derecha o de derecha a izquierda.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+Especifica la alineación horizontal del texto en el bloque de texto de la forma.
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+Especifica la distancia a la que la primera línea de cada párrafo en el bloque de texto de la forma está sangrada desde la sangría izquierda del párrafo. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, la sangría de la primera línea permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+Especifica la distancia a la que todas las líneas de texto en un párrafo están sangradas desde el margen izquierdo del bloque de texto. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, la sangría izquierda permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+Especifica la distancia a la que todas las líneas de texto en un párrafo están sangradas desde el margen derecho del bloque de texto. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, la sangría derecha permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+Especifica si la fuente de viñeta debe localizarse (traducirse a otro idioma).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+Especifica la cantidad de espacio insertado después de cada párrafo en el bloque de texto de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+Especifica la cantidad de espacio insertado antes de cada párrafo en el bloque de texto de la forma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+Especifica la distancia entre una línea de texto y la siguiente, donde el 100 % es la altura de una línea de texto.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+Representa la distancia entre la primera línea del párrafo y la viñeta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBullet()](../../com.aspose.diagram/para\#getBullet--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/para\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFlags()](../../com.aspose.diagram/para\#getFlags--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/para\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/paracollection/_index.md
+++ b/spanish/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de párrafos.
+type: docs
+weight: 275
+url: /es/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+Colección de párrafos.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | Agregue el objeto Para a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getPara(int IX)](#getPara-int-) | Obtiene el elemento en el índice especificado IX. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | Elimine el objeto Para de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+Agregue el objeto Para a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+Obtiene el elemento en el índice especificado IX. Devuelve Null si el elemento no existe.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+Elimine el objeto Para de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el nivel de cumplimiento PDF para el archivo de salida.
+type: docs
+weight: 276
+url: /es/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+Especifica el nivel de cumplimiento PDF para el archivo de salida.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [PDF_15](#PDF-15) | El archivo de salida será compatible con PDF 1.5. |
+| [PDF_A_1_A](#PDF-A-1-A) | El archivo de salida será compatible con PDF/A-1a. |
+| [PDF_A_1_B](#PDF-A-1-B) | El archivo de salida será compatible con PDF/A-1b. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+El archivo de salida será compatible con PDF 1.5.
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+El archivo de salida será compatible con PDF/A-1a.
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+El archivo de salida será compatible con PDF/A-1b.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el algoritmo de hash digital utilizado por la firma digital.
+type: docs
+weight: 277
+url: /es/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+Especifica el algoritmo de hash digital utilizado por la firma digital.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [MD_5](#MD-5) | Algoritmo de hash SHA-1. |
+| [SHA_1](#SHA-1) | Algoritmo de hash SHA-1. |
+| [SHA_256](#SHA-256) | Algoritmo de hash SHA-256. |
+| [SHA_384](#SHA-384) | Algoritmo de hash SHA-384. |
+| [SHA_512](#SHA-512) | Algoritmo de hash SHA-512. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+Algoritmo de hash SHA-1.
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+Algoritmo de hash SHA-1.
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+Algoritmo de hash SHA-256.
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+Algoritmo de hash SHA-384.
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+Algoritmo de hash SHA-512.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el algoritmo de cifrado a usar para encriptar un documento PDF.
+type: docs
+weight: 278
+url: /es/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+Especifica el algoritmo de cifrado a usar para encriptar un documento PDF.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | Cifrado RC4, longitud de clave de 128 bits. |
+| [RC_4_40](#RC-4-40) | Cifrado RC4, longitud de clave de 40 bits. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+Cifrado RC4, longitud de clave de 128 bits.
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+Cifrado RC4, longitud de clave de 40 bits.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene detalles para un cifrado PDF.
+type: docs
+weight: 279
+url: /es/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+Contiene detalles para un cifrado PDF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | Ctor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | el modo de cifrado. |
+| [getOwnerPassword()](#getOwnerPassword--) | la contraseña Owner. |
+| [getPermissions()](#getPermissions--) | los permisos. |
+| [getUserPassword()](#getUserPassword--) | la contraseña User. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | Para la descripción de esta propiedad, consulte [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | Para la descripción de esta propiedad, consulte [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) |
+| [setPermissions(int value)](#setPermissions-int-) | Para la descripción de esta propiedad, consulte [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | Para la descripción de esta propiedad, consulte [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+Ctor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+el modo de cifrado.
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+la contraseña del propietario. Abrir el documento con la contraseña de propietario correcta (asumiendo que no sea la misma que la contraseña de usuario) permite acceso total (de propietario) al documento. Este acceso ilimitado incluye la capacidad de cambiar las contraseñas del documento\\u9225\\u6a9a y los permisos de acceso.
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+los permisos.
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+la contraseña de usuario. Abrir el documento con la contraseña de usuario correcta (o abrir un documento que no tenga contraseña de usuario) permite realizar operaciones adicionales según los permisos de acceso de usuario especificados en el diccionario de cifrado del documento\\u9225\\u6a9a.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica los permisos de usuario para el documento PDF.
+type: docs
+weight: 280
+url: /es/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+Especifica los permisos de usuario para el documento PDF.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | Permite todas las operaciones en el documento PDF. |
+| [CONTENT_COPY](#CONTENT-COPY) | Permite copiar o extraer de otro modo texto y gráficos del documento, incluida la extracción con fines de accesibilidad. |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | Permite extraer texto y gráficos en apoyo a la accesibilidad para usuarios con discapacidad o para otros propósitos. |
+| [DISALLOW_ALL](#DISALLOW-ALL) | No permite ninguna operación en el documento PDF. |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | Permite ensamblar el documento: insertar, rotar o eliminar páginas y crear elementos de navegación como marcadores o imágenes en miniatura. |
+| [FILL_IN](#FILL-IN) | Permite rellenar formularios y firmar el documento. |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | Permite imprimir el documento a la mayor resolución posible. Cuando se usa cifrado RC4 de 40 bits, esta opción se ignora y la impresión de alta resolución está permitida cuando la opción Printing está activada. |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | Permite agregar o modificar anotaciones de texto. |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | Permite modificar el contenido del documento\u9225\u6a9a. |
+| [PRINTING](#PRINTING) | Permite imprimir el documento. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+Permite todas las operaciones en el documento PDF.
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+Permite copiar o extraer de otro modo texto y gráficos del documento, incluida la extracción con fines de accesibilidad.
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+Permite extraer texto y gráficos en apoyo a la accesibilidad para usuarios con discapacidad o para otros propósitos. Al usar cifrado RC4 de 40 bits, esta opción se ignora y la accesibilidad está permitida siempre que ContentCopy esté configurado.
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+No permite ninguna operación en el documento PDF. Este es el valor predeterminado.
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+Permite ensamblar el documento: insertar, rotar o eliminar páginas y crear elementos de navegación como marcadores o imágenes en miniatura. Al usar cifrado RC4 de 40 bits, esta opción se ignora y el ensamblado del documento está permitido cuando ModifyContents está configurado.
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+Permite rellenar formularios y firmar el documento. Al usar cifrado RC4 de 40 bits, esta opción se ignora y el relleno de formularios está permitido siempre que ModifyAnnotations esté configurado.
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+Permite imprimir el documento a la mayor resolución posible. Cuando se usa cifrado RC4 de 40 bits, esta opción se ignora y la impresión de alta resolución está permitida cuando la opción Printing está activada.
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+Permite agregar o modificar anotaciones de texto. Al usar cifrado RC4 de 40 bits, esta opción también permite rellenar campos de formulario.
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+Permite modificar el contenido del documento\u9225\u6a9a.
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+Permite imprimir el documento.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagramas a PDF.
+type: docs
+weight: 281
+url: /es/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagramas a PDF.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | Nivel de conformidad deseado para el documento PDF generado. |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | un detalle de cifrado. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Define si es necesario exportar la página oculta o no. |
+| [getHorizontalResolution()](#getHorizontalResolution--) | la resolución horizontal para imágenes generadas, en puntos por pulgada. |
+| [getJpegQuality()](#getJpegQuality--) | Especifica la calidad de la compresión JPEG para imágenes (si se utiliza compresión JPEG). |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar en PDF. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la primera página a renderizar. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | Controlar/Indicar el progreso del proceso de guardado de la página. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si todas las páginas se guardarán en una imagen o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getSplitMultiPages()](#getSplitMultiPages--) | Define si se divide el diagrama en varias páginas según la configuración de la página. |
+| [getTextCompression()](#getTextCompression--) | Especifica el tipo de compresión que se utilizará para todas las transmisiones de contenido, excepto imágenes. |
+| [getVerticalResolution()](#getVerticalResolution--) | la resolución vertical para imágenes generadas, en puntos por pulgada. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | Para la descripción de esta propiedad, consulte [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | Para la descripción de esta propiedad, consulte [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | Para la descripción de esta propiedad, consulte [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | Para la descripción de esta propiedad, consulte [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | Para la descripción de esta propiedad, consulte [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | Para la descripción de esta propiedad, consulte [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) |
+| [setTextCompression(int value)](#setTextCompression-int-) | Para la descripción de esta propiedad, consulte [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | Para la descripción de esta propiedad, consulte [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+Nivel de conformidad deseado para el documento PDF generado. El valor predeterminado es PdfCompliance.PDF\_15.
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+un detalle de cifrado. Si no se establece, no se realizará ningún cifrado.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Define si es necesario exportar la página oculta o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+la resolución horizontal para imágenes generadas, en puntos por pulgada. Se aplica al método de generación de imágenes, excepto a imágenes en formato Emf. El valor predeterminado es 96.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Especifica la calidad de la compresión JPEG para imágenes (si se utiliza compresión JPEG). El valor predeterminado es 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar en PDF. El valor predeterminado es MaxValue, lo que significa que se renderizarán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la primera página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+Controlar/Indicar el progreso del proceso de guardado de la página.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si todas las páginas se guardarán en la imagen o solo el primer plano. Si es true, se renderizan solo las páginas de primer plano (con fondo si está presente). Si es false, se renderizan las páginas de primer plano (con fondo si está presente) y luego esas páginas de fondo vacías. Solo puede devolver true cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. Solo puede ser Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+Define si se divide el diagrama en varias páginas según la configuración de la página. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+Especifica el tipo de compresión que se utilizará para todas las secuencias de contenido, excepto imágenes. El valor predeterminado es PdfTextCompression.FLATE.
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+La resolución vertical para las imágenes generadas, en puntos por pulgada. Se aplica al método de generación de imágenes, excepto a imágenes en formato Emf. El valor predeterminado es 96.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/spanish/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica un tipo de compresión aplicado a todo el contenido del archivo PDF, excepto a las imágenes.
+type: docs
+weight: 282
+url: /es/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+Especifica un tipo de compresión aplicado a todo el contenido del archivo PDF, excepto a las imágenes.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FLATE](#FLATE) | Compresión Flate (ZIP). |
+| [NONE](#NONE) | Sin compresión. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Compresión Flate (ZIP).
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Sin compresión.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la posición del pin para la forma.
+type: docs
+weight: 283
+url: /es/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+Especifica la posición del pin para la forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | bottom-center |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | inferior-izquierda. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | inferior-derecha |
+| [CENTER_CENTER](#CENTER-CENTER) | centro-centro |
+| [CENTER_LEFT](#CENTER-LEFT) | centro-izquierda. |
+| [CENTER_RIGHT](#CENTER-RIGHT) | centro-derecha |
+| [TOP_CENTER](#TOP-CENTER) | superior-centro |
+| [TOP_LEFT](#TOP-LEFT) | izquierda-superior |
+| [TOP_RIGHT](#TOP-RIGHT) | superior-derecha |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+bottom-center
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+inferior-izquierda.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+inferior-derecha
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+centro-centro
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+centro-izquierda.
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+centro-derecha
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+superior-centro
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+izquierda-superior
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+superior-derecha
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/spanish/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo se desplazan los píxeles durante el renderizado.
+type: docs
+weight: 284
+url: /es/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+Especifica cómo se desplazan los píxeles durante el renderizado.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | Especifica el modo predeterminado. |
+| [HALF](#HALF) | Especifica que los píxeles se desplazan -.5 unidades, tanto horizontal como verticalmente, para antialiasing de alta velocidad. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Especifica renderizado de alta calidad y baja velocidad. |
+| [HIGH_SPEED](#HIGH-SPEED) | Especifica renderizado de alta velocidad y baja calidad. |
+| [INVALID](#INVALID) | Especifica un modo no válido. |
+| [NONE](#NONE) | Especifica sin desplazamiento de píxeles. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Especifica el modo predeterminado.
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+Especifica que los píxeles se desplazan -.5 unidades, tanto horizontal como verticalmente, para antialiasing de alta velocidad.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Especifica renderizado de alta calidad y baja velocidad.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Especifica renderizado de alta velocidad y baja calidad.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Especifica un modo no válido.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Especifica sin desplazamiento de píxeles.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placedepth/_index.md
+++ b/spanish/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+type: docs
+weight: 285
+url: /es/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/placedepth\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/placedepth\\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+type: docs
+weight: 286
+url: /es/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+Para un dibujo que se dispone automáticamente, especifica el método mediante el cual se analiza el dibujo antes de crear el diseño y determina el tipo de diseño.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEEP](#DEEP) | Profundo. |
+| [MEDIUM](#MEDIUM) | Medio. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [SHALLOW](#SHALLOW) | Superficial. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+Profundo.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Medio.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+Superficial.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placeflip/_index.md
+++ b/spanish/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio.
+type: docs
+weight: 287
+url: /es/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Lay Out Shapes en Microsoft Visio. Se permiten los siguientes valores hexadecimales.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Lay Out Shapes en Microsoft Visio. Se permiten los siguientes valores hexadecimales.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Organizar Formas en Microsoft Visio.
+type: docs
+weight: 288
+url: /es/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Especifica cómo las formas colocables se voltean y/o rotan en una página cuando las formas se disponen usando el comando Lay Out Shapes en Microsoft Visio. Se permiten los siguientes valores hexadecimales.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | Predeterminado. |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | Voltear en incrementos de 90 grados. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Voltear horizontalmente. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Voltear verticalmente. |
+| [NO_FLIP](#NO-FLIP) | Sin volteo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+Predeterminado. No voltear.
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+Voltear en incrementos de 90 grados.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Voltear horizontalmente.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Voltear verticalmente.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Sin volteo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placestyle/_index.md
+++ b/spanish/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo se colocan las formas en la página cuando se organizan las formas al seleccionar el menú Lay Out Shapes Shape.
+type: docs
+weight: 289
+url: /es/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma). |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/placestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/placestyle\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo se colocan las formas en la página cuando se organizan las formas al seleccionar el menú Lay Out Shapes Shape.
+type: docs
+weight: 290
+url: /es/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+Especifica cómo se colocan las formas en la página cuando se disponen y el usuario selecciona Organizar Formas (menú Forma).
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | De abajo a arriba. |
+| [CIRCULAR](#CIRCULAR) | Circular. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | Predeterminado. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | De izquierda a derecha. |
+| [RADIAL](#RADIAL) | Radial. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | De derecha a izquierda. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | De arriba a abajo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+De abajo a arriba.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Circular.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+Predeterminado. Radial.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+De izquierda a derecha.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+De derecha a izquierda.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+De arriba a abajo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/polylineto/_index.md
+++ b/spanish/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del último punto de una polilínea y la fórmula de la polilínea.
+type: docs
+weight: 291
+url: /es/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+Contiene las coordenadas x e y del último punto de una polilínea y la fórmula de la polilínea. Las coordenadas se especifican en los elementos X y Y, y la fórmula se especifica en el elemento A.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | Crea una instancia de la clase [PolylineTo](../../com.aspose.diagram/polylineto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La fórmula de la polilínea. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de una polilínea. |
+| [getY()](#getY--) | La coordenada y del vértice final de una polilínea. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/polylineto\#getA--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/polylineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/polylineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/polylineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/polylineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+Crea una instancia de la clase [PolylineTo](../../com.aspose.diagram/polylineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+La fórmula de la polilínea.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de una polilínea.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de una polilínea.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/polylineto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/polylineto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/polylineto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/polylineto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/polylineto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección PolylineTo.
+type: docs
+weight: 292
+url: /es/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+Colección PolylineTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pos/_index.md
+++ b/spanish/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la posición del texto de la forma respecto a la línea base.
+type: docs
+weight: 293
+url: /es/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+Especifica la posición del texto de la forma respecto a la línea base.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la posición del texto de la forma respecto a la línea base. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/pos\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pos\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la posición del texto de la forma respecto a la línea base.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/pos\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/pos\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/posvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la posición del texto de la forma respecto a la línea base.
+type: docs
+weight: 294
+url: /es/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+Especifica la posición del texto de la forma respecto a la línea base.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | Posición normal. |
+| [SUBSCRIPT](#SUBSCRIPT) | Subíndice. |
+| [SUPERSCRIPT](#SUPERSCRIPT) | Superíndice. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+Posición normal.
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+Subíndice.
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+Superíndice.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/pp/_index.md
+++ b/spanish/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el comienzo de una ejecución de propiedades de párrafo.
+type: docs
+weight: 295
+url: /es/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+Especifica el comienzo de una secuencia de propiedades de párrafo. La secuencia se define hasta el final del texto o hasta el siguiente
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int | El índice del elemento Para que especifica el formato aplicado a esta secuencia. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/spanish/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa diferentes métodos algorítmicos para establecer todas las propiedades de la cámara, incluida la posición.
+type: docs
+weight: 296
+url: /es/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+Representa diferentes métodos algorítmicos para establecer todas las propiedades de la cámara, incluida la posición.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Se usa para establecer la propiedad de color de los estilos de tema de Shape
+type: docs
+weight: 297
+url: /es/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Se utiliza para establecer la propiedad de color del estilo de tema de Shape.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Color1. |
+| [COLOR_2](#COLOR-2) | Color2. |
+| [COLOR_3](#COLOR-3) | Color3. |
+| [COLOR_4](#COLOR-4) | Color4. |
+| [COLOR_5](#COLOR-5) | Color5. |
+| [COLOR_6](#COLOR-6) | Color6. |
+| [COLOR_7](#COLOR-7) | Color7. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Color1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Color2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Color3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Color4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Color5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Color6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Color7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el valor del estilo rápido del tema.
+type: docs
+weight: 298
+url: /es/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+Especifica el valor del estilo rápido del tema.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/spanish/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de sombra predefinido.
+type: docs
+weight: 299
+url: /es/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+Representa el tipo de sombra predefinido.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BELOW](#BELOW) | Sombra externa abajo. |
+| [CUSTOM](#CUSTOM) | Sombra personalizada. |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | Sombra interna en la parte inferior. |
+| [INSIDE_CENTER](#INSIDE-CENTER) | Sombra interna en el centro. |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | Sombra interna en diagonal inferior izquierda. |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | Sombra interna en diagonal inferior derecha. |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | Sombra interna en diagonal superior izquierda. |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | Sombra interna en diagonal superior derecha. |
+| [INSIDE_LEFT](#INSIDE-LEFT) | Sombra interna a la izquierda. |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | Sombra interna a la derecha. |
+| [INSIDE_TOP](#INSIDE-TOP) | Sombra interna en la parte superior. |
+| [NO_SHADOW](#NO-SHADOW) | Sin sombra. |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | Desplazamiento de sombra externa inferior. |
+| [OFFSET_CENTER](#OFFSET-CENTER) | Desplazamiento de sombra externa centro. |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | Desplazamiento de sombra externa diagonal inferior izquierda. |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | Desplazamiento de sombra externa diagonal inferior derecha. |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | Desplazamiento de sombra externa diagonal superior izquierda. |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | Desplazamiento de sombra externa diagonal superior derecha. |
+| [OFFSET_LEFT](#OFFSET-LEFT) | Desplazamiento de sombra externa a la izquierda. |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | Desplazamiento de sombra externa a la derecha. |
+| [OFFSET_TOP](#OFFSET-TOP) | Desplazamiento de sombra externa superior. |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | Perspectiva de sombra externa diagonal inferior izquierda. |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | Perspectiva de sombra externa diagonal inferior derecha. |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | Perspectiva de sombra externa diagonal superior izquierda. |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | Perspectiva de sombra externa diagonal superior derecha. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+Sombra externa abajo.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Sombra personalizada.
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+Sombra interna en la parte inferior.
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+Sombra interna en el centro.
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Sombra interna en diagonal inferior izquierda.
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Sombra interna en diagonal inferior derecha.
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+Sombra interna en diagonal superior izquierda.
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+Sombra interna en diagonal superior derecha.
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+Sombra interna a la izquierda.
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+Sombra interna a la derecha.
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+Sombra interna en la parte superior.
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+Sin sombra.
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+Desplazamiento de sombra externa inferior.
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+Desplazamiento de sombra externa centro.
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Desplazamiento de sombra externa diagonal inferior izquierda.
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Desplazamiento de sombra externa diagonal inferior derecha.
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+Desplazamiento de sombra externa diagonal superior izquierda.
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+Desplazamiento de sombra externa diagonal superior derecha.
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+Desplazamiento de sombra externa a la izquierda.
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+Desplazamiento de sombra externa a la derecha.
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+Desplazamiento de sombra externa superior.
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+Perspectiva de sombra externa diagonal inferior izquierda.
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+Perspectiva de sombra externa diagonal inferior derecha.
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+Perspectiva de sombra externa diagonal superior izquierda.
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+Perspectiva de sombra externa diagonal superior derecha.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Se utiliza para establecer la propiedad de estilo de tema de Shape.
+type: docs
+weight: 300
+url: /es/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Se utiliza para establecer la propiedad de estilo de tema de Shape.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el valor del tema.
+type: docs
+weight: 301
+url: /es/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+Especifica el valor del tema.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | Burbuja |
+| [CLOUDS](#CLOUDS) | Nubes |
+| [DAYBREAK](#DAYBREAK) | Amanecer |
+| [FACET](#FACET) | Faceta |
+| [GEMSTONE](#GEMSTONE) | Gema |
+| [INTEGRAL](#INTEGRAL) | Integral |
+| [ION](#ION) | Ion |
+| [LINEAR](#LINEAR) | Linear |
+| [LINES](#LINES) | Lines |
+| [MARKER](#MARKER) | Marker |
+| [NO_THEME](#NO-THEME) | NoTheme |
+| [OFFICE](#OFFICE) | Office |
+| [ORGANIC](#ORGANIC) | Organic |
+| [PARALLEL](#PARALLEL) | Parallel |
+| [PEN](#PEN) | Pen |
+| [PENCIL](#PENCIL) | Pencil |
+| [PROMINENCE](#PROMINENCE) | Prominence |
+| [RADIANCE](#RADIANCE) | Radiance |
+| [RETROSPECT](#RETROSPECT) | Retrospect |
+| [SEQUENCE](#SEQUENCE) | Sequence |
+| [SHADE](#SHADE) | Shade |
+| [SIMPLE](#SIMPLE) | Simple |
+| [SLICE](#SLICE) | Slice |
+| [SMOKE](#SMOKE) | Smoke |
+| [WHISP](#WHISP) | Whisp |
+| [WHITE_BOARD](#WHITE-BOARD) | WhiteBoard |
+| [ZEPHYR](#ZEPHYR) | Zephyr |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+Burbuja
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+Nubes
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+Amanecer
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+Faceta
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+Gema
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integral
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ion
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Lines
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marker
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NoTheme
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Office
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organic
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallel
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Pen
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Pencil
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Prominence
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Radiance
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospect
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequence
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Shade
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Slice
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Smoke
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Whisp
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+WhiteBoard
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zephyr
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el valor de la variante del tema.
+type: docs
+weight: 302
+url: /es/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+Especifica el valor de la variante del tema.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/previewscope/_index.md
+++ b/spanish/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+type: docs
+weight: 303
+url: /es/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/previewscope\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/previewscope\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+type: docs
+weight: 304
+url: /es/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+Especifica si el documento incluye una vista previa y, de ser así, si la vista previa muestra solo la primera página o todas las páginas del documento.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | Todas las páginas. |
+| [FIRST_PAGE](#FIRST-PAGE) | Primera página. |
+| [NO_PREVIEW](#NO-PREVIEW) | Sin vista previa. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+Todas las páginas.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+Primera página.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+Sin vista previa.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/spanish/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si la página se imprime en orientación vertical u horizontal.
+type: docs
+weight: 305
+url: /es/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+Determina si la página se imprime en orientación vertical u horizontal.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina si la página se imprime en orientación vertical u horizontal. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina si la página se imprime en orientación vertical u horizontal.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina si la página se imprime en orientación vertical u horizontal.
+type: docs
+weight: 306
+url: /es/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+Determina si la página se imprime en orientación vertical u horizontal.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | Horizontal. |
+| [PORTRAIT](#PORTRAIT) | Vertical. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Igual que la impresora. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+Horizontal.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+Vertical.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Igual que la impresora.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/printprops/_index.md
+++ b/spanish/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan cómo la página de dibujo formateada aparece en la página de la impresora.
+type: docs
+weight: 307
+url: /es/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+Contiene elementos que controlan cómo se formatea (aparece) la página de dibujo en la página de la impresora.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | Determina si la página de dibujo está centrada horizontalmente en la página impresa. |
+| [getCenterY()](#getCenterY--) | Determina si la página de dibujo está centrada verticalmente en la página impresa. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getOnPage()](#getOnPage--) | Indica si el dibujo se imprime en un número específico de páginas de la impresora. |
+| [getPageBottomMargin()](#getPageBottomMargin--) | Especifica el margen en la parte inferior de la página impresa. |
+| [getPageLeftMargin()](#getPageLeftMargin--) | Especifica el margen en el lado izquierdo de la página impresa. |
+| [getPageRightMargin()](#getPageRightMargin--) | Especifica el margen en el lado derecho de la página impresa. |
+| [getPageTopMargin()](#getPageTopMargin--) | Especifica el margen en la parte superior de la página de la impresora. |
+| [getPagesX()](#getPagesX--) | Determina el número de páginas de la impresora en las que ajustar la página de dibujo horizontalmente. |
+| [getPagesY()](#getPagesY--) | Determina el número de páginas de la impresora en las que ajustar la página de dibujo verticalmente. |
+| [getPaperKind()](#getPaperKind--) | Especifica el tipo de papel en el que imprimir la página. |
+| [getPaperSource()](#getPaperSource--) | Determina la fuente de papel para la página. |
+| [getPrintGrid()](#getPrintGrid--) | Especifica si se debe imprimir la cuadrícula al imprimir una página de documento. |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | Determina si la página se imprime en orientación vertical u horizontal. |
+| [getScaleX()](#getScaleX--) | Especifica el porcentaje de ampliación de la página de dibujo en la página de la impresora, en la dirección x (horizontal). |
+| [getScaleY()](#getScaleY--) | Especifica el porcentaje de ampliación de la página de dibujo en la página de la impresora, en la dirección y (vertical). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/printprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+Determina si la página de dibujo está centrada horizontalmente en la página impresa.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+Determina si la página de dibujo está centrada verticalmente en la página impresa.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+Indica si el dibujo se imprime en un número específico de páginas de la impresora.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+Especifica el margen en la parte inferior de la página impresa.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+Especifica el margen en el lado izquierdo de la página impresa.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+Especifica el margen en el lado derecho de la página impresa.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+Especifica el margen en la parte superior de la página de la impresora.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+Determina el número de páginas de la impresora en las que ajustar la página de dibujo horizontalmente.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+Determina el número de páginas de la impresora en las que ajustar la página de dibujo verticalmente.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+Especifica el tipo de papel en el que imprimir la página.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+Determina la fuente de papel para la página.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+Especifica si se debe imprimir la cuadrícula al imprimir una página de documento.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+Determina si la página se imprime en orientación vertical u horizontal.
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+Especifica el porcentaje de ampliación de la página de dibujo en la página de la impresora, en la dirección x (horizontal).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+Especifica el porcentaje de ampliación de la página de dibujo en la página de la impresora, en la dirección y (vertical).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/printprops\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al imprimir el diagrama.
+type: docs
+weight: 308
+url: /es/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+Permite especificar opciones adicionales al imprimir el diagrama.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | Inicializa una nueva instancia de esta clase |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar al guardar en un archivo multipágina. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si se imprimirán todas las páginas o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar al guardar en un archivo multipágina. El valor predeterminado es MaxValue, lo que significa que se imprimirán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si se imprimirán todas las páginas o solo el primer plano. Si es verdadero, se imprimen solo las páginas del primer plano (con fondo si está presente). Si es falso, se imprimen las páginas del primer plano (con fondo si está presente) y luego las páginas de fondo vacías. Solo puede devolver verdadero cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/prop/_index.md
+++ b/spanish/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: Propiedad
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos para definir propiedades personalizadas y elementos para asociar datos con una forma.
+type: docs
+weight: 309
+url: /es/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+Contiene elementos para definir propiedades personalizadas y elementos para asociar datos con una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Prop()](#Prop--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getFormat()](#getFormat--) | El elemento de formato especifica el formato de una propiedad personalizada que es una cadena, lista fija, número, lista variable, fecha u hora, duración o moneda. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getInvisible()](#getInvisible--) | El elemento invisible especifica si la propiedad personalizada es visible en el cuadro de diálogo Propiedades personalizadas en Microsoft Visio. |
+| [getLabel()](#getLabel--) | Especifica la etiqueta que aparece a los usuarios en el cuadro de diálogo Propiedades personalizadas. |
+| [getLangID()](#getLangID--) | Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPrompt()](#getPrompt--) | El elemento de solicitud especifica el texto descriptivo o instructivo que aparece a los usuarios en el cuadro de diálogo Propiedades personalizadas cuando se selecciona la propiedad. |
+| [getSortKey()](#getSortKey--) | Especifica una clave que determina el orden en que se enumeran las propiedades personalizadas en la interfaz de usuario de la aplicación. |
+| [getType()](#getType--) | Tipo especifica un tipo de datos para el valor de la propiedad personalizada. |
+| [getValue()](#getValue--) | Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento. |
+| [getVerify()](#getVerify--) | Especifica si se solicita al usuario que introduzca información de la propiedad personalizada para una forma cuando se crea una instancia o la forma se duplica o copia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/prop\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/prop\#getID--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/prop\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/prop\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/prop\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Determina el calendario que se utiliza para propiedades personalizadas, campos de texto y fórmulas de elementos.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+El elemento Format especifica el formato de una propiedad personalizada que es una cadena, lista fija, número, lista variable, fecha o hora, duración o moneda. El tipo de propiedad personalizada se especifica en el elemento Type correspondiente.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+El elemento invisible especifica si la propiedad personalizada es visible en el cuadro de diálogo Propiedades personalizadas en Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+Especifica la etiqueta que aparece a los usuarios en el cuadro de diálogo Propiedades personalizadas.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Indica el ID de configuración regional (LCID) del idioma en el que se ingresó la fórmula de la celda, el texto, la propiedad personalizada o el comentario.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+El elemento Prompt especifica el texto descriptivo o instructivo que aparece a los usuarios en el cuadro de diálogo Propiedades personalizadas cuando se selecciona la propiedad. Este texto también aparece como información sobre herramientas cuando el puntero del ratón se detiene sobre la propiedad en la ventana Propiedades personalizadas.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Especifica una clave que determina el orden en que se enumeran las propiedades personalizadas en la interfaz de usuario de la aplicación.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+Especifica si se solicita al usuario que introduzca información de la propiedad personalizada para una forma cuando se crea una instancia o la forma se duplica o copia.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/prop\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/prop\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/prop\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/prop\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/prop\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/propcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Prop.
+type: docs
+weight: 310
+url: /es/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Colección Prop.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | Agregue el objeto Prop a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getProp(int ID)](#getProp-int-) | Obtiene el elemento con el ID especificado. |
+| [getProp(String name)](#getProp-java.lang.String-) | Obtiene el elemento con el nombre especificado. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | Elimine el objeto Prop de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+Agregue el objeto Prop a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+Obtiene el elemento con el nombre especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+Elimine el objeto Prop de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/proptype/_index.md
+++ b/spanish/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo de propiedad.
+type: docs
+weight: 311
+url: /es/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+Tipo de propiedad.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOOL](#BOOL) | Booleano. |
+| [DATE](#DATE) | Fecha. |
+| [NUMBER](#NUMBER) | Número. |
+| [STRING](#STRING) | Cadena. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Booleano.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Fecha.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Número.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Cadena.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/protection/_index.md
+++ b/spanish/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: Protección
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El bloqueo ayuda a prevenir cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias.
+type: docs
+weight: 312
+url: /es/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+El bloqueo ayuda a evitar cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. Tampoco protege contra cambios realizados en la ventana ShapeSheet.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getLockAspect()](#getLockAspect--) | Especifica si la relación de aspecto de la forma está bloqueada. |
+| [getLockBegin()](#getLockBegin--) | Especifica si el punto inicial de una forma 1-D está bloqueado en una ubicación específica. |
+| [getLockCalcWH()](#getLockCalcWH--) | Especifica si el rectángulo de selección de una forma está bloqueado de modo que no pueda recalcularse cuando se edita un vértice o se cambia el tipo de elemento en el elemento Geom. |
+| [getLockCrop()](#getLockCrop--) | Especifica si un objeto externo está bloqueado contra ser recortado con la herramienta Recortar en Microsoft Visio. |
+| [getLockCustProp()](#getLockCustProp--) | Determina si el usuario puede agregar, eliminar o modificar propiedades personalizadas en la interfaz de usuario (UI) mediante el cuadro de diálogo Definir propiedades personalizadas. |
+| [getLockDelete()](#getLockDelete--) | Especifica si una forma está bloqueada contra ser eliminada. |
+| [getLockEnd()](#getLockEnd--) | Especifica si el punto final de una forma 1-D está bloqueado en una ubicación específica. |
+| [getLockFormat()](#getLockFormat--) | Especifica si el formato de una forma está bloqueado de modo que no pueda cambiarse. |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | Permite que una subforma bloquee los cambios de formato que se aplican a una forma de grupo principal en la interfaz de usuario de Visio y que de otro modo se propagarían a las formas de grupo individuales. |
+| [getLockGroup()](#getLockGroup--) | Especifica si un grupo está bloqueado de modo que no pueda desagruparse. |
+| [getLockHeight()](#getLockHeight--) | Especifica si la altura de la forma está bloqueada. |
+| [getLockMoveX()](#getLockMoveX--) | Especifica si la posición horizontal de la forma está bloqueada de modo que no pueda moverse horizontalmente. |
+| [getLockMoveY()](#getLockMoveY--) | Especifica si la posición vertical de la forma está bloqueada de modo que no pueda moverse verticalmente. |
+| [getLockRotate()](#getLockRotate--) | Especifica si la forma está bloqueada contra ser rotada con la herramienta Rotación o los comandos Rotar a la izquierda o Rotar a la derecha en Microsoft Visio. |
+| [getLockSelect()](#getLockSelect--) | Especifica si el rectángulo de selección de una forma está bloqueado de modo que no pueda recalcularse cuando se edita un vértice o se cambia el tipo de elemento en el elemento Geom. |
+| [getLockTextEdit()](#getLockTextEdit--) | Especifica si el texto de una forma está bloqueado de modo que no pueda editarse. |
+| [getLockThemeColors()](#getLockThemeColors--) | Impide que los usuarios apliquen colores de tema a la forma. |
+| [getLockThemeEffects()](#getLockThemeEffects--) | Impide que los usuarios apliquen efectos de tema a la forma. |
+| [getLockVtxEdit()](#getLockVtxEdit--) | Especifica si los vértices de una forma están bloqueados de modo que no puedan editarse con ninguna herramienta de la barra de herramientas. |
+| [getLockWidth()](#getLockWidth--) | Especifica si el ancho de la forma está bloqueado de modo que permanezca sin cambios cuando se redimensiona la forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/protection\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+Especifica si la relación de aspecto de la forma está bloqueada. Si está bloqueada, la forma solo puede dimensionarse proporcionalmente; no puede dimensionarse en una sola dimensión.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+Especifica si el punto inicial de una forma 1-D está bloqueado en una ubicación específica.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+Especifica si el rectángulo de selección de una forma está bloqueado de modo que no pueda recalcularse cuando se edita un vértice o se cambia el tipo de elemento en el elemento Geom.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Especifica si un objeto externo está bloqueado contra ser recortado con la herramienta Recortar en Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+Determina si el usuario puede agregar, eliminar o modificar propiedades personalizadas en la interfaz de usuario (UI) mediante el cuadro de diálogo Definir propiedades personalizadas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+Especifica si una forma está bloqueada contra ser eliminada.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+Especifica si el punto final de una forma 1-D está bloqueado en una ubicación específica.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+Especifica si el formato de una forma está bloqueado de modo que no pueda cambiarse. Específicamente, este elemento protege contra la modificación del formato de texto, línea y relleno, o contra el cambio del elemento Style del que hereda la forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+Permite que una subforma bloquee los cambios de formato que se aplican a una forma de grupo principal en la interfaz de usuario de Visio y que de otro modo se propagarían a las formas de grupo individuales.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+Especifica si un grupo está bloqueado de modo que no pueda desagruparse.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+Especifica si la altura de la forma está bloqueada. Si está bloqueada, su altura permanece sin cambios cuando se redimensiona la forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+Especifica si la posición horizontal de la forma está bloqueada de modo que no pueda moverse horizontalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+Especifica si la posición vertical de la forma está bloqueada de modo que no pueda moverse verticalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Especifica si la forma está bloqueada contra ser rotada con la herramienta Rotación o los comandos Rotar a la izquierda o Rotar a la derecha en Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+Especifica si el rectángulo de selección de una forma está bloqueado de modo que no pueda recalcularse cuando se edita un vértice o se cambia el tipo de elemento en el elemento Geom.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+Especifica si el texto de una forma está bloqueado de modo que no pueda editarse. Sin embargo, el texto aún puede formatearse aplicando un estilo, usando las opciones de Style en la pestaña Fuente del cuadro de diálogo Texto.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+Impide que los usuarios apliquen colores de tema a la forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+Impide que los usuarios apliquen efectos de tema a la forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+Especifica si los vértices de una forma están bloqueados de modo que no puedan editarse con ninguna herramienta de la barra de herramientas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+Especifica si el ancho de la forma está bloqueado de modo que permanezca sin cambios cuando se redimensiona la forma.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/protection\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX RadioButton.
+type: docs
+weight: 313
+url: /es/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+Representa un control ActiveX RadioButton.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | la tecla de acceso rápido para el control. |
+| [getAlignment()](#getAlignment--) | la posición del Caption relativa al control. |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getCaption()](#getCaption--) | el texto descriptivo que aparece en un control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getGroupName()](#getGroupName--) | el nombre del grupo. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPicturePosition()](#getPicturePosition--) | la ubicación de la imagen del control relativa a su leyenda. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getValue()](#getValue--) | Indica si el control está marcado o no. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isTripleState()](#isTripleState--) | Indica cómo el control especificado mostrará los valores Null. |
+| [isWordWrapped()](#isWordWrapped--) | Indica si el contenido del control se ajusta automáticamente al final de una línea. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+la tecla de acceso rápido para el control.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+la posición del Caption relativa al control.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+el texto descriptivo que aparece en un control.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+el nombre del grupo.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la ubicación de la imagen del control relativa a su leyenda.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica si el control está marcado o no.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica cómo el control especificado mostrará los valores Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Configuración | Descripción                                                                                                                                     |
+| True    | El control ciclará a través de los estados para los valores Sí, No y Null. El control aparece atenuado (gris) cuando su propiedad Value está establecida en Null. |
+| False   | (Predeterminado) El control ciclará a través de los estados para los valores Sí y No. Los valores Null se muestran como si fueran valores No.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica si el contenido del control se ajusta automáticamente al final de una línea.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/spanish/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa cómo posicionar dos rectángulos entre sí.
+type: docs
+weight: 314
+url: /es/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+Representa cómo posicionar dos rectángulos entre sí.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Inferior |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | InferiorIzquierda |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | InferiorDerecha |
+| [CENTER](#CENTER) | Centro |
+| [LEFT](#LEFT) | Izquierda |
+| [RIGHT](#RIGHT) | Derecha |
+| [TOP](#TOP) | Superior |
+| [TOP_LEFT](#TOP-LEFT) | SuperiorIzquierda |
+| [TOP_RIGHT](#TOP-RIGHT) | SuperiorDerecha |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Inferior
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+InferiorIzquierda
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+InferiorDerecha
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centro
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Izquierda
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Derecha
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Superior
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+SuperiorIzquierda
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+SuperiorDerecha
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/spanish/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: 
+type: docs
+weight: 315
+url: /es/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | Efecto de reflexión personalizado. |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | Reflexión completa, desplazamiento de 4 pt. |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | Reflexión completa, desplazamiento de 8 pt. |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | Reflexión completa, tocando. |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | Reflexión parcial, desplazamiento de 4 pt. |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | Reflexión parcial, desplazamiento de 8 pt. |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | Media reflexión, tocando. |
+| [NONE](#NONE) | Sin efecto de reflexión. |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | Reflexión ajustada, desplazamiento de 4 pt. |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | Reflexión ajustada, desplazamiento de 8 pt. |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | Reflexión ajustada, tocando. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Efecto de reflexión personalizado.
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+Reflexión completa, desplazamiento de 4 pt.
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+Reflexión completa, desplazamiento de 8 pt.
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+Reflexión completa, tocando.
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+Reflexión parcial, desplazamiento de 4 pt.
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+Reflexión parcial, desplazamiento de 8 pt.
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+Media reflexión, tocando.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Sin efecto de reflexión.
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+Reflexión ajustada, desplazamiento de 4 pt.
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+Reflexión ajustada, desplazamiento de 8 pt.
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+Reflexión ajustada, tocando.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/spanish/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene coordenadas x e y para los puntos de un RelCubBezTo.
+type: docs
+weight: 316
+url: /es/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+Contiene las coordenadas x e y de los puntos de un RelCubBezTo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) | Crea una instancia de la clase [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordenada x del punto de control al inicio de la curva en coordenadas relativas. |
+| [getB()](#getB--) | La coordenada y del punto de control al inicio de la curva en coordenadas relativas. |
+| [getC()](#getC--) | La coordenada x del punto de control al final de la curva en coordenadas relativas. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | La coordenada y del punto de control al final de la curva en coordenadas relativas. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del punto final en coordenadas relativas. |
+| [getY()](#getY--) | La coordenada y del punto final en coordenadas relativas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relcubbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relcubbezto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/relcubbezto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/relcubbezto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relcubbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relcubbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+Crea una instancia de la clase [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordenada x del punto de control al inicio de la curva en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordenada y del punto de control al inicio de la curva en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+La coordenada x del punto de control al final de la curva en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+La coordenada y del punto de control al final de la curva en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del punto final en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del punto final en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relcubbezto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relcubbezto\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/relcubbezto\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/relcubbezto\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relcubbezto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relcubbezto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección RelCubBezTo.
+type: docs
+weight: 317
+url: /es/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+Colección RelCubBezTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/spanish/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican información sobre un arco elíptico. Las coordenadas se especifican como coordenadas relativas.
+type: docs
+weight: 318
+url: /es/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+Contiene elementos que especifican información sobre un arco elíptico. Las coordenadas se especifican como coordenadas relativas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | Crea una instancia de la clase [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordenada x del punto de control del arco. |
+| [getB()](#getB--) | La coordenada y del punto de control de un arco. |
+| [getC()](#getC--) | El ángulo del eje mayor de un arco relativo al eje x de su elemento padre. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | La proporción del eje mayor de un arco respecto a su eje menor. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de un arco elíptico. |
+| [getY()](#getY--) | La coordenada y del vértice final de un arco elíptico. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+Crea una instancia de la clase [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordenada x del punto de control del arco. El punto de control se ubica mejor aproximadamente a mitad de camino entre los vértices inicial y final del arco. De lo contrario, el arco puede crecer a un tamaño extremo para pasar por el punto de control, con resultados impredecibles.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordenada y del punto de control de un arco.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+El ángulo del eje mayor de un arco relativo al eje x de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+La proporción del eje mayor de un arco respecto a su eje menor. A pesar del significado habitual de estas palabras, el eje mayor no tiene que ser mayor que el eje menor, por lo que esta proporción no tiene que ser mayor que 1. Establecer este elemento a un valor menor o igual a 0 o mayor que 1000 puede producir resultados impredecibles.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de un arco elíptico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de un arco elíptico.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: RelEllipticalArcTo  colección.
+type: docs
+weight: 319
+url: /es/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+Colección RelEllipticalArcTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rellineto/_index.md
+++ b/spanish/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del vértice final de un segmento de línea recta.
+type: docs
+weight: 320
+url: /es/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+Contiene las coordenadas x e y del vértice final de un segmento de línea recta. Estas coordenadas se encuentran en los elementos X y Y, respectivamente. Las coordenadas se especifican como coordenadas relativas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | Crea una instancia de la clase [LineTo](../../com.aspose.diagram/lineto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del vértice final de un segmento de línea recta. |
+| [getY()](#getY--) | La coordenada y del vértice final de un segmento de línea recta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/rellineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/rellineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/rellineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/rellineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+Crea una instancia de la clase [LineTo](../../com.aspose.diagram/lineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del vértice final de un segmento de línea recta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del vértice final de un segmento de línea recta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/rellineto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/rellineto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/rellineto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/rellineto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección RelLineTo.
+type: docs
+weight: 321
+url: /es/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+Colección RelLineTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relmoveto/_index.md
+++ b/spanish/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del primer vértice de una forma o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. Las coordenadas se especifican como coordenadas relativas.
+type: docs
+weight: 322
+url: /es/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+Contiene las coordenadas x e y del primer vértice de una forma, o contiene las coordenadas x e y del primer vértice después de una interrupción en una ruta. Las coordenadas se especifican como coordenadas relativas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | Crea una instancia de la clase [MoveTo](../../com.aspose.diagram/moveto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | El elemento X representa la coordenada x del primer vértice de una ruta. |
+| [getY()](#getY--) | El elemento Y representa la coordenada y del primer vértice de una ruta. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relmoveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relmoveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relmoveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relmoveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+Crea una instancia de la clase [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+El elemento X representa la coordenada x del primer vértice de una ruta. Si el elemento MoveTo aparece entre dos elementos, el elemento X representa la coordenada x del primer vértice después de la interrupción en la ruta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+El elemento Y representa la coordenada y del primer vértice de una ruta. Si el elemento MoveTo aparece entre dos elementos, el elemento Y representa la coordenada y del primer vértice después de la interrupción en la ruta.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relmoveto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relmoveto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección RelMoveTo.
+type: docs
+weight: 323
+url: /es/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+Colección RelMoveTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/spanish/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene coordenadas x e y para los puntos de un RelQuadBezTo.
+type: docs
+weight: 324
+url: /es/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+Contiene coordenadas x e y para los puntos de un RelQuadBezTo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) | Crea una instancia de la clase [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | La coordenada x del punto de control en coordenadas relativas. |
+| [getB()](#getB--) | La coordenada y del punto de control en coordenadas relativas. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del punto final en coordenadas relativas. |
+| [getY()](#getY--) | La coordenada y del punto final en coordenadas relativas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relquadbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relquadbezto\#getB--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relquadbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relquadbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+Crea una instancia de la clase [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+La coordenada x del punto de control en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+La coordenada y del punto de control en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del punto final en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del punto final en coordenadas relativas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/relquadbezto\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/relquadbezto\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/relquadbezto\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/relquadbezto\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/spanish/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección RelQuadBezTo.
+type: docs
+weight: 325
+url: /es/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+Colección RelQuadBezTo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/spanish/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la eliminación de información oculta para el diagrama.
+type: docs
+weight: 326
+url: /es/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+Especifica la eliminación de información oculta para el diagrama.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular.
+type: docs
+weight: 327
+url: /es/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/resizemode/_index.md
+++ b/spanish/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+type: docs
+weight: 328
+url: /es/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/resizemode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/resizemode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+type: docs
+weight: 329
+url: /es/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | Solo reposicionar. |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | Escalar con el grupo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | Usar la configuración del grupo |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+Solo reposicionar.
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+Escalar con el grupo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+Usar la configuración del grupo
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/reviewer/_index.md
+++ b/spanish/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: Reviewer
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que incluyen información de identificación sobre un revisor de documentos.
+type: docs
+weight: 330
+url: /es/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+Contiene elementos que incluyen información de identificación sobre un revisor de documentos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | El elemento Color especifica un valor RGB que representa el color asignado al marcado del revisor del documento. |
+| [getCurrentIndex()](#getCurrentIndex--) | Indica el valor del elemento MarkerIndex que se añadirá cuando el revisor actual añada otro comentario al documento. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getInitials()](#getInitials--) | Contiene las iniciales de un revisor de documento. |
+| [getName()](#getName--) | El elemento Name especifica el nombre de un revisor de documento. |
+| [getReviewerID()](#getReviewerID--) | Contiene el número de ID del revisor que agrega marcas al documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/reviewer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/reviewer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+El elemento Color especifica un valor RGB que representa el color asignado al marcado del revisor del documento.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+Indica el valor del elemento MarkerIndex que se añadirá cuando el revisor actual añada otro comentario al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+Contiene las iniciales de un revisor de documento.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+El elemento Name especifica el nombre de un revisor de documento.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Contiene el número de ID del revisor que agrega marcas al documento.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/reviewer\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/reviewer\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/spanish/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Reviewer.
+type: docs
+weight: 331
+url: /es/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+Colección Reviewer.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | Agregar el objeto Reviewer a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | Eliminar el objeto Reviewer de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+Agregar el objeto Reviewer a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+Eliminar el objeto Reviewer de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rotationtype/_index.md
+++ b/spanish/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 332
+url: /es/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de bisel. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rotationtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de bisel.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de proyección de las propiedades de efecto de una forma
+type: docs
+weight: 333
+url: /es/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+Especifica el tipo de proyección de las propiedades de efecto de una forma
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [NONE](#NONE) | Especifica sin rotación de efectos 3D. |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | Especifica que la forma gira en proyección oblicua desde la esquina inferior izquierda del cuadro delimitador de la forma. |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | Especifica que la forma gira en proyección oblicua desde la esquina inferior derecha del cuadro delimitador de la forma. |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | Especifica que la forma gira en proyección oblicua desde la esquina superior izquierda del cuadro delimitador de la forma. |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | Especifica que la forma gira en proyección oblicua desde la esquina superior derecha del cuadro delimitador de la forma. |
+| [PARALLEL](#PARALLEL) | Especifica que se aplica una proyección paralela a las propiedades de efecto 3D. |
+| [PERSPECTIVE](#PERSPECTIVE) | Especifica que la forma gira en proyección en perspectiva. |
+| [UNDEFINED](#UNDEFINED) | Sin bastidor de luz. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Especifica sin rotación de efectos 3D.
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+Especifica que la forma gira en proyección oblicua desde la esquina inferior izquierda del cuadro delimitador de la forma.
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+Especifica que la forma gira en proyección oblicua desde la esquina inferior derecha del cuadro delimitador de la forma.
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+Especifica que la forma gira en proyección oblicua desde la esquina superior izquierda del cuadro delimitador de la forma.
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+Especifica que la forma gira en proyección oblicua desde la esquina superior derecha del cuadro delimitador de la forma.
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Especifica que se aplica una proyección paralela a las propiedades de efecto 3D.
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+Especifica que la forma gira en proyección en perspectiva.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Sin bastidor de luz.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/routestyle/_index.md
+++ b/spanish/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de enrutamiento y la dirección para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+type: docs
+weight: 334
+url: /es/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/routestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/routestyle\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de enrutamiento y la dirección para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+type: docs
+weight: 335
+url: /es/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+Especifica el estilo y la dirección de enrutamiento para todos los conectores dinámicos en la página de dibujo que no tienen un estilo de enrutamiento local.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centro a centro. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | Predeterminado. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Diagrama de flujo de abajo hacia arriba. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Diagrama de flujo de izquierda a derecha. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Diagrama de flujo de derecha a izquierda. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Diagrama de flujo de arriba hacia abajo. |
+| [NETWORK](#NETWORK) | Red. |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organigrama de abajo hacia arriba. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Diagrama organizativo de izquierda a derecha. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Diagrama organizativo de derecha a izquierda. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Diagrama organizativo de arriba a abajo. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Ángulo recto. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Simple de abajo a arriba. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Simple horizontal vertical. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Simple de izquierda a derecha. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Simple de derecha a izquierda. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Simple de arriba a abajo. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Simple vertical horizontal. |
+| [STRAIGHT](#STRAIGHT) | Recto. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Árbol de abajo a arriba. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Árbol de izquierda a derecha. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Árbol de derecha a izquierda. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Árbol de arriba a abajo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centro a centro.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+Predeterminado. Ángulo recto.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Diagrama de flujo de abajo hacia arriba.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Diagrama de flujo de izquierda a derecha.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Diagrama de flujo de derecha a izquierda.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Diagrama de flujo de arriba hacia abajo.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Red.
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organigrama de abajo hacia arriba.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Diagrama organizativo de izquierda a derecha.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Diagrama organizativo de derecha a izquierda.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Diagrama organizativo de arriba a abajo.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Ángulo recto.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Simple de abajo a arriba.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Simple horizontal vertical.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Simple de izquierda a derecha.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Simple de derecha a izquierda.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Simple de arriba a abajo.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Simple vertical horizontal.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Recto.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Árbol de abajo a arriba.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Árbol de izquierda a derecha.
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Árbol de derecha a izquierda.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Árbol de arriba a abajo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/row/_index.md
+++ b/spanish/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica una fila en el conjunto de registros de datos.
+type: docs
+weight: 336
+url: /es/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+Indica una fila en el conjunto de registros de datos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Row()](#Row--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | ID de página de la forma. |
+| [getRowID()](#getRowID--) | El ID de fila original. |
+| [getShapeID()](#getShapeID--) | ID de forma de la forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | Para la descripción de esta propiedad, consulte [getPageID()](../../com.aspose.diagram/row\#getPageID--) |
+| [setRowID(long value)](#setRowID-long-) | Para la descripción de esta propiedad, consulte [getRowID()](../../com.aspose.diagram/row\#getRowID--) |
+| [setShapeID(long value)](#setShapeID-long-) | Para la descripción de esta propiedad, consulte [getShapeID()](../../com.aspose.diagram/row\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+ID de página de la forma.
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+El ID de fila original.
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+ID de forma de la forma.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageID()](../../com.aspose.diagram/row\#getPageID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRowID()](../../com.aspose.diagram/row\#getRowID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rowcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Row.
+type: docs
+weight: 337
+url: /es/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+Colección Row.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | Agregar la fila en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | Eliminar la fila de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+Agregar la fila en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+Eliminar la fila de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rule/_index.md
+++ b/spanish/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa una regla de validación única en un conjunto de reglas de validación de diagramas.
+type: docs
+weight: 338
+url: /es/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+Representa una regla de validación única en un conjunto de reglas de validación de diagramas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Rule()](#Rule--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Especifica el texto que se muestra en la columna Categoría de la ventana de Problemas. |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | la descripción de la regla de validación que aparece en la interfaz de usuario. |
+| [getID()](#getID--) | Especifica el identificador único de la regla de validación. |
+| [getIgnored()](#getIgnored--) | Especifica si la regla de validación está actualmente ignorada. |
+| [getNameU()](#getNameU--) | Especifica el nombre universal de la regla de validación. |
+| [getRuleFilter()](#getRuleFilter--) | Especifica la expresión lógica que determina si la regla de validación debe aplicarse a un objeto objetivo. |
+| [getRuleTarget()](#getRuleTarget--) | Especifica el tipo de objeto al que se aplica la regla de validación. |
+| [getRuleTest()](#getRuleTest--) | Especifica la expresión lógica que determina si el objeto objetivo cumple la regla de validación |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCategory()](../../com.aspose.diagram/rule\#getCategory--) |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDescription()](../../com.aspose.diagram/rule\#getDescription--) |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/rule\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | Para la descripción de esta propiedad, consulte [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/rule\#getNameU--) |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | Para la descripción de esta propiedad, consulte [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | Para la descripción de esta propiedad, consulte [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | Para la descripción de esta propiedad, consulte [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Especifica el texto que se muestra en la columna Categoría de la ventana Problemas. El valor predeterminado es una cadena vacía.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+la descripción de la regla de validación que aparece en la interfaz de usuario. El valor predeterminado es "Unknown".
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Especifica el identificador único de la regla de validación.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Especifica si la regla de validación está actualmente ignorada. El valor predeterminado es False.
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Especifica el nombre universal de la regla de validación.
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+Especifica la expresión lógica que determina si la regla de validación debe aplicarse a un objeto objetivo.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+Especifica el tipo de objeto al que se aplica la regla de validación.
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+Especifica la expresión lógica que determina si el objeto objetivo cumple la regla de validación
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCategory()](../../com.aspose.diagram/rule\#getCategory--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDescription()](../../com.aspose.diagram/rule\#getDescription--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/rule\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/rule\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección Rule.
+type: docs
+weight: 339
+url: /es/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+Colección Rule.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | Agrega la regla en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | Elimina la regla de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+Agrega la regla en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+Elimina la regla de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/spanish/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica información sobre la regla de validación a la que se refiere el problema de validación principal.
+type: docs
+weight: 340
+url: /es/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+Especifica información sobre la regla de validación a la que se refiere el problema de validación principal.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | Especifica el identificador único de la regla de validación a la que se refiere el problema principal. |
+| [getRuleSetId()](#getRuleSetId--) | Especifica el identificador único del conjunto de reglas de validación al que se refiere el problema principal. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | Para la descripción de esta propiedad, consulte [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--) |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | Para la descripción de esta propiedad, consulte [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+Especifica el identificador único de la regla de validación a la que se refiere el problema principal.
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+Especifica el identificador único del conjunto de reglas de validación al que se refiere el problema principal.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/spanish/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica las subdivisiones horizontales en la regla para la página.
+type: docs
+weight: 344
+url: /es/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+Especifica las subdivisiones horizontales en la regla para la página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica las subdivisiones horizontales en la regla para la página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica las subdivisiones horizontales en la regla para la página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica las subdivisiones horizontales en la regla para la página.
+type: docs
+weight: 345
+url: /es/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+Especifica las subdivisiones horizontales en la regla para la página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [COARSE](#COARSE) | Grueso. |
+| [FINE](#FINE) | Bien. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grueso.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Bien.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulergrid/_index.md
+++ b/spanish/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican la configuración de las reglas y la cuadrícula de las páginas.
+type: docs
+weight: 346
+url: /es/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getXGridDensity()](#getXGridDensity--) | Especifica el punto cero en la regla del eje y (vertical) para la página. |
+| [getXGridOrigin()](#getXGridOrigin--) | Especifica la coordenada horizontal del origen de la cuadrícula para una página. |
+| [getXGridSpacing()](#getXGridSpacing--) | Especifica la distancia entre líneas horizontales en una cuadrícula fija (es decir, un elemento RulerGrid donde el elemento XGridDensity está configurado a 0). |
+| [getXRulerDensity()](#getXRulerDensity--) | Especifica las subdivisiones horizontales en la regla para la página. |
+| [getXRulerOrigin()](#getXRulerOrigin--) | Especifica el punto cero en la regla del eje x (horizontal) para la página. |
+| [getYGridDensity()](#getYGridDensity--) | Especifica el tipo de cuadrícula vertical a usar para una página. |
+| [getYGridOrigin()](#getYGridOrigin--) | Especifica el origen vertical de la cuadrícula en la página. |
+| [getYGridSpacing()](#getYGridSpacing--) | Especifica la distancia entre líneas verticales en una cuadrícula fija (es decir, un elemento RulerGrid donde el elemento YGridDensity está configurado a 0). |
+| [getYRulerDensity()](#getYRulerDensity--) | Especifica las subdivisiones verticales en la regla para la página. |
+| [getYRulerOrigin()](#getYRulerOrigin--) | Especifica el punto cero en la regla del eje y (vertical) para la página. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+Especifica el punto cero en la regla del eje y (vertical) para la página.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+Especifica la coordenada horizontal del origen de la cuadrícula para una página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+Especifica la distancia entre líneas horizontales en una cuadrícula fija (es decir, un elemento RulerGrid donde el elemento XGridDensity está configurado a 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+Especifica las subdivisiones horizontales en la regla para la página.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+Especifica el punto cero en la regla del eje x (horizontal) para la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+Especifica el tipo de cuadrícula vertical a usar para una página.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+Especifica el origen vertical de la cuadrícula en la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+Especifica la distancia entre líneas verticales en una cuadrícula fija (es decir, un elemento RulerGrid donde el elemento YGridDensity está configurado a 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+Especifica las subdivisiones verticales en la regla para la página.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+Especifica el punto cero en la regla del eje y (vertical) para la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/rulergrid\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/ruleset/_index.md
+++ b/spanish/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un conjunto de reglas de validación de diagramas.
+type: docs
+weight: 341
+url: /es/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+Representa un conjunto de reglas de validación de diagramas.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Especifica la descripción del conjunto de reglas de validación que aparece en la interfaz de usuario. |
+| [getEnabled()](#getEnabled--) | Especifica si las reglas del conjunto de reglas de validación especificado se verifican cuando se desencadena la validación para el documento actual. |
+| [getID()](#getID--) | Especifica el identificador único del conjunto de reglas de validación. |
+| [getName()](#getName--) | Especifica el nombre local del conjunto de reglas de validación. |
+| [getNameU()](#getNameU--) | Especifica el nombre universal del conjunto de reglas de validación. |
+| [getRuleSetFlags()](#getRuleSetFlags--) | Especifica si el conjunto de reglas aparece en la lista de Reglas a Verificar. |
+| [getRules()](#getRules--) | Colección Rule. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) |
+| [setEnabled(int value)](#setEnabled-int-) | Para la descripción de esta propiedad, consulte [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/ruleset\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/ruleset\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | Para la descripción de esta propiedad, consulte [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Especifica la descripción del conjunto de reglas de validación que aparece en la interfaz de usuario. El valor predeterminado es una cadena vacía.
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Especifica si las reglas del conjunto de reglas de validación especificado se verifican cuando se activa la validación para el documento actual. El valor predeterminado es Verdadero.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Especifica el identificador único del conjunto de reglas de validación.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Especifica el nombre local del conjunto de reglas de validación. El valor predeterminado es el atributo NameU.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Especifica el nombre universal del conjunto de reglas de validación.
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+Especifica si el conjunto de reglas aparece en la lista de Reglas a Verificar.
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+Colección Rule.
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/ruleset\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/ruleset\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección RuleSet.
+type: docs
+weight: 342
+url: /es/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+Colección RuleSet.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | Agregue el ruleSet a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | Elimine el ruleSet de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+Agregue el ruleSet a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+Elimine el ruleSet de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/rulevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor de regla.
+type: docs
+weight: 343
+url: /es/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+Valor de regla.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | Representa la fórmula del elemento. |
+| [getValue()](#getValue--) | Valor de regla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | Para la descripción de esta propiedad, consulte [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rulevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| formula | java.lang.String |  |
+| valor | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+Representa la fórmula del elemento. Este atributo puede contener una de las siguientes cadenas: "someFormula" si la fórmula existe localmente, "No Formula" si la fórmula se elimina o bloquea localmente, o "Inh" si la fórmula se hereda. Si el atributo no está presente, la fórmula del elemento es una constante simple.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valor de regla.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/savefileformat/_index.md
+++ b/spanish/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Enumeración para la selección del formato de guardado del diagrama.
+type: docs
+weight: 348
+url: /es/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+Enumeración para la selección del formato de guardado del diagrama.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BMP](#BMP) | Formato de imagen Bmp. |
+| [EMF](#EMF) | Formato de imagen EMF. |
+| [GIF](#GIF) | Formato Gif. |
+| [HTML](#HTML) | Formato Html. |
+| [JPEG](#JPEG) | Formato de imagen Jpeg. |
+| [PDF](#PDF) | Formato Pdf. |
+| [PNG](#PNG) | Formato de imagen Png. |
+| [SVG](#SVG) | Formato Svg. |
+| [TIFF](#TIFF) | Formato de imagen Tiff. |
+| [VDX](#VDX) | Formato xml Vdx de MS Visio. |
+| [VSDM](#VSDM) | Formato de archivo Vsdm de MS Visio que permite macros. |
+| [VSDX](#VSDX) | Formato de archivo Vsdx de MS Visio 2013. |
+| [VSSM](#VSSM) | Formato de archivo Vssm de MS Visio que permite macros. |
+| [VSSX](#VSSX) | Formato de archivo Vssx de MS Visio 2013 |
+| [VSTM](#VSTM) | Formato de archivo Vstm de MS Visio que permite macros. |
+| [VSTX](#VSTX) | Formato de archivo Vstx de MS Visio 2013,archivo de plantilla. |
+| [VSX](#VSX) | Formato de plantilla xml Vsx de MS Visio. |
+| [VTX](#VTX) | Formato de plantilla xml Vst de MS Visio. |
+| [XAML](#XAML) | Formato Xaml. |
+| [XPS](#XPS) | Formato Xps. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Formato de imagen Bmp.
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+Formato de imagen EMF.
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Formato Gif.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Formato Html.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Formato de imagen Jpeg.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Formato Pdf.
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Formato de imagen Png.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Formato Svg.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Formato de imagen Tiff.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+Formato xml Vdx de MS Visio.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+Formato de archivo Vsdm de MS Visio que permite macros.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+Formato de archivo Vsdx de MS Visio 2013.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+Formato de archivo Vssm de MS Visio que permite macros.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+Formato de archivo Vssx de MS Visio 2013
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+Formato de archivo Vstm de MS Visio que permite macros.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+Formato de archivo Vstx de MS Visio 2013,archivo de plantilla.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+Formato de plantilla xml Vsx de MS Visio.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+Formato de plantilla xml Vst de MS Visio.
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Formato Xaml.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Formato Xps.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/saveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular.
+type: docs
+weight: 349
+url: /es/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+Esta es una clase base abstracta para clases que permiten al usuario especificar opciones adicionales al guardar un diagrama en un formato particular. Una instancia de la clase SaveOptions o cualquier clase derivada se pasa a las sobrecargas de Save de flujo o Save de cadena para que el usuario defina opciones personalizadas al guardar un documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/scratch/_index.md
+++ b/spanish/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene un área de trabajo para ingresar y probar fórmulas a las que hacen referencia otros elementos.
+type: docs
+weight: 350
+url: /es/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+Contiene un área de trabajo para ingresar y probar fórmulas que son referenciadas por otros elementos. Este elemento se utiliza típicamente para aislar cálculos complejos repetidos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Scratch()](#Scratch--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Un elemento de propósito general. |
+| [getB()](#getB--) | Un elemento de propósito general scratch. |
+| [getC()](#getC--) | Un elemento de propósito general. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Un elemento de propósito general. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | Especifica una coordenada x en una forma en coordenadas locales. |
+| [getY()](#getY--) | Especifica una coordenada y en una forma en coordenadas locales. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/scratch\#getA--) |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/scratch\#getB--) |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/scratch\#getC--) |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/scratch\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/scratch\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/scratch\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/scratch\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/scratch\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+Un elemento de propósito general.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+Un elemento de propósito general scratch.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+Un elemento de propósito general.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+Un elemento de propósito general.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Especifica una coordenada x en una forma en coordenadas locales. La tabla siguiente describe el elemento X según el elemento que lo contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Especifica una coordenada y en una forma en coordenadas locales. Las coordenadas locales son aquellas cuyo marco de referencia es la forma, en lugar de la página.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/scratch\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/scratch\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/scratch\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/scratch\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/scratch\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/scratch\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/scratch\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/scratch\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de Scratch.
+type: docs
+weight: 351
+url: /es/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+Colección de Scratch.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | Agregar el objeto Scratch en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | Eliminar el objeto Scratch de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+Agregar el objeto Scratch en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+Eliminar el objeto Scratch de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control ScrollBar.
+type: docs
+weight: 352
+url: /es/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+Representa el control ScrollBar.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getLargeChange()](#getLargeChange--) | la cantidad en que cambia la propiedad Position |
+| [getMax()](#getMax--) | el valor máximo aceptable. |
+| [getMin()](#getMin--) | el valor mínimo aceptable. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getOrientation()](#getOrientation--) | si el SpinButton o ScrollBar está orientado verticalmente u horizontalmente. |
+| [getPosition()](#getPosition--) | el valor. |
+| [getSmallChange()](#getSmallChange--) | la cantidad en que cambia la propiedad Position |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLargeChange(int value)](#setLargeChange-int-) | Para la descripción de esta propiedad, consulte [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Para la descripción de esta propiedad, consulte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Para la descripción de esta propiedad, consulte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Para la descripción de esta propiedad, consulte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+la cantidad en que cambia la propiedad Position
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+el valor máximo aceptable.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+el valor mínimo aceptable.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+si el SpinButton o ScrollBar está orientado verticalmente u horizontalmente.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+el valor.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+la cantidad en que cambia la propiedad Position
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/selectmode/_index.md
+++ b/spanish/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+type: docs
+weight: 353
+url: /es/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica cómo el usuario selecciona una forma de grupo y sus miembros. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/selectmode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/selectmode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+type: docs
+weight: 354
+url: /es/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+Especifica cómo el usuario selecciona una forma de grupo y sus miembros.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | Seleccione primero la forma del grupo. |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | Seleccione solo la forma del grupo. |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | Seleccione primero los miembros del grupo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+Seleccione primero la forma del grupo.
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+Seleccione solo la forma del grupo.
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+Seleccione primero los miembros del grupo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shape/_index.md
+++ b/spanish/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: Forma
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que definen una forma en una página maestra o en un elemento de forma grupal.
+type: docs
+weight: 355
+url: /es/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+Contiene elementos que definen una forma en un Master, una Página o un elemento de forma de grupo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Shape()](#Shape--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [bringForward()](#bringForward--) | Mueve la forma un puesto hacia adelante en el orden Z. |
+| [bringToFront()](#bringToFront--) | Mueve la forma al frente del orden Z. |
+| [centerDrawing()](#centerDrawing--) | Centra la forma con respecto a la extensión de la página. |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | Devuelve una matriz que contiene los identificadores (IDs) de las formas que están conectadas a la forma. |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | Devuelve una matriz que contiene los identificadores de las formas que dependen de una forma. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | Obtiene el control ActiveX. |
+| [getActs()](#getActs--) | Contiene una colección de elementos Act. |
+| [getAlign()](#getAlign--) | Indica la alineación de una forma con respecto a la guía o punto de guía al que la forma está adherida. |
+| [getChars()](#getChars--) | Contiene una colección de elementos Char. |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una colección de elementos ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una colección de elementos Connection. |
+| [getConnectorRule()](#getConnectorRule--) | Devuelve un connectorRule que contiene el id de la forma y la conexión que están conectados a la forma. |
+| [getConnectorsType()](#getConnectorsType--) | Obtener tipo de conectores |
+| [getControlData()](#getControlData--) | Obtiene los datos del control. |
+| [getControls()](#getControls--) | Contiene una colección de elementos Control. |
+| [getData1()](#getData1--) | Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma. |
+| [getData2()](#getData2--) | Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma. |
+| [getData3()](#getData3--) | Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento está eliminado localmente. |
+| [getDiagram()](#getDiagram--) | Elemento raíz de la jerarquía de objetos de Visio. |
+| [getDisplayText()](#getDisplayText--) | Obtener el texto mostrado en la interfaz. |
+| [getEvent()](#getEvent--) | Contiene elementos que especifican fórmulas que controlan eventos de forma. |
+| [getFields()](#getFields--) | Contiene una colección de elementos Field. |
+| [getFill()](#getFill--) | Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo. |
+| [getFillStyle()](#getFillStyle--) | Hoja de estilo de la cual esta forma hereda el formato de relleno. |
+| [getForeign()](#getForeign--) | Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [getGeoms()](#getGeoms--) | Contiene una colección de elementos Geom. |
+| [getGroup()](#getGroup--) | Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos. |
+| [getHelp()](#getHelp--) | Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor. |
+| [getHyperlinks()](#getHyperlinks--) | Contiene una colección de elementos Hyperlink. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getImage()](#getImage--) | Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits. |
+| [getInheritChars()](#getInheritChars--) | Contiene los valores de carácter para la forma heredados por la forma maestra. |
+| [getInheritFill()](#getInheritFill--) | Contiene los valores de formato de relleno para la forma heredados por el estilo padre y la forma maestra. |
+| [getInheritGeoms()](#getInheritGeoms--) | Contiene los valores Geoms de la forma heredados por la forma maestra. |
+| [getInheritLine()](#getInheritLine--) | Contiene los valores de formato de línea para la forma heredados por el estilo padre y la forma maestra. |
+| [getInheritParas()](#getInheritParas--) | Contiene los paras de la forma heredados por el estilo padre y la forma maestra. |
+| [getInheritProps()](#getInheritProps--) | Contiene las props de la forma heredados por la forma maestra. |
+| [getInheritTextBlock()](#getInheritTextBlock--) | Contiene los valores del bloque de texto para la forma heredados por el estilo padre y la forma maestra. |
+| [getInheritUsers()](#getInheritUsers--) | Contiene los usuarios de la forma heredados por la forma maestra. |
+| [getLayerMem()](#getLayerMem--) | Contiene el elemento LayerMember, que especifica cada capa a la que se asigna la forma. |
+| [getLayout()](#getLayout--) | Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores. |
+| [getLine()](#getLine--) | Contiene elementos que controlan los atributos de línea de una forma, como patrón, grosor y color. |
+| [getLineStyle()](#getLineStyle--) | Hoja de estilo de la cual esta forma hereda el formato de línea |
+| [getMaster()](#getMaster--) | El maestro del cual la forma hereda sus datos. |
+| [getMasterShape()](#getMasterShape--) | Este atributo solo puede estar presente en formas que son miembros de una forma de grupo, y el grupo es una instancia de un maestro. |
+| [getMisc()](#getMisc--) | Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getOneD()](#getOneD--) | Determina si la forma se comporta como un objeto unidimensional (1-D). |
+| [getPage()](#getPage--) | Elemento raíz de la jerarquía de objetos de Visio. |
+| [getParas()](#getParas--) | Contiene una colección de elementos Para. |
+| [getParentShape()](#getParentShape--) | Padre de la forma. |
+| [getProps()](#getProps--) | Contiene una colección de elementos Prop. |
+| [getProtection()](#getProtection--) | El bloqueo ayuda a prevenir cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. |
+| [getPureText()](#getPureText--) | Obtener la cadena de texto |
+| [getRootShape()](#getRootShape--) | Devuelve la forma de nivel superior de una instancia si esta forma es parte de una instancia maestra. |
+| [getScratchs()](#getScratchs--) | Contiene una colección de elementos Scratch. |
+| [getShapes()](#getShapes--) | Contiene una colección de elementos Shape. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Contiene una colección de elementos SmartTagDef. |
+| [getTabsCollection()](#getTabsCollection--) | Contiene una colección de elementos Tab. |
+| [getText()](#getText--) | Contiene el texto de una forma. |
+| [getTextBlock()](#getTextBlock--) | Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma. |
+| [getTextStyle()](#getTextStyle--) | Hoja de estilo de la cual esta forma hereda el formato de texto. |
+| [getTextXForm()](#getTextXForm--) | Contiene elementos que especifican información de posicionamiento sobre el bloque de texto de una forma. |
+| [getThreeDFormat()](#getThreeDFormat--) | Obtiene el ThreeDFormat. |
+| [getTwoD()](#getTwoD--) | Determina si la forma se comporta como un objeto bidimensional (2-D). |
+| [getType()](#getType--) | El tipo de una forma. |
+| [getUniqueID()](#getUniqueID--) | Un GUID (identificador global único) asignado a la forma. |
+| [getUsers()](#getUsers--) | Contiene una colección de elementos User. |
+| [getXForm()](#getXForm--) | Contiene elementos que especifican información general de posicionamiento sobre una forma. |
+| [getXForm1D()](#getXForm1D--) | Contiene las coordenadas x e y del punto inicial y del punto final de una forma 1-D. |
+| [getZOrderIndex()](#getZOrderIndex--) | Devuelve el índice de una forma en el orden Z, excepto la forma guía. |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | Devuelve una matriz que contiene los identificadores de las formas que están pegadas a una forma. |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | Indica si estas dos formas están conectadas. |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | Indica si esta forma contiene otra forma. |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | Indica si estas dos formas están pegadas. |
+| [isInGroup()](#isInGroup--) | Indica si esta forma está en una forma de grupo. |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | Indica si esta forma intersecta otra forma. |
+| [isTextEmpty()](#isTextEmpty--) | Indica si la forma tiene texto y si el texto está vacío o no. |
+| [move(double dX, double dY)](#move-double-double-) | Mueve la forma dX y dY pulgadas desde la posición actual. |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | Mueve la forma a una nueva posición absoluta en la página. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | Actualiza la posición de la forma, incluyendo xform, conexión y geom, al cambiar el texto de la forma o de otros. |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | Reemplaza la cadena de texto de una forma. |
+| [sendBackward()](#sendBackward--) | Mueve la forma una posición atrás en el orden Z. |
+| [sendToBack()](#sendToBack--) | Mueve la forma al fondo del orden Z. |
+| [setAngle(double angle)](#setAngle-double-) | Establece un nuevo ángulo para la forma. |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | Para la descripción de esta propiedad, consulte [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | Establecer tipo de conectores |
+| [setData1(String value)](#setData1-java.lang.String-) | Para la descripción de esta propiedad, consulte [getData1()](../../com.aspose.diagram/shape\#getData1--) |
+| [setData2(String value)](#setData2-java.lang.String-) | Para la descripción de esta propiedad, consulte [getData2()](../../com.aspose.diagram/shape\#getData2--) |
+| [setData3(String value)](#setData3-java.lang.String-) | Para la descripción de esta propiedad, consulte [getData3()](../../com.aspose.diagram/shape\#getData3--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/shape\#getDel--) |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | Para la descripción de esta propiedad, consulte [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | Para la descripción de esta propiedad, consulte [getEvent()](../../com.aspose.diagram/shape\#getEvent--) |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) |
+| [setHeight(double height)](#setHeight-double-) | Establece una nueva altura para la forma. |
+| [setID(long value)](#setID-long-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/shape\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Para la descripción de esta propiedad, consulte [getMaster()](../../com.aspose.diagram/shape\#getMaster--) |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | Para la descripción de esta propiedad, consulte [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/shape\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/shape\#getNameU--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Para la descripción de esta propiedad, consulte [getPage()](../../com.aspose.diagram/shape\#getPage--) |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | Para la descripción de esta propiedad, consulte [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Aplicar un tema preestablecido a esta forma |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Aplicar un estilo rápido de variante de tema preestablecido a esta forma |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | Aplicar un estilo rápido de variante de tema preestablecido a esta forma, como opciones de estilos de tema en la lista desplegable de estilos de forma |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Aplicar una variante de tema preestablecida a esta forma |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | Para la descripción de esta propiedad, consulte [getProps()](../../com.aspose.diagram/shape\#getProps--) |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/shape\#getText--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--) |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | Para la descripción de esta propiedad, consulte [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--) |
+| [setType(int value)](#setType-int-) | Para la descripción de esta propiedad, consulte [getType()](../../com.aspose.diagram/shape\#getType--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--) |
+| [setWidth(double width)](#setWidth-double-) | Establece el nuevo ancho de la forma. |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | Para la descripción de esta propiedad, consulte [getXForm()](../../com.aspose.diagram/shape\#getXForm--) |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | Para la descripción de esta propiedad, consulte [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--) |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | Crea el HTML de la forma y lo guarda en un flujo en el formato especificado. |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | Crea el HTML de la forma y lo guarda en un flujo en el formato especificado. |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | Crea el HTML y lo guarda en un archivo. |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | Crea la imagen de la forma y la guarda en un flujo en el formato especificado. |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | Crea la imagen de la forma y la guarda en un flujo en el formato especificado. |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | Crea la imagen de la forma y la guarda en un archivo. |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | Crea el PDF de la forma y lo guarda en un flujo. |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | Crea el PDF de la forma y lo guarda en un flujo. |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | Guarda la forma en un archivo PDF. |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | Guarda la forma en un archivo SVG. |
+| [ungroup()](#ungroup--) | Desagrupar forma |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+Constructor.
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+Mueve la forma un puesto hacia adelante en el orden Z.
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+Mueve la forma al frente del orden Z.
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centra la forma con respecto a la extensión de la página.
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+Devuelve una matriz que contiene los identificadores (IDs) de las formas que están conectadas a la forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| bandera | int | Filtra la matriz de IDs de forma devueltos por la direccionalidad de los conectores. Consulte Remarks para los valores posiblesAspose.Diagram.ConnectedShapesFlags. |
+| categoryFilter | java.lang.String | Filtra la matriz de IDs de formas devueltos limitándola a los IDs de formas que coincidan con el categoryString especificado. |
+
+**Returns:**
+long[] - matriz de IDs long.
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+Devuelve una matriz que contiene los identificadores de las formas que dependen de una forma.
+
+**Returns:**
+long[] - matriz de IDs long.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+Obtiene el control ActiveX.
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Contiene una colección de elementos Act.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+Indica la alineación de una forma con respecto a la guía o punto de guía al que la forma está pegada. El elemento Align aparece solo para formas que están pegadas a guías o puntos de guía.
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Contiene una colección de elementos Char.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una colección de elementos ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una colección de elementos Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+Devuelve un connectorRule que contiene el id de la forma y la conexión que están conectados a la forma.
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+Obtener tipo de conectores
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+Obtiene los datos del control.
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Contiene una colección de elementos Control.
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma.
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma.
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+Contiene un valor de cadena arbitrario que se utiliza para proporcionar información adicional sobre una forma.
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento está eliminado localmente. Un valor de 1 indica que el elemento está eliminado localmente.
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Elemento raíz de la jerarquía de objetos de Visio.
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+Obtener el texto mostrado en la interfaz.
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Contiene elementos que especifican fórmulas que controlan eventos de forma.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Contiene una colección de elementos Field.
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Hoja de estilo de la cual esta forma hereda el formato de relleno.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento Microsoft Visio. También incluye elementos que especifican la distancia a la que la imagen del objeto se desplaza dentro de sus bordes.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Contiene una colección de elementos Geom.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Contiene una colección de elementos Hyperlink.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+Contiene los valores de carácter para la forma heredados por la forma maestra.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+Contiene los valores de formato de relleno para la forma heredados por el estilo padre y la forma maestra.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+Contiene los valores Geoms de la forma heredados por la forma maestra.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+Contiene los valores de formato de línea para la forma heredados por el estilo padre y la forma maestra.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+Contiene los paras de la forma heredados por el estilo padre y la forma maestra.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+Contiene las props de la forma heredados por la forma maestra.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+Contiene los valores del bloque de texto para la forma heredados por el estilo padre y la forma maestra.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+Contiene los usuarios de la forma heredados por la forma maestra.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+Contiene el elemento LayerMember, que especifica cada capa a la que se asigna la forma.
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Contiene elementos que controlan los atributos de línea de una forma, como el patrón, el grosor y el color. Estos elementos determinan si los extremos de la línea están formateados (por ejemplo, con una punta de flecha), el tamaño de los formatos de los extremos de la línea, el radio del círculo de redondeo aplicado a la línea y el estilo de terminación de la línea (redondo o cuadrado).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Hoja de estilo de la cual esta forma hereda el formato de línea
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+El maestro del cual la forma hereda sus datos.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+Este atributo solo puede estar presente en formas que son miembros de una forma de grupo, y el grupo es una instancia de un master. El atributo contiene un ID que hace referencia a la sub‑forma correspondiente en el master.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+Determina si la forma se comporta como un objeto unidimensional (1‑D). Solo lectura.
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Elemento raíz de la jerarquía de objetos de Visio.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Contiene una colección de elementos Para.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+Padre de la forma.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Contiene una colección de elementos Prop.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+El bloqueo ayuda a evitar cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. Tampoco protege contra cambios realizados en la ventana ShapeSheet.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+Obtener la cadena de texto
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+Devuelve la forma de nivel superior de una instancia si esta forma es parte de una instancia de master. Solo lectura.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Contiene una colección de elementos Scratch.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Contiene una colección de elementos Shape.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Contiene una colección de elementos SmartTagDef.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Contiene una colección de elementos Tab.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+Contiene el texto de una forma.
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Hoja de estilo de la cual esta forma hereda el formato de texto.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+Contiene elementos que especifican información de posicionamiento sobre el bloque de texto de una forma.
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+Obtiene el ThreeDFormat.
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+Determina si la forma se comporta como un objeto bidimensional (2-D).
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+El tipo de una forma. Puede ser uno de los siguientes valores: Group, Shape, Guide o Foreign.
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+Un GUID (identificador global único) asignado a la forma.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Contiene una colección de elementos User.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Contiene elementos que especifican información general de posicionamiento sobre una forma.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+Contiene las coordenadas x e y del punto inicial y del punto final de una forma 1-D. Este elemento aparece solo para formas 1-D.
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+Devuelve el índice de una forma en el orden Z, excepto la forma guía.
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+Devuelve una matriz que contiene los identificadores de las formas que están pegadas a una forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| bandera | int | La dimensionalidad y direccionalidad de los puntos de conexión de las formas a devolver. Consulte Remarks para los valores posibles Aspose.Diagram.GluedShapesFlags. |
+| categoryFilter | java.lang.String | Filtra la matriz de IDs de formas devueltos limitándola a los IDs de formas que coincidan con el categoryString especificado. |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | Opcional: forma adicional a la que también deben estar pegadas las formas devueltas, puede ser [Shape](../../com.aspose.diagram/shape) o null. |
+
+**Returns:**
+long[] - matriz de IDs long.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+Indica si estas dos formas están conectadas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+Indica si esta forma contiene otra forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+Indica si estas dos formas están pegadas.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | shape |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+Indica si esta forma está en una forma de grupo.
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+Indica si esta forma intersecta otra forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+Indica si la forma tiene texto y si el texto está vacío o no.
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+Mueve la forma dX y dY pulgadas desde la posición actual.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dX | double | Desplazamiento X double. |
+| dY | double | Desplazamiento Y double. |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+Mueve la forma a una nueva posición absoluta en la página.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| newPinX | double | Nueva coordenada x del pin de la shape (centro de rotación) en relación con el origen de su padre. double. |
+| newPinY | double | Nueva coordenada y del pin de la shape (centro de rotación) en relación con el origen de su padre. double. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+Actualiza la posición de la shape incluyendo xform, connection y geom al cambiar el texto de la shape u otros. Recopilaremos los datos de la shape, como el texto de la shape, y luego calcularemos su posición. Este método solo se usa para actualizar los datos de la shape.
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+Reemplaza la cadena de texto de una forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| text | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+Mueve la forma una posición atrás en el orden Z.
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+Mueve la forma al fondo del orden Z.
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+Establece el nuevo ángulo de la shape. La unidad del ángulo es radian.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| angle | double | Nuevo ángulo cuya unidad es radian y no grado double. |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+Establecer tipo de conectores
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| tipo | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getData1()](../../com.aspose.diagram/shape\#getData1--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getData2()](../../com.aspose.diagram/shape\#getData2--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getData3()](../../com.aspose.diagram/shape\#getData3--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/shape\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEvent()](../../com.aspose.diagram/shape\#getEvent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+Establece una nueva altura para la forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| height | double | New heightdouble. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/shape\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMaster()](../../com.aspose.diagram/shape\#getMaster--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/shape\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/shape\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPage()](../../com.aspose.diagram/shape\#getPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Aplicar un tema preestablecido a esta forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Aplicar un estilo rápido de variante de tema preestablecido a esta forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+Aplicar un estilo rápido de variante de tema preestablecido a esta forma, como opciones de estilos de tema en la lista desplegable de estilos de forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| styleIndex | int | the row of style matrics |
+| colorIndex | int | the column of style matrics |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Aplicar una variante de tema preestablecida a esta forma
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getProps()](../../com.aspose.diagram/shape\#getProps--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/shape\#getText--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getType()](../../com.aspose.diagram/shape\#getType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+Establece el nuevo ancho de la forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| width | double | New widthdouble. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getXForm()](../../com.aspose.diagram/shape\#getXForm--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+Crea el HTML de la forma y lo guarda en un flujo en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+Crea el HTML de la forma y lo guarda en un flujo en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | The output stream. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Addtional html creation options |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+Crea el HTML y lo guarda en un archivo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | html save options |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+Crea la imagen de la forma y la guarda en un flujo en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+Crea la imagen de la forma y la guarda en un flujo en el formato especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | The output stream. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Creates the shape image and saves it to a file. The extension of the file name determines the format of the image.
+
+The format of the image is specified by using the extension of the file name. For example, if you specify "myfile.png", then the image will be saved in the PNG format. The following file extensions are recognized: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| imageFile | java.lang.String | The image file name with full path. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Additional image creation options |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+Crea el PDF de la forma y lo guarda en un flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.InputStream | The output stream. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+Crea el PDF de la forma y lo guarda en un flujo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| flujo | java.io.OutputStream | The output stream. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+Guarda la forma en un archivo PDF.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| fileName | java.lang.String | the pdf file name with full path |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+Guarda la forma en un archivo SVG.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+Desagrupar forma
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de Formas.
+type: docs
+weight: 356
+url: /es/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+Colección de Formas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | Agregar la forma en la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getShape(String name)](#getShape-java.lang.String-) | Obtiene el elemento con el nombre especificado. |
+| [getShape(long ID)](#getShape-long-) | Obtiene el elemento con el ID especificado. |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | Obtiene el elemento incluyendo su forma hija en el id especificado. |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | Obtiene el elemento incluyendo su forma hija en el nombre especificado. |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | Agrupar las formas. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | Eliminar la forma de la colección. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | Eliminar las formas, incluyendo las formas DEPENDSON, de la colección. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | Desagrupar la forma. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+Agregar la forma en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+Obtiene el elemento con el nombre especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+Obtiene el elemento incluyendo su forma hija en el id especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+Obtiene el elemento incluyendo su forma hija en el nombre especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+Agrupar las formas. La forma en groupItems no debe agruparse. La forma debe estar en esta colección Shapes.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | los elementos del grupo. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+Eliminar la forma de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Forma |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+Eliminar las formas, incluyendo las formas DEPENDSON, de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Forma |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+Desagrupar la forma.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | la forma del grupo. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/spanish/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el comportamiento de colocación para una forma colocable.
+type: docs
+weight: 357
+url: /es/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+Especifica el comportamiento de colocación para una forma colocable.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el comportamiento de colocación para una forma colocable. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el comportamiento de colocación para una forma colocable.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el comportamiento de colocación para una forma colocable.
+type: docs
+weight: 358
+url: /es/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+Especifica el comportamiento de colocación para una forma colocable.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | Solo permitir el enrutamiento a los lados con puntos de conexión. |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | Ignorar las ubicaciones de los puntos de conexión al enrutarse. |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | No pegar al perímetro de esta forma. |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | No mover esta forma pero sí permitir que otras formas colocables se coloquen sobre ella. |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | No mover esta forma y no permitir que otras formas colocables se coloquen sobre ella. |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | No mover esta forma al usar el comando Lay Out Shapes en Microsoft Visio. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+Solo permitir el enrutamiento a los lados con puntos de conexión.
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+Ignorar las ubicaciones de los puntos de conexión al enrutarse.
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+No pegar al perímetro de esta forma. Pegue a la caja de alineación de la forma en su lugar.
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+No mover esta forma pero sí permitir que otras formas colocables se coloquen sobre ella.
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+No mover esta forma y no permitir que otras formas colocables se coloquen sobre ella.
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+No mover esta forma al usar el comando Lay Out Shapes en Microsoft Visio.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo una forma colocable se voltea y/o rota en la página cuando el usuario selecciona el menú Disposición de Formas.
+type: docs
+weight: 359
+url: /es/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes).
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes). |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cómo una forma colocable se voltea y/o rota en la página cuando el usuario selecciona el menú Disposición de Formas.
+type: docs
+weight: 360
+url: /es/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+Especifica cómo una forma colocable se voltea y/o rota en la página cuando un usuario selecciona Lay Out Shapes (menú Shapes).
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | Voltear en incrementos de 90 grados entre 0 y 270. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Voltear horizontalmente. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Voltear verticalmente. |
+| [NO_FLIP](#NO-FLIP) | Sin volteo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Utilice el valor predeterminado de la página. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+Voltear en incrementos de 90 grados entre 0 y 270.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Voltear horizontalmente.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Voltear verticalmente.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Sin volteo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Utilice el valor predeterminado de la página.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de colocación para los hijos.
+type: docs
+weight: 361
+url: /es/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+Determina el estilo de colocación para los hijos.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Determina la apariencia de un conector. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Determina la apariencia de un conector.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Determina el estilo de colocación para los hijos.
+type: docs
+weight: 362
+url: /es/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+Determina el estilo de colocación para los hijos.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | Colocar de abajo hacia arriba. |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | Colocar circular. |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | Colocar compacto abajo a la izquierda. |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | Colocar compacto abajo a la derecha. |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | Colocar compacto a la izquierda abajo. |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | Colocar compacto a la izquierda arriba. |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | Colocar compacto a la derecha abajo. |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | Colocar compacto a la derecha arriba. |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | Colocar compacto arriba a la izquierda. |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | Colocar compacto arriba a la derecha. |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | Colocar predeterminado. |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | Colocar jerarquía de abajo al centro. |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | Colocar jerarquía de abajo a la izquierda. |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | Colocar jerarquía de abajo a la derecha. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | colocar jerarquía de izquierda a derecha abajo. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | Colocar jerarquía de izquierda a derecha medio. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | Colocar jerarquía de izquierda a derecha arriba. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | Colocar jerarquía de derecha a izquierda abajo. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | Colocar jerarquía de derecha a izquierda arriba. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | Colocar jerarquía de derecha a izquierda arriba. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | Colocar jerarquía de arriba a abajo al centro. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | Colocar jerarquía de arriba a abajo a la izquierda. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | Colocar jerarquía de arriba a abajo a la derecha. |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | Colocar padre predeterminado. |
+| [PLACE_RADIAL](#PLACE-RADIAL) | Colocar radial. |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | Colocar de derecha a izquierda. |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | Colocar de arriba a abajo. |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | Colocar a la derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+Colocar de abajo hacia arriba.
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+Colocar circular.
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+Colocar compacto abajo a la izquierda.
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+Colocar compacto abajo a la derecha.
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+Colocar compacto a la izquierda abajo.
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+Colocar compacto a la izquierda arriba.
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+Colocar compacto a la derecha abajo.
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+Colocar compacto a la derecha arriba.
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+Colocar compacto arriba a la izquierda.
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+Colocar compacto arriba a la derecha.
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+Colocar predeterminado.
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+Colocar jerarquía de abajo al centro.
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+Colocar jerarquía de abajo a la izquierda.
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+Colocar jerarquía de abajo a la derecha.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+colocar jerarquía de izquierda a derecha abajo.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+Colocar jerarquía de izquierda a derecha medio.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+Colocar jerarquía de izquierda a derecha arriba.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+Colocar jerarquía de derecha a izquierda abajo.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+Colocar jerarquía de derecha a izquierda arriba.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+Colocar jerarquía de derecha a izquierda arriba.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+Colocar jerarquía de arriba a abajo al centro.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+Colocar jerarquía de arriba a abajo a la izquierda.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+Colocar jerarquía de arriba a abajo a la derecha.
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+Colocar padre predeterminado.
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+Colocar radial.
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+Colocar de derecha a izquierda.
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+Colocar de arriba a abajo.
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+Colocar a la derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+type: docs
+weight: 363
+url: /es/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+type: docs
+weight: 364
+url: /es/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+Especifica si una forma colocable se aleja cuando arrastras otra forma colocable cerca de la forma en la página de dibujo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | Mover forma. |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | No mover forma. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Utilice el valor predeterminado de la página. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+Mover forma.
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+No mover forma.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Utilice el valor predeterminado de la página.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/spanish/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+type: docs
+weight: 365
+url: /es/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+type: docs
+weight: 366
+url: /es/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+Especifica el estilo de enrutamiento y la dirección para un conector en la página de dibujo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centro a centro. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Diagrama de flujo. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Diagrama de flujo. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Diagrama de flujo. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Diagrama de flujo. |
+| [NETWORK](#NETWORK) | Red |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organigrama. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organigrama. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organigrama. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organigrama. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Predeterminado de página. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Ángulo recto. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Simple. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Simple horizontal-vertical. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Simple. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Simple. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Simple. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Simple vertical-horizontal. |
+| [STRAIGHT](#STRAIGHT) | Recto. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Árbol. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Árbol. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Árbol. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Árbol. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centro a centro.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Diagrama de flujo. De abajo a arriba.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Diagrama de flujo. De izquierda a derecha.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Diagrama de flujo. De derecha a izquierda.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Diagrama de flujo. De arriba a abajo.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Red
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organigrama. De abajo a arriba.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organigrama. De izquierda a derecha.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organigrama. De derecha a izquierda.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organigrama. Dirección de arriba a abajo.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Predeterminado de página.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Ángulo recto.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Simple. De abajo a arriba.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Simple horizontal-vertical.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Simple. De izquierda a derecha.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Simple. De derecha a izquierda.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Simple. De arriba a abajo.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Simple vertical-horizontal.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Recto.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Árbol. De abajo a arriba.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Árbol. De izquierda a derecha
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Árbol. De derecha a izquierda.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Árbol. De arriba a abajo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 367
+url: /es/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de sombra para una forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de sombra para una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 368
+url: /es/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+Especifica el tipo de sombra para una forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | Especifica que el conjunto de efectos de sombra siempre se muestra. |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | Especifica que el conjunto de efectos de sombra se muestra solo si la forma tiene un Geometry Section\_Type. |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | Especifica que el conjunto de efectos de sombra se muestra solo si la forma tiene un Geometry Section\_Type y la forma es una forma de nivel superior. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+Especifica que el conjunto de efectos de sombra siempre se muestra.
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+Especifica que el conjunto de efectos de sombra se muestra solo si la forma tiene un Geometry Section\_Type.
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+Especifica que el conjunto de efectos de sombra se muestra solo si la forma tiene un Geometry Section\_Type y la forma es una forma de nivel superior.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 369
+url: /es/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+Especifica el tipo de sombra para una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el tipo de sombra para una forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el tipo de sombra para una forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el tipo de sombra para una forma.
+type: docs
+weight: 370
+url: /es/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+Especifica el tipo de sombra para una forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [INNER](#INNER) | Interno |
+| [OBLIQUE](#OBLIQUE) | Oblicuo. |
+| [SIMPLE](#SIMPLE) | Simple. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [USE_PAGE](#USE-PAGE) | Usar predeterminado de página (el predeterminado). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+Interno
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblicuo.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+Usar predeterminado de página (el predeterminado).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shdwtype/_index.md
+++ b/spanish/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica el tipo de sombra predeterminado para una página.
+type: docs
+weight: 371
+url: /es/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+Indica el tipo de sombra predeterminado para una página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Indica el tipo de sombra predeterminado para una página. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica el tipo de sombra predeterminado para una página.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Indica el tipo de sombra predeterminado para una página.
+type: docs
+weight: 372
+url: /es/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+Indica el tipo de sombra predeterminado para una página.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | Oblicuo. |
+| [SIMPLE](#SIMPLE) | Simple. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Oblicuo.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/spanish/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShowDropButtonType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica cuándo mostrar el botón de despliegue
+type: docs
+weight: 373
+url: /es/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+Especifica cuándo mostrar el botón de despliegue
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Mostrar siempre el botón desplegable. |
+| [FOCUS](#FOCUS) | Mostrar el botón desplegable cuando el control tiene el foco. |
+| [NEVER](#NEVER) | Nunca mostrar el botón desplegable. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Mostrar siempre el botón desplegable.
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+Mostrar el botón desplegable cuando el control tiene el foco.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Nunca mostrar el botón desplegable.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/spanish/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que incluyen información para cada etiqueta inteligente definida para una forma o página.
+type: docs
+weight: 374
+url: /es/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+Contiene elementos que incluyen información para cada etiqueta inteligente definida para una forma o página.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | Contiene el ID de la imagen de la cara del botón que aparece en el botón de la etiqueta inteligente. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getDescription()](#getDescription--) | El elemento Description contiene una cadena que describe la etiqueta inteligente, que aparece como una información sobre herramienta cuando el usuario mantiene el mouse sobre la etiqueta. |
+| [getDisabled()](#getDisabled--) | El elemento Disabled determina si la etiqueta inteligente aparece en la ventana de dibujo. |
+| [getDisplayMode()](#getDisplayMode--) | El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getTagName()](#getTagName--) | Contiene el nombre de la etiqueta inteligente que se usa como clave para asociar la etiqueta inteligente con sus acciones. |
+| [getX()](#getX--) | La posición de la coordenada x en las coordenadas locales de la forma alrededor de la cual se coloca el botón de la etiqueta inteligente. |
+| [getXJustify()](#getXJustify--) | El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [getY()](#getY--) | La posición de la coordenada y en las coordenadas locales de la forma alrededor de la cual se coloca el botón de la etiqueta inteligente. |
+| [getYJustify()](#getYJustify--) | Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/smarttagdef\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/smarttagdef\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Contiene el ID de la imagen de la cara del botón que aparece en el botón de la etiqueta inteligente.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+El elemento Description contiene una cadena que describe la etiqueta inteligente, que aparece como una información sobre herramienta cuando el usuario mantiene el mouse sobre la etiqueta.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+El elemento Disabled determina si la etiqueta inteligente aparece en la ventana de dibujo.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+El elemento DisplayMode determina si la etiqueta inteligente aparece cuando el usuario mantiene el mouse sobre la etiqueta, cuando la forma está seleccionada, o todo el tiempo.
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Contiene el nombre de la etiqueta inteligente que se usa como clave para asociar la etiqueta inteligente con sus acciones.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La posición de la coordenada x en las coordenadas locales de la forma alrededor de la cual se coloca el botón de la etiqueta inteligente.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La posición de la coordenada y en las coordenadas locales de la forma alrededor de la cual se coloca el botón de la etiqueta inteligente.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/smarttagdef\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/smarttagdef\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección SmartTagDef.
+type: docs
+weight: 375
+url: /es/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+Colección SmartTagDef.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | Agrega el objeto SmartTagDef a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | Elimina el objeto SmartTagDef de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+Agrega el objeto SmartTagDef a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+Elimina el objeto SmartTagDef de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/spanish/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si se aplica suavizado antialiasing a líneas y curvas y a los bordes de áreas rellenas.
+type: docs
+weight: 376
+url: /es/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+Especifica si el suavizado (antialiasing) se aplica a líneas y curvas y a los bordes de áreas rellenas.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | Especifica renderizado con antialiasing. |
+| [DEFAULT](#DEFAULT) | Especifica sin antialiasing. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Especifica renderizado con antialiasing. |
+| [HIGH_SPEED](#HIGH-SPEED) | Especifica sin antialiasing. |
+| [INVALID](#INVALID) | Especifica un modo no válido. |
+| [NONE](#NONE) | Especifica sin antialiasing. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+Especifica renderizado con antialiasing.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Especifica sin antialiasing.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Especifica renderizado con antialiasing.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Especifica sin antialiasing.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Especifica un modo no válido.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Especifica sin antialiasing.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/snapextensions/_index.md
+++ b/spanish/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa.
+type: docs
+weight: 377
+url: /es/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+Especifica si una configuración de extensión de ajuste específica está habilitada o deshabilitada para la ventana activa. El valor puede ser una suma de los valores.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | Extensión de ajuste a la caja de alineación. |
+| [CENTER_AXES](#CENTER-AXES) | Extensión de ajuste al eje central. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | Extensión de ajuste a la curva. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | Extensión de ajuste a la tangente de la curva. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | Extensión de ajuste al centro de la elipse. |
+| [ENDPOINT](#ENDPOINT) | Extensión de ajuste al punto final. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | Extensión de ajuste horizontal al punto final. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | Extensión de ajuste perpendicular al punto final. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | Extensión de ajuste vertical al punto final. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | Extensión de ajuste a ángulos isométricos. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | Extensión de ajuste lineal. |
+| [MIDPOINT](#MIDPOINT) | Extensión de ajuste al punto medio. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | Extensión de ajuste perpendicular al punto medio. |
+| [NONE](#NONE) | No ajustar a nada. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+Extensión de ajuste a la caja de alineación.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+Extensión de ajuste al eje central.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+Extensión de ajuste a la curva.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+Extensión de ajuste a la tangente de la curva.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+Extensión de ajuste al centro de la elipse.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+Extensión de ajuste al punto final.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+Extensión de ajuste horizontal al punto final.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+Extensión de ajuste perpendicular al punto final.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+Extensión de ajuste vertical al punto final.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+Extensión de ajuste a ángulos isométricos.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+Extensión de ajuste lineal.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+Extensión de ajuste al punto medio.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+Extensión de ajuste perpendicular al punto medio.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+No ajustar a nada.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa.
+type: docs
+weight: 378
+url: /es/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+Especifica si una configuración de extensión de ajuste específica está habilitada o deshabilitada para la ventana activa. El valor puede ser una suma de los valores en la tabla siguiente.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | Extensión de ajuste a la caja de alineación. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | Extensión de ajuste al eje central. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | Extensión de ajuste a la curva. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | Extensión de ajuste a la tangente de la curva. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | Extensión de ajuste al centro de la elipse. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | Extensión de ajuste al punto final. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | Extensión de ajuste horizontal al punto final. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | Extensión de ajuste perpendicular al punto final. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | Extensión de ajuste vertical al punto final. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | Extensión de ajuste a ángulos isométricos. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | Extensión de ajuste lineal. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | Extensión de ajuste al punto medio. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | Extensión de ajuste perpendicular al punto medio. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | No ajustar a nada. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+Extensión de ajuste a la caja de alineación.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+Extensión de ajuste al eje central.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+Extensión de ajuste a la curva.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+Extensión de ajuste a la tangente de la curva.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+Extensión de ajuste al centro de la elipse.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+Extensión de ajuste al punto final.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+Extensión de ajuste horizontal al punto final.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Extensión de ajuste perpendicular al punto final.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+Extensión de ajuste vertical al punto final.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+Extensión de ajuste a ángulos isométricos.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+Extensión de ajuste lineal.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+Extensión de ajuste al punto medio.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Extensión de ajuste perpendicular al punto medio.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+No ajustar a nada.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/snapsettings/_index.md
+++ b/spanish/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana.
+type: docs
+weight: 379
+url: /es/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | Ajustar a la caja de alineación. |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Ajustar a los puntos de conexión. |
+| [DISABLED](#DISABLED) | Ajuste desactivado. |
+| [EXTENSIONS](#EXTENSIONS) | Ajustar a las opciones de extensiones de forma. |
+| [GEOMETRY](#GEOMETRY) | Ajustar a los bordes visibles de las formas. |
+| [GRID](#GRID) | Ajustar a la cuadrícula. |
+| [GUIDES](#GUIDES) | Ajustar a las guías. |
+| [HANDLES](#HANDLES) | Ajustar a los controladores de selección. |
+| [INTERSECTIONS](#INTERSECTIONS) | Ajustar a las intersecciones. |
+| [NONE](#NONE) | No ajustar a nada. |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | Ajustar a las subdivisiones de la regla. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VERTICES](#VERTICES) | Ajustar a los vértices. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+Ajustar a la caja de alineación.
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Ajustar a los puntos de conexión.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Ajuste desactivado.
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+Ajustar a las opciones de extensiones de forma.
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Ajustar a los bordes visibles de las formas.
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+Ajustar a la cuadrícula.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Ajustar a las guías.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Ajustar a los controladores de selección.
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+Ajustar a las intersecciones.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+No ajustar a nada.
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+Ajustar a las subdivisiones de la regla.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Ajustar a los vértices.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana
+type: docs
+weight: 380
+url: /es/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | Ajuste desactivado. |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | Ajustar a la caja de alineación. |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | Ajustar a los puntos de conexión. |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | Ajustar a la cuadrícula. |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | Ajustar a las guías. |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | Ajustar a las intersecciones. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | No ajustar a nada. |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | Ajustar a las subdivisiones de la regla. |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | Ajustar a los controladores de selección. |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | Ajustar a las opciones de extensiones de forma. |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | Ajustar a los bordes visibles de las formas. |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | Ajustar a los vértices. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+Ajuste desactivado.
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+Ajustar a la caja de alineación.
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+Ajustar a los puntos de conexión.
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+Ajustar a la cuadrícula.
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+Ajustar a las guías.
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+Ajustar a las intersecciones.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+No ajustar a nada.
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+Ajustar a las subdivisiones de la regla.
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+Ajustar a los controladores de selección.
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+Ajustar a las opciones de extensiones de forma.
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+Ajustar a los bordes visibles de las formas.
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+Ajustar a los vértices.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/solutionxml/_index.md
+++ b/spanish/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene datos XML bien formados específicos de la solución que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+type: docs
+weight: 381
+url: /es/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | Constructor. |
+| [SolutionXML()](#SolutionXML--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | Un nombre único para identificar el conjunto de datos XML. |
+| [getXmlValue()](#getXmlValue--) | Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/solutionxml\#getName--) |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Un nombre único para identificar el conjunto de datos XML.
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/solutionxml\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección SolutionXML.
+type: docs
+weight: 382
+url: /es/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+Colección SolutionXML.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | Agregue el SolutionXML a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [get(String name)](#get-java.lang.String-) | Obtiene el elemento con el atributo Name especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | Elimine el SolutionXML de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+Agregue el SolutionXML a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+Obtiene el elemento con el atributo Name especificado. Devuelve null si el elemento no existe.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+Elimine el SolutionXML de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el control SpinButton.
+type: docs
+weight: 383
+url: /es/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+Representa el control SpinButton.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMax()](#getMax--) | el valor máximo aceptable. |
+| [getMin()](#getMin--) | el valor mínimo aceptable. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getOrientation()](#getOrientation--) | si el SpinButton o ScrollBar está orientado verticalmente u horizontalmente. |
+| [getPosition()](#getPosition--) | el valor. |
+| [getSmallChange()](#getSmallChange--) | la cantidad en que cambia la propiedad Position |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | Para la descripción de esta propiedad, consulte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | Para la descripción de esta propiedad, consulte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | Para la descripción de esta propiedad, consulte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+el valor máximo aceptable.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+el valor mínimo aceptable.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+si el SpinButton o ScrollBar está orientado verticalmente u horizontalmente.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+el valor.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+la cantidad en que cambia la propiedad Position
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/splineknot/_index.md
+++ b/spanish/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y para un punto de control de spline y un nudo de spline representados por los elementos X, Y y A respectivamente.
+type: docs
+weight: 384
+url: /es/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+Contiene coordenadas x e y para el punto de control de una spline y el nudo de una spline, representados por los elementos X, Y y A, respectivamente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | Crea una instancia de la clase [SplineKnot](../../com.aspose.diagram/splineknot). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Uno de los nudos del spline (que no sea el último ni los dos primeros). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x de un punto de control. |
+| [getY()](#getY--) | La coordenada y de un punto de control. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/splineknot\\#getA--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/splineknot\\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/splineknot\\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/splineknot\\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/splineknot\\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+Crea una instancia de la clase [SplineKnot](../../com.aspose.diagram/splineknot).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Uno de los nudos del spline (que no sea el último ni los dos primeros).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x de un punto de control.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y de un punto de control.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/splineknot\\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/splineknot\\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/splineknot\\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/splineknot\\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/splineknot\\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección SplineKnot.
+type: docs
+weight: 385
+url: /es/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+Colección SplineKnot.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/splinestart/_index.md
+++ b/spanish/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y para el segundo punto de control de una spline, su segundo nudo, su primer nudo, el último nudo y el grado de la spline.
+type: docs
+weight: 386
+url: /es/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+Contiene las coordenadas x e y para el segundo punto de control de una spline, su segundo nudo, su primer nudo, el último nudo y el grado de la spline. Esta información se encuentra en los elementos X, Y, A, B, C y D, respectivamente.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | Crea una instancia de la clase [SplineStart](../../com.aspose.diagram/splinestart). |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | El segundo nudo de la spline. |
+| [getB()](#getB--) | El primer nudo de una spline. |
+| [getC()](#getC--) | El último nudo de la spline. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | El grado de la spline (un entero de 1 a 25). |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getX()](#getX--) | La coordenada x del segundo punto de control de una spline. |
+| [getY()](#getY--) | La coordenada y del segundo punto de control de una spline. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/splinestart\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/splinestart\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/splinestart\#getC--) |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/splinestart\#getD--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/splinestart\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/splinestart\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/splinestart\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/splinestart\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+Crea una instancia de la clase [SplineStart](../../com.aspose.diagram/splinestart).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+El segundo nudo de la spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+El primer nudo de una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+El último nudo de la spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+El grado de la spline (un entero de 1 a 25).
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+La coordenada x del segundo punto de control de una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+La coordenada y del segundo punto de control de una spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getA()](../../com.aspose.diagram/splinestart\#getA--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getB()](../../com.aspose.diagram/splinestart\#getB--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getC()](../../com.aspose.diagram/splinestart\#getC--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getD()](../../com.aspose.diagram/splinestart\#getD--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/splinestart\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/splinestart\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getX()](../../com.aspose.diagram/splinestart\#getX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getY()](../../com.aspose.diagram/splinestart\#getY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección SplineStart.
+type: docs
+weight: 387
+url: /es/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+Colección SplineStart.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/str2value/_index.md
+++ b/spanish/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor de cadena.
+type: docs
+weight: 388
+url: /es/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+Valor de cadena.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | Constructor. |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getUfev()](#getUfev--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor de cadena. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Para la descripción de esta propiedad, consulte [getUfev()](../../com.aspose.diagram/str2value\#getUfev--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valor de cadena.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/spanish/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa las opciones de flujo.
+type: docs
+weight: 390
+url: /es/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+Representa las opciones de flujo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | La ruta predeterminada (URL) guardada en el archivo HTML generado para la fuente referenciada. |
+| [getStream()](#getStream--) | Obtiene/Establece el flujo de salida para escribir los datos guardados |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | La ruta personalizada del usuario (URL) guardada en el archivo HTML generado para la fuente referenciada. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | Para la descripción de esta propiedad, consulte [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+La ruta predeterminada (URL) guardada en el archivo HTML generado para la fuente referenciada. Por ejemplo, los datos de la hoja guardados en xxx\_files/sheet001.htm, la URL utilizada en el archivo HTML principal debería ser como "src=\"xxx\_files/sheet001.htm\""
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+Obtiene/Establece el flujo de salida para escribir los datos guardados
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+La ruta personalizada del usuario (URL) guardada en el archivo HTML generado para la fuente referenciada. Si no es definida por el usuario, se utilizará DefaultPath. Por ejemplo, los datos de la hoja serán guardados por el usuario en d:/sheet001.htm, la URL utilizada en el archivo HTML principal debería ser "d:/sheet001.htm" u otra ruta relativa válida que pueda ser accedida por el archivo HTML principal.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/strvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor de cadena
+type: docs
+weight: 389
+url: /es/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+Valor de cadena
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | Constructor. |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | Constructor. |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Atributos de un elemento. |
+| [getValue()](#getValue--) | Valor de cadena. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+| unidad | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Valor de cadena.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/style/_index.md
+++ b/spanish/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Estilo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de las formas.
+type: docs
+weight: 391
+url: /es/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Style(int value)](#Style-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/styleprop/_index.md
+++ b/spanish/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan el comportamiento del estilo, como si un estilo incluye atributos de línea de texto y de relleno.
+type: docs
+weight: 392
+url: /es/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+Contiene elementos que controlan el comportamiento del estilo, como si un estilo incluye atributos de texto, línea y relleno.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getEnableFillProps()](#getEnableFillProps--) | Especifica si un estilo incluye propiedades de relleno. |
+| [getEnableLineProps()](#getEnableLineProps--) | Especifica si un estilo incluye propiedades de línea |
+| [getEnableTextProps()](#getEnableTextProps--) | Especifica si un estilo incluye propiedades de texto. |
+| [getHideForApply()](#getHideForApply--) | Especifica dónde se muestra un estilo en la interfaz de usuario de Microsoft Visio. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/styleprop\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+Especifica si un estilo incluye propiedades de relleno.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+Especifica si un estilo incluye propiedades de línea
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+Especifica si un estilo incluye propiedades de texto.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Especifica dónde se muestra un estilo en la interfaz de usuario de Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/styleprop\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/stylesheet/_index.md
+++ b/spanish/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un estilo definido en un documento.
+type: docs
+weight: 393
+url: /es/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+Representa un estilo definido en un documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Contiene una colección de elementos Char. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Contiene una colección de elementos ConnectionABCD. |
+| [getConnections()](#getConnections--) | Contiene una colección de elementos Connection. |
+| [getEvent()](#getEvent--) | Contiene elementos que especifican fórmulas que controlan eventos de forma. |
+| [getFill()](#getFill--) | Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo. |
+| [getFillStyle()](#getFillStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de relleno. |
+| [getForeign()](#getForeign--) | Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento de Microsoft Visio. |
+| [getForeignData()](#getForeignData--) | Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE. |
+| [getGroup()](#getGroup--) | Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos. |
+| [getHelp()](#getHelp--) | Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getImage()](#getImage--) | Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits. |
+| [getLayout()](#getLayout--) | Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores. |
+| [getLine()](#getLine--) | Contiene elementos que controlan los atributos de línea de una forma, como patrón, grosor y color. |
+| [getLineStyle()](#getLineStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de línea. |
+| [getMisc()](#getMisc--) | Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPageLayout()](#getPageLayout--) | Contiene Diagram que controla la configuración de diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página. |
+| [getParas()](#getParas--) | Contiene una colección de elementos Para. |
+| [getProtection()](#getProtection--) | El bloqueo ayuda a prevenir cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. |
+| [getRulerGrid()](#getRulerGrid--) | Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página. |
+| [getStyleProp()](#getStyleProp--) | Contiene elementos que controlan el comportamiento del estilo, como si un estilo incluye atributos de texto, línea y relleno. |
+| [getTabsCollection()](#getTabsCollection--) | Contiene una colección de elementos Tab. |
+| [getTextBlock()](#getTextBlock--) | Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma. |
+| [getTextStyle()](#getTextStyle--) | Elemento StyleSheet del cual este estilo hereda el formato de texto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/stylesheet\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/stylesheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Contiene una colección de elementos Char.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Contiene una colección de elementos ConnectionABCD.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Contiene una colección de elementos Connection.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Contiene elementos que especifican fórmulas que controlan eventos de forma.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Contiene los valores actuales de formato de relleno para la forma y la sombra paralela de la forma, incluyendo el patrón, el color de primer plano y el color de fondo.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de relleno.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Contiene elementos que especifican el ancho y la altura de un objeto de otro programa utilizado en un documento Microsoft Visio. También incluye elementos que especifican la distancia a la que la imagen del objeto se desplaza dentro de sus bordes.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Contiene un BLOB codificado en MIME (Multipurpose Internet Mail Extensions) de datos de imagen, como metafile de Windows, bitmap o datos OLE.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Contiene elementos que controlan cómo agregar formas a un grupo, mover miembros de un grupo y seleccionar grupos.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Contiene los valores de gamma, brillo, contraste, desenfoque, nitidez, reducción de ruido y transparencia para un mapa de bits.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Contiene elementos que controlan la colocación de formas y la configuración de enrutamiento de conectores.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Contiene elementos que controlan los atributos de línea de una forma, como el patrón, el grosor y el color. Estos elementos determinan si los extremos de la línea están formateados (por ejemplo, con una punta de flecha), el tamaño de los formatos de los extremos de la línea, el radio del círculo de redondeo aplicado a la línea y el estilo de terminación de la línea (redondo o cuadrado).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de línea.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Contiene elementos que especifican el tema del archivo de ayuda del elemento Shape y la información de derechos de autor.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Contiene Diagram que controla la configuración de diseño de página para formas y conectores, como el espaciado entre todas las formas en la página, el espaciado entre todos los conectores en la página y el estilo de enrutamiento para todos los conectores en la página.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Contiene una colección de elementos Para.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+El bloqueo ayuda a evitar cambios inadvertidos en la forma, pero no impide que Microsoft Visio restablezca valores en otras circunstancias. Tampoco protege contra cambios realizados en la ventana ShapeSheet.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Contiene elementos que especifican la configuración de las reglas y la cuadrícula de la página.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+Contiene elementos que controlan el comportamiento del estilo, como si un estilo incluye atributos de texto, línea y relleno.
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Contiene una colección de elementos Tab.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Elemento StyleSheet del cual este estilo hereda el formato de texto.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/stylesheet\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/stylesheet\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de hojas de estilo.
+type: docs
+weight: 394
+url: /es/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+Colección de hojas de estilo.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | Agregar StyleSheet a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | Obtiene el elemento con el ID especificado. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | Eliminar StyleSheet de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+Agregar StyleSheet a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+Eliminar StyleSheet de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/stylevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de las formas.
+type: docs
+weight: 395
+url: /es/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+Especifica el formato de caracteres aplicado a un rango de texto en el bloque de texto de la forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOLD](#BOLD) | Negrita. |
+| [ITALIC](#ITALIC) | Cursiva. |
+| [SMALL_CAPS](#SMALL-CAPS) | Versalitas. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [UNDERLINE](#UNDERLINE) | Subrayado. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Negrita.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Cursiva.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Versalitas.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Subrayado.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagramas a SVG.
+type: docs
+weight: 347
+url: /es/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagramas a SVG.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | La ruta personalizada del usuario (URL) guardada en el archivo SVG generado para la imagen. |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Configuración para renderizar metarchivo Emf. |
+| [getEnlargePage()](#getEnlargePage--) | Especifica si se amplía la página. |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | Define si es necesario exportar los elementos de rectángulo como etiqueta rect o no. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Define si es necesario exportar las formas guía o no. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Define si es necesario exportar la página oculta o no. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la página a renderizar. |
+| [getPageSize()](#getPageSize--) | el tamaño de página para las imágenes generadas. |
+| [getQuality()](#getQuality--) | un valor que determina la calidad de las imágenes generadas y que se aplica solo al guardar páginas en formato JPEG. |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | si esta propiedad es verdadera, el SVG generado se ajustará al viewport. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado. |
+| [getShapes()](#getShapes--) | formas a renderizar. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Define si es necesario exportar los comentarios o no. |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | Define si es necesario exportar la escala en una matriz o no. |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | Define si se guarda el patrón de línea personalizado. |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | Define si se guarda la imagen por separado. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | Para la descripción de esta propiedad, consulte [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | Para la descripción de esta propiedad, consulte [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setQuality(int value)](#setQuality-int-) | Para la descripción de esta propiedad, consulte [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | Para la descripción de esta propiedad, consulte [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | Para la descripción de esta propiedad, consulte [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | Para la descripción de esta propiedad, consulte [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+La ruta personalizada del usuario (URL) guardada en el archivo svg generado para la imagen. Si no es definida por el usuario, se utilizará el directorio actual.
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Configuración para renderizar metafiles EMF. Los metafiles EMF identificados como "EMF+ Dual" pueden contener tanto registros EMF+ como registros EMF. Cualquiera de los tipos de registro puede usarse para renderizar la imagen, solo registros EMF+, o solo registros EMF. Cuando EmfPlusPrefer está configurado, se analizarán los registros EMF+, de lo contrario solo se analizarán los registros EMF. El valor predeterminado es EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Especifica si se debe ampliar la página. Si es verdadero, se amplía la página. Si es falso, no se amplía la página. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+Define si es necesario exportar los elementos rectángulo como etiqueta rect o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Define si es necesario exportar las formas guía o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Define si es necesario exportar la página oculta o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+el tamaño de página para las imágenes generadas. Puede ser [PageSize](../../com.aspose.diagram/pagesize) o nulo. El valor predeterminado es nulo. Si PageSize es nulo, entonces el tamaño de página para la imagen generada se obtiene del diagrama de origen.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+un valor que determina la calidad de las imágenes generadas y se aplica solo al guardar páginas en formato JPEG. El valor predeterminado es 100. Tiene efecto solo al guardar en JPEG. El valor debe estar entre 0 y 100. El valor predeterminado es 100.
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+si esta propiedad es verdadera, el SVG generado se ajustará al viewport.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardará el documento si se utiliza este objeto de opciones de guardado.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+formas para renderizar. El recuento predeterminado es 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Define si es necesario exportar los comentarios o no. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+Define si es necesario exportar la escala en una matriz o no. El valor predeterminado es true.
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+Define si se guarda el patrón de línea personalizado.
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+Define si se guarda la imagen por separado.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/tab/_index.md
+++ b/spanish/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una colección de elementos Tab.
+type: docs
+weight: 396
+url: /es/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Contiene una colección de elementos Tab.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | Especifica la alineación de la pestaña. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [getLeader()](#getLeader--) | Se especificó el líder. |
+| [getPosition()](#getPosition--) | Especifica la posición de una tabulación. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/tab\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/tab\#getIX--) |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | Para la descripción de esta propiedad, consulte [getLeader()](../../com.aspose.diagram/tab\#getLeader--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/tab\#getPosition--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+Especifica la alineación de la pestaña.
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+Se especificó el líder.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Especifica la posición de una tabulación.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/tab\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/tab\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLeader()](../../com.aspose.diagram/tab\#getLeader--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPosition()](../../com.aspose.diagram/tab\#getPosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/tabcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una colección de elementos Tab.
+type: docs
+weight: 397
+url: /es/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Contiene una colección de elementos Tab.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | Agregue el objeto Tab a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getIX()](#getIX--) | El índice basado en cero del elemento dentro de su elemento padre. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | Elimine el objeto Tab de la colección. |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/tabcollection\#getDel--) |
+| [setIX(int value)](#setIX-int-) | Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/tabcollection\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+Agregue el objeto Tab a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+El índice basado en cero del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+Elimine el objeto Tab de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/tabscollection/_index.md
+++ b/spanish/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene una colección de elementos TabCollection.
+type: docs
+weight: 398
+url: /es/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+Contiene una colección de elementos TabCollection.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | Agregue el objeto Tab a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | Elimine el objeto Tab de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+Agregue el objeto Tab a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+Elimine el objeto Tab de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/text/_index.md
+++ b/spanish/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: Texto
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene el texto de una forma.
+type: docs
+weight: 399
+url: /es/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+Contiene el texto de una forma.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Text()](#Text--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Colección FormatTxt que contiene el texto de una forma. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+Colección FormatTxt que contiene el texto de una forma.
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textblock/_index.md
+++ b/spanish/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican los márgenes de alineación y las posiciones de tabulación predeterminadas del texto en el bloque de texto de una forma.
+type: docs
+weight: 400
+url: /es/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+Contiene elementos que especifican la alineación, los márgenes y las posiciones predeterminadas de tabulaciones del texto en el bloque de texto de una forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | Determina la distancia entre el borde inferior del bloque de texto y la última línea de texto que contiene. |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | Especifica el intervalo de las tabulaciones predeterminadas en un bloque de texto. |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getLeftMargin()](#getLeftMargin--) | Especifica la distancia entre el borde izquierdo del bloque de texto y el texto que contiene. |
+| [getRightMargin()](#getRightMargin--) | Especifica la distancia entre el borde derecho del bloque de texto y el texto que contiene. |
+| [getTextBkgnd()](#getTextBkgnd--) | Especifica el color de fondo del texto para una forma. |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | Especifica el nivel de transparencia del color de fondo del bloque de texto de una forma, de 0 (completamente opaco) a 1 (completamente transparente). |
+| [getTextDirection()](#getTextDirection--) | Especifica la dirección de los caracteres en un bloque de texto. |
+| [getTopMargin()](#getTopMargin--) | Especifica la distancia entre el borde superior del bloque de texto y la primera línea de texto que contiene. |
+| [getVerticalAlign()](#getVerticalAlign--) | Especifica la alineación vertical del texto dentro del bloque de texto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/textblock\#getDel--) |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | Para la descripción de esta propiedad, consulte [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | Para la descripción de esta propiedad, consulte [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+Determina la distancia entre el borde inferior del bloque de texto y la última línea de texto que contiene. El valor predeterminado es 4 pt. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, el margen inferior permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+Especifica el intervalo de las tabulaciones predeterminadas en un bloque de texto.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+Especifica la distancia entre el borde izquierdo del bloque de texto y el texto que contiene. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, el margen izquierdo permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+Especifica la distancia entre el borde derecho del bloque de texto y el texto que contiene. Este valor es independiente de la escala del dibujo. Si el dibujo se escala, el margen derecho permanece igual.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+Especifica el color de fondo del texto para una forma.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+Especifica el nivel de transparencia del color de fondo del bloque de texto de una forma, de 0 (completamente opaco) a 1 (completamente transparente).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+Especifica la dirección de los caracteres en un bloque de texto.
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+Especifica la distancia entre el borde superior del bloque de texto y la primera línea de texto que contiene.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+Especifica la alineación vertical del texto dentro del bloque de texto.
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/textblock\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX de cuadro de texto.
+type: docs
+weight: 401
+url: /es/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+Representa un control ActiveX de cuadro de texto.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getBorderOleColor()](#getBorderOleColor--) | el color OLE del fondo. |
+| [getBorderStyle()](#getBorderStyle--) | el tipo de borde utilizado por el control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Especifica el símbolo que se muestra en el botón desplegable |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Especifica el comportamiento de selección al entrar al control. |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | Especifica el comportamiento de la tecla ENTER. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getHideSelection()](#getHideSelection--) | Indica si el texto seleccionado en el control aparece resaltado cuando el control no tiene el foco. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indica si el control solo mostrará líneas completas de texto sin mostrar líneas parciales. |
+| [getMaxLength()](#getMaxLength--) | el número máximo de caracteres |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPasswordChar()](#getPasswordChar--) | un carácter que se mostrará en lugar de los caracteres introducidos. |
+| [getScrollBars()](#getScrollBars--) | Indica si el control tiene barras de desplazamiento verticales, horizontales, ambas o ninguna. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Especifica el símbolo que se muestra en el botón desplegable |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | Indica si se permiten caracteres de tabulación en el texto del control. |
+| [getText()](#getText--) | texto del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isAutoTab()](#isAutoTab--) | Indica si el foco se moverá automáticamente al siguiente control cuando el usuario ingrese el número máximo de caracteres. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Especifica la unidad básica utilizada para ampliar una selección. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indica si arrastrar y soltar está habilitado para el control. |
+| [isEditable()](#isEditable--) | Indica si el usuario puede escribir en el control. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isMultiLine()](#isMultiLine--) | Indica si el control puede mostrar más de una línea de texto. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isWordWrapped()](#isWordWrapped--) | Indica si el contenido del control se ajusta automáticamente al final de una línea. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | Para la descripción de esta propiedad, consulte [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | Para la descripción de esta propiedad, consulte [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | Para la descripción de esta propiedad, consulte [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | Para la descripción de esta propiedad, consulte [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | Para la descripción de esta propiedad, consulte [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | Para la descripción de esta propiedad, consulte [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | Para la descripción de esta propiedad, consulte [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | Para la descripción de esta propiedad, consulte [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | Para la descripción de esta propiedad, consulte [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | Para la descripción de esta propiedad, consulte [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | Para la descripción de esta propiedad, consulte [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | Para la descripción de esta propiedad, consulte [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | Para la descripción de esta propiedad, consulte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | Para la descripción de esta propiedad, consulte [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) |
+| [setText(String value)](#setText-java.lang.String-) | Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+el tipo de borde utilizado por el control.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Especifica el símbolo que se muestra en el botón desplegable
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Especifica el comportamiento de selección al entrar en el control. True especifica que la selección permanece sin cambios desde la última vez que el control estuvo activo. False especifica que todo el texto en el control será seleccionado al entrar en el control.
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+Especifica el comportamiento de la tecla ENTER. Verdadero indica que al presionar ENTER se creará una nueva línea. Falso indica que al presionar ENTER el foco se moverá al siguiente objeto en el orden de tabulación.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indica si el texto seleccionado en el control aparece resaltado cuando el control no tiene el foco.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indica si el control solo mostrará líneas completas de texto sin mostrar líneas parciales.
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+el número máximo de caracteres
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+un carácter que se mostrará en lugar de los caracteres introducidos.
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indica si el control tiene barras de desplazamiento verticales, horizontales, ambas o ninguna.
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Especifica el símbolo que se muestra en el botón desplegable
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+Indica si se permiten caracteres de tabulación en el texto del control.
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+texto del control.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+Indica si el foco se moverá automáticamente al siguiente control cuando el usuario ingrese el número máximo de caracteres.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Especifica la unidad básica utilizada para ampliar una selección. True especifica que la unidad básica es un solo carácter. false especifica que la unidad básica es una palabra completa.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indica si arrastrar y soltar está habilitado para el control.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indica si el usuario puede escribir en el control.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+Indica si el control puede mostrar más de una línea de texto.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Indica si el contenido del control se ajusta automáticamente al final de una línea.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene el texto de una forma.
+type: docs
+weight: 402
+url: /es/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+Contiene el texto de una forma. Cada elemento es texto con propiedades de carácter, párrafo y tabulaciones.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | Agregar el objeto Text a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | Eliminar el objeto Text de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+Agregar el objeto Text a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+Eliminar el objeto Text de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textdirection/_index.md
+++ b/spanish/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los caracteres en un bloque de texto.
+type: docs
+weight: 403
+url: /es/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+Especifica la dirección de los caracteres en un bloque de texto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la dirección de los caracteres en un bloque de texto. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/textdirection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la dirección de los caracteres en un bloque de texto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/textdirection\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la dirección de los caracteres en un bloque de texto.
+type: docs
+weight: 404
+url: /es/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+Especifica la dirección de los caracteres en un bloque de texto.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | Horizontal. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VERTICAL](#VERTICAL) | Vertical. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Horizontal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Vertical.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/textxform/_index.md
+++ b/spanish/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que especifican información de posicionamiento sobre el bloque de texto de una forma.
+type: docs
+weight: 405
+url: /es/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+Contiene elementos que especifican información de posicionamiento sobre el bloque de texto de una forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getTxtAngle()](#getTxtAngle--) | Especifica el ángulo de rotación actual del bloque de texto en relación con el eje x de la forma. |
+| [getTxtHeight()](#getTxtHeight--) | Especifica la altura del bloque de texto. |
+| [getTxtLocPinX()](#getTxtLocPinX--) | Especifica la coordenada x del centro de rotación del bloque de texto en relación con el origen del bloque de texto. |
+| [getTxtLocPinY()](#getTxtLocPinY--) | Especifica la coordenada y del centro de rotación del bloque de texto en relación con el origen del bloque de texto. |
+| [getTxtPinX()](#getTxtPinX--) | Especifica la coordenada x del centro de rotación del bloque de texto en relación con el origen de la forma. |
+| [getTxtPinY()](#getTxtPinY--) | Especifica la coordenada y del centro de rotación del bloque de texto en relación con el origen de la forma. |
+| [getTxtWidth()](#getTxtWidth--) | Especifica el ancho del bloque de texto. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/textxform\#getDel--) |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--) |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--) |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--) |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--) |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--) |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--) |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+Especifica el ángulo de rotación actual del bloque de texto en relación con el eje x de la forma. El valor predeterminado es 0 grados.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+Especifica la altura del bloque de texto. La fórmula predeterminada, que evalúa a la altura de la forma, es F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+Especifica la coordenada x del centro de rotación del bloque de texto en relación con el origen del bloque de texto. La fórmula predeterminada, que evalúa al centro horizontal del bloque de texto, es F="TxtWidth\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+Especifica la coordenada y del centro de rotación del bloque de texto en relación con el origen del bloque de texto. La fórmula predeterminada, que evalúa al centro vertical del bloque de texto, es F="TxtHeight\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+Especifica la coordenada x del centro de rotación del bloque de texto en relación con el origen de la forma. La fórmula predeterminada, que evalúa al centro horizontal de la forma, es F="Width\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+Especifica la coordenada y del centro de rotación del bloque de texto en relación con el origen de la forma. La fórmula predeterminada, que evalúa al centro vertical de la forma, es F="Height\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+Especifica el ancho del bloque de texto. La fórmula predeterminada, que evalúa al ancho de la forma, es F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/textxform\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/threedformat/_index.md
+++ b/spanish/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el formato tridimensional de una forma.
+type: docs
+weight: 406
+url: /es/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+Representa el formato tridimensional de una forma.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | Especifica la altura del bisel inferior en una forma 3D. |
+| [getBevelBottomType()](#getBevelBottomType--) | Especifica el tipo de bisel predefinido para el bisel inferior en una forma 3D |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | Especifica el ancho del bisel inferior en una forma 3D. |
+| [getBevelContourColor()](#getBevelContourColor--) | Especifica el color del contorno en una forma 3D |
+| [getBevelContourSize()](#getBevelContourSize--) | Especifica el grosor del contorno en una forma 3D |
+| [getBevelDepthColor()](#getBevelDepthColor--) | Especifica el color de la extrusión en una forma 3D |
+| [getBevelDepthSize()](#getBevelDepthSize--) | Especifica la profundidad de la extrusión en una forma 3D |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | Especifica la dirección de la iluminación en una forma 3D. |
+| [getBevelLightingType()](#getBevelLightingType--) | Especifica el tipo de iluminación predefinido en una forma 3D |
+| [getBevelMaterialType()](#getBevelMaterialType--) | Especifica la apariencia de superficie predefinida en una forma 3D |
+| [getBevelTopHeight()](#getBevelTopHeight--) | Especifica la altura del bisel superior en una forma 3D |
+| [getBevelTopType()](#getBevelTopType--) | Especifica el tipo de bisel predefinido para el bisel superior en una forma 3D |
+| [getBevelTopWidth()](#getBevelTopWidth--) | Especifica el ancho del bisel superior en una forma 3D. |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | Especifica la distancia que una forma con propiedades de rotación 3D |
+| [getKeepTextFlat()](#getKeepTextFlat--) | Especifica si las propiedades de rotación 3D se aplican al texto de una forma |
+| [getPerspective()](#getPerspective--) | Especifica el ángulo de visión para una forma con propiedades de rotación 3D |
+| [getRotationType()](#getRotationType--) | Especifica el tipo de proyección de las propiedades de efecto de una forma. |
+| [getRotationXAngle()](#getRotationXAngle--) | Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje y. |
+| [getRotationYAngle()](#getRotationYAngle--) | Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje x |
+| [getRotationZAngle()](#getRotationZAngle--) | Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje z. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | Para la descripción de esta propiedad, consulte [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | Para la descripción de esta propiedad, consulte [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | Para la descripción de esta propiedad, consulte [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | Para la descripción de esta propiedad, consulte [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | Para la descripción de esta propiedad, consulte [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | Para la descripción de esta propiedad, consulte [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+Especifica la altura del bisel inferior en una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+Especifica el tipo de bisel predefinido para el bisel inferior en una forma 3D
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+Especifica el ancho del bisel inferior en una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+Especifica el color del contorno en una forma 3D
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+Especifica el grosor del contorno en una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+Especifica el color de la extrusión en una forma 3D
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+Especifica la profundidad de la extrusión en una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+Especifica la dirección de la iluminación en una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+Especifica el tipo de iluminación predefinido en una forma 3D
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+Especifica la apariencia de superficie predefinida en una forma 3D
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+Especifica la altura del bisel superior en una forma 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+Especifica el tipo de bisel predefinido para el bisel superior en una forma 3D
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+Especifica el ancho del bisel superior en una forma 3D.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+Especifica la distancia que una forma con propiedades de rotación 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+Especifica si las propiedades de rotación 3D se aplican al texto de una forma
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+Especifica el ángulo de visión para una forma con propiedades de rotación 3D
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+Especifica el tipo de proyección de las propiedades de efecto de una forma.
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje y.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje x
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+Especifica el ángulo de rotación en sentido antihorario de una forma alrededor del eje z.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/spanish/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica qué tipo de compresión aplicar al guardar páginas en formato TIFF.
+type: docs
+weight: 407
+url: /es/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+Especifica qué tipo de compresión aplicar al guardar páginas en formato TIFF.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | Especifica el esquema de compresión CCITT3. |
+| [CCITT_4](#CCITT-4) | Especifica el esquema de compresión CCITT4. |
+| [LZW](#LZW) | Especifica el esquema de compresión LZW. |
+| [NONE](#NONE) | Especifica sin compresión. |
+| [RLE](#RLE) | Especifica el esquema de compresión RLE. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+Especifica el esquema de compresión CCITT3.
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+Especifica el esquema de compresión CCITT4.
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+Especifica el esquema de compresión LZW.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Especifica sin compresión.
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+Especifica el esquema de compresión RLE.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/spanish/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Referencia de API de Aspose.Diagram para Java
+description: TimeLineHelper para establecer la propiedad de la forma de línea de tiempo.
+type: docs
+weight: 408
+url: /es/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+TimeLineHelper para establecer la propiedad de la forma de línea de tiempo.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | Convertir la fecha y hora a valor doble. |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | Periodo de tiempo para el final de la forma de línea de tiempo |
+| [getTimePeriodStart()](#getTimePeriodStart--) | Periodo de tiempo para el inicio de la forma de línea de tiempo |
+| [getTimeScale()](#getTimeScale--) | escala de la forma de línea de tiempo |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | Actualizar tiempo de las formas de línea de tiempo |
+| [setArrowHead(int value)](#setArrowHead-int-) | ArrowHead de la forma de línea de tiempo |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | si se actualizan los datos de los marcadores (hitos, intervalos) a medida que se mueven en la línea de tiempo |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | Semana de inicio de la forma de línea de tiempo |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | Formato de fecha para el inicio y final de la forma de línea de tiempo /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | Formato de fecha para Intm de la forma de línea de tiempo /// |
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | Cadena de formato de fecha para el inicio y final de la forma de línea de tiempo |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | Cadena de formato de fecha para Intm de la forma de línea de tiempo |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | si se muestran las fechas de Inicio y Fin en la línea de tiempo |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | si se muestran marcas de fecha/hora intermedias en la línea de tiempo |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | si se muestran fechas intermedias en las marcas intermedias |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | Primer día del año fiscal |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | Semana de inicio de la forma de línea de tiempo |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+Convertir la fecha y hora a valor doble.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | La fecha y hora. |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+Periodo de tiempo para el final de la forma de línea de tiempo
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+Periodo de tiempo para el inicio de la forma de línea de tiempo
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+escala de la forma de línea de tiempo
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| weekStart | int | (0domingo 1lunes 2 3 4 5 6) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+Actualizar tiempo de las formas de línea de tiempo
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+ArrowHead de la forma de línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+si se actualizan los datos de los marcadores (hitos, intervalos) a medida que se mueven en la línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+Semana de inicio de la forma de línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+Formato de fecha para el inicio y final de la forma de línea de tiempo ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+Formato de fecha para Intm de la forma de línea de tiempo ///
+
+| ----------------------- | ------------------------------- |
+| **Value**\u9286\u20ac | **Format String**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+Cadena de formato de fecha para el inicio y final de la forma de línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+Cadena de formato de fecha para Intm de la forma de línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+si se muestran las fechas de Inicio y Fin en la línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+si se muestran marcas de fecha/hora intermedias en la línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+si se muestran fechas intermedias en las marcas intermedias
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+Primer día del año fiscal
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+Semana de inicio de la forma de línea de tiempo
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa un control ActiveX de botón de alternancia.
+type: docs
+weight: 410
+url: /es/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+Representa un control ActiveX de botón de alternancia.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | la tecla de acceso rápido para el control. |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getCaption()](#getCaption--) | el texto descriptivo que aparece en un control. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPicture()](#getPicture--) | los datos de la imagen. |
+| [getPicturePosition()](#getPicturePosition--) | la ubicación de la imagen del control relativa a su leyenda. |
+| [getSpecialEffect()](#getSpecialEffect--) | el efecto especial del control. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getValue()](#getValue--) | Indica si el control está marcado o no. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [isTripleState()](#isTripleState--) | Indica cómo el control especificado mostrará los valores Null. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+la tecla de acceso rápido para el control.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+el texto descriptivo que aparece en un control.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+los datos de la imagen.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+la ubicación de la imagen del control relativa a su leyenda.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+el efecto especial del control.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Indica si el control está marcado o no.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Indica cómo el control especificado mostrará los valores Null.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Configuración | Descripción                                                                                                                                     |
+| True    | El control ciclará a través de los estados para los valores Sí, No y Null. El control aparece atenuado (gris) cuando su propiedad Value está establecida en Null. |
+| False   | (Predeterminado) El control ciclará a través de los estados para los valores Sí y No. Los valores Null se muestran como si fueran valores No.                           |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/topartvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: La parte de una forma a la que se hace una conexión.
+type: docs
+weight: 409
+url: /es/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+La parte de una forma a la que se hace una conexión.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | Punto de conexión. |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | Intersección de guía. |
+| [GUIDE_X](#GUIDE-X) | GuideX. |
+| [GUIDE_Y](#GUIDE-Y) | GuideY. |
+| [NONE](#NONE) | Ninguno. |
+| [TO_ANGLE](#TO-ANGLE) | Al ángulo. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | Forma completa. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+Punto de conexión.
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+Intersección de guía.
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuideX.
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuideY.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ninguno.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+Al ángulo.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+Forma completa.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/tp/_index.md
+++ b/spanish/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el comienzo de una ejecución de propiedades de tabulaciones.
+type: docs
+weight: 411
+url: /es/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+Especifica el comienzo de una secuencia de propiedades de tabulaciones. La secuencia se define hasta el final del texto o hasta el siguiente
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| IX | int | El índice basado en cero del elemento dentro de su elemento padre. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/txt/_index.md
+++ b/spanish/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Texto
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Texto de la forma
+type: docs
+weight: 412
+url: /es/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+Texto de la forma
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | Constructor |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | Contiene el texto de una forma. |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/txt\#getText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+Constructor
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String | Texto de la forma. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Contiene el texto de una forma.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getText()](../../com.aspose.diagram/txt\#getText--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typeconnection/_index.md
+++ b/spanish/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica varios tipos basados en el elemento en el que está contenido.
+type: docs
+weight: 413
+url: /es/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+Especifica varios tipos, según el elemento en el que está contenido.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica varios tipos, según el elemento en el que está contenido. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typeconnection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica varios tipos, según el elemento en el que está contenido.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica varios tipos basados en el elemento en el que está contenido.
+type: docs
+weight: 414
+url: /es/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+Especifica varios tipos, según el elemento en el que está contenido.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [INWARD](#INWARD) | Inward. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Inward and outward. |
+| [OUTWARD](#OUTWARD) | Outward. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Inward.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Inward and outward.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Outward.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typefield/_index.md
+++ b/spanish/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo especifica un tipo de datos para el valor del campo de texto.
+type: docs
+weight: 415
+url: /es/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Tipo especifica un tipo de datos para el valor del campo de texto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Tipo especifica un tipo de datos para el valor del campo de texto. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typefield\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Tipo especifica un tipo de datos para el valor del campo de texto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typefield\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo especifica un tipo de datos para el valor del campo de texto.
+type: docs
+weight: 416
+url: /es/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Tipo especifica un tipo de datos para el valor del campo de texto.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | Valor de moneda. |
+| [DATE_TIME](#DATE-TIME) | Valor de fecha o hora. |
+| [DURATION](#DURATION) | Valor de duración. |
+| [NUMBER](#NUMBER) | Número. |
+| [STRING](#STRING) | Cadena. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valor monetario. Utiliza la configuración regional actual del sistema.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Valor de fecha o hora. Muestra días, meses y años, o segundos, minutos y horas, o un valor combinado de fecha y hora.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Valor de duración. Muestra el tiempo transcurrido.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Número. Incluye valores de fecha, hora, duración y moneda, así como escalares, dimensiones y ángulos.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Cadena.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typeprop/_index.md
+++ b/spanish/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+type: docs
+weight: 417
+url: /es/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Tipo especifica un tipo de datos para el valor de la propiedad personalizada. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typeprop\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/typeprop\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+type: docs
+weight: 418
+url: /es/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Tipo especifica un tipo de datos para el valor de la propiedad personalizada.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | Booleano. |
+| [CURRENCY](#CURRENCY) | Valor de moneda. |
+| [DATE_TIME](#DATE-TIME) | Valor de fecha o hora. |
+| [DURATION](#DURATION) | Valor de duración. |
+| [FIXED_LIST](#FIXED-LIST) | Lista fija. |
+| [NUMBER](#NUMBER) | Número. |
+| [STRING](#STRING) | Cadena. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | Lista variable. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Boolean. Muestra FALSE y TRUE como elementos que los usuarios pueden seleccionar de un cuadro de lista desplegable en el cuadro de diálogo Propiedades personalizadas en la aplicación Visio.
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valor de moneda. Utiliza la configuración regional actual del sistema.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Valor de fecha o hora. Muestra días, meses y años, o segundos, minutos y horas, o un valor combinado de fecha y hora.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Valor de duración. Muestra el tiempo transcurrido.
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+Lista fija. Muestra los elementos de la lista en un cuadro combinado desplegable en el cuadro de diálogo Propiedades personalizadas.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Número. Incluye valores de fecha, hora, duración y moneda, así como escalares, dimensiones y ángulos.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Cadena. Este es el valor predeterminado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+Lista variable. Muestra los elementos de la lista en un cuadro combinado desplegable en el cuadro de diálogo Propiedades personalizadas en Visio. Los usuarios pueden seleccionar un elemento de la lista o introducir un nuevo elemento que se agrega a la lista actual en el elemento Formato.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/typevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Enumeración opcional.
+type: docs
+weight: 419
+url: /es/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+Enumeración opcional. El tipo de una forma.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | Extranjero. |
+| [GROUP](#GROUP) | Grupo. |
+| [GUIDE](#GUIDE) | Guía. |
+| [SHAPE](#SHAPE) | Forma. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+Extranjero.
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+Grupo.
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+Guía.
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+Forma.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/uivisibility/_index.md
+++ b/spanish/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación de la pestaña.
+type: docs
+weight: 420
+url: /es/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+Especifica la alineación de la pestaña.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la uivisibility. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/uivisibility\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la uivisibility.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación de la pestaña.
+type: docs
+weight: 421
+url: /es/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+Especifica la alineación de la pestaña.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | Oculto. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VISIBLE](#VISIBLE) | Visible . |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+Oculto.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+Visible .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/spanish/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica los atributos de un elemento.
+type: docs
+weight: 422
+url: /es/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+Especifica los atributos de un elemento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | Constructor. |
+| [UnitFormulaErr()](#UnitFormulaErr--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indica que la fórmula evalúa a un error. |
+| [getF()](#getF--) | Representa la fórmula del elemento. |
+| [getUnit()](#getUnit--) | Unidades de medida. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Para la descripción de esta propiedad, consulte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Para la descripción de esta propiedad, consulte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unidad | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indica que la fórmula evalúa a un error.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Representa la fórmula del elemento.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Unidades de medida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/spanish/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Atributos especificados de un elemento.
+type: docs
+weight: 423
+url: /es/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+Atributos especificados de un elemento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indica que la fórmula evalúa a un error. |
+| [getF()](#getF--) | Representa la fórmula del elemento. |
+| [getUnit()](#getUnit--) | Unidades de medida. |
+| [getV()](#getV--) | Representa la condición de cadena nula para el valor de una celda de cadena. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | Para la descripción de esta propiedad, consulte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | Para la descripción de esta propiedad, consulte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [setV(String value)](#setV-java.lang.String-) | Para la descripción de esta propiedad, consulte [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| unidad | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indica que la fórmula evalúa a un error.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Representa la fórmula del elemento.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Unidades de medida.
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+Representa la condición de cadena nula para el valor de una celda de cadena. En algunos casos es útil distinguir entre una celda de cadena vacía nula y un valor de cadena nula. Este atributo se utiliza para distinguir entre estas formas de un valor vacío.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/spanish/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Control desconocido.
+type: docs
+weight: 424
+url: /es/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+Control desconocido.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | el color OLE del fondo. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | los datos binarios del control. |
+| [getForeOleColor()](#getForeOleColor--) | el color OLE del primer plano. |
+| [getHeight()](#getHeight--) | la altura del control en unidades de puntos. |
+| [getIMEMode()](#getIMEMode--) | el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco. |
+| [getMouseIcon()](#getMouseIcon--) | un ícono personalizado para mostrar como puntero del mouse del control. |
+| [getMousePointer()](#getMousePointer--) | el tipo de ícono que se muestra como puntero del mouse del control. |
+| [getPersistenceType()](#getPersistenceType--) | Obtiene el método de persistencia para persistir un control ActiveX. |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | Obtiene los datos de la relación. |
+| [getType()](#getType--) | Obtiene el tipo del control ActiveX. |
+| [getWidth()](#getWidth--) | el ancho del control en unidades de punto. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido. |
+| [isEnabled()](#isEnabled--) | Indica si el control puede recibir el foco y responder a eventos generados por el usuario. |
+| [isLocked()](#isLocked--) | Indica si los datos del control están bloqueados para edición. |
+| [isTransparent()](#isTransparent--) | Indica si el control es transparente. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+el color OLE del fondo.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+los datos binarios del control.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+El color OLE del primer plano. No se aplica al control Image.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+la altura del control en unidades de puntos.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+el modo de ejecución predeterminado del Editor de Métodos de Entrada para el control al recibir el foco.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+un ícono personalizado para mostrar como puntero del mouse del control.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+el tipo de ícono que se muestra como puntero del mouse del control.
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+Obtiene el método de persistencia para persistir un control ActiveX.
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+Obtiene los datos de la relación.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| relId | java.lang.String | El identificador de la relación. |
+
+**Returns:**
+byte[] - devuelve los datos de la relación.
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo del control ActiveX.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+el ancho del control en unidades de punto.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indica si el control cambiará de tamaño automáticamente para mostrar todo su contenido.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indica si el control puede recibir el foco y responder a eventos generados por el usuario.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indica si los datos del control están bloqueados para edición.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indica si el control es transparente.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/user/_index.md
+++ b/spanish/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: Usuario
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene un área de trabajo para ingresar fórmulas en elementos específicos del usuario que son referenciados por otros elementos y herramientas complementarias.
+type: docs
+weight: 425
+url: /es/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+Contiene un área de trabajo para ingresar fórmulas en elementos específicos del usuario que son referenciados por otros elementos y herramientas complementarias.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [User()](#User--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getName()](#getName--) | El nombre del elemento. |
+| [getNameU()](#getNameU--) | El nombre universal del elemento. |
+| [getPrompt()](#getPrompt--) | Especifica una indicación descriptiva o comentario para el elemento definido por el usuario. |
+| [getValue()](#getValue--) | Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/user\#getDel--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/user\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/user\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/user\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/user\#getPrompt--) |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/user\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+Constructor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+El nombre del elemento.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+El nombre universal del elemento.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Especifica una indicación descriptiva o comentario para el elemento definido por el usuario.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/user\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/user\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/user\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getNameU()](../../com.aspose.diagram/user\#getNameU--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/user\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/usercollection/_index.md
+++ b/spanish/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de usuarios.
+type: docs
+weight: 426
+url: /es/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+Colección de usuarios.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | Agregar el objeto User a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [getUser(int ID)](#getUser-int-) | Obtiene el elemento con el ID especificado. |
+| [getUser(String name)](#getUser-java.lang.String-) | Obtiene el elemento con el ID especificado. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | Eliminar el objeto User de la colección. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+Agregar el objeto User a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+Obtiene el elemento con el ID especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+Eliminar el objeto User de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/validation/_index.md
+++ b/spanish/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: Validación
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Almacena información sobre la validación del diagrama para el documento.
+type: docs
+weight: 427
+url: /es/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+Almacena información sobre la validación del diagrama para el documento.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | Contiene todos los elementos Issue del documento. |
+| [getRuleSets()](#getRuleSets--) | Incluye un elemento RuleSet para cada conjunto de reglas de validación en el documento. |
+| [getValidationProperties()](#getValidationProperties--) | Encapsula propiedades relacionadas con la validación del documento. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+Contiene todos los elementos Issue del documento.
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+Incluye un elemento RuleSet para cada conjunto de reglas de validación en el documento.
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+Encapsula propiedades relacionadas con la validación del documento.
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/validationproperties/_index.md
+++ b/spanish/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Encapsula propiedades relacionadas con la validación del documento.
+type: docs
+weight: 428
+url: /es/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+Encapsula propiedades relacionadas con la validación del documento.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | La fecha y hora en que el documento fue validado por última vez |
+| [getShowIgnored()](#getShowIgnored--) | Indica si se deben mostrar los problemas de validación ignorados en la ventana de Problemas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | Para la descripción de esta propiedad, consulte [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | Para la descripción de esta propiedad, consulte [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+La fecha y hora en que el documento fue validado por última vez
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Indica si se deben mostrar los problemas de validación ignorados en la ventana de Problemas.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/value/_index.md
+++ b/spanish/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: Value
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Valor.
+type: docs
+weight: 429
+url: /es/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+Valor.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento. |
+| [getUfev()](#getUfev--) | Atributos especificados de un elemento. |
+| [getVal()](#getVal--) | Valor de texto |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | Para la descripción de esta propiedad, consulte [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | Para la descripción de esta propiedad, consulte [getUfev()](../../com.aspose.diagram/value\#getUfev--) |
+| [setVal(String value)](#setVal-java.lang.String-) | Para la descripción de esta propiedad, consulte [getVal()](../../com.aspose.diagram/value\#getVal--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+Contiene datos XML bien formados, específicos de la solución, que están prefijados en un espacio de nombres explícito y se almacenan con un documento.
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Atributos especificados de un elemento.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+Valor de texto
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfev()](../../com.aspose.diagram/value\#getUfev--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getVal()](../../com.aspose.diagram/value\#getVal--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbamodule/_index.md
+++ b/spanish/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el módulo que está contenido en el proyecto VBA.
+type: docs
+weight: 430
+url: /es/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+Representa el módulo que está contenido en el proyecto VBA.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | los códigos del módulo. |
+| [getName()](#getName--) | el nombre del módulo. |
+| [getType()](#getType--) | Obtiene el tipo de módulo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | Para la descripción de esta propiedad, consulte [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbamodule\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+los códigos del módulo.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+el nombre del módulo.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo de módulo.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbamodule\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la lista de
+type: docs
+weight: 431
+url: /es/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+Representa la lista de [VbaModule](../../com.aspose.diagram/vbamodule)
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Agrega módulo para una página. |
+| [add(int type, String name)](#add-int-java.lang.String-) | Agrega módulo. |
+| [add(Object o)](#add-java.lang.Object-) | Agrega un elemento a la instancia de CollectionBase. |
+| [clear()](#clear--) | Elimina todos los objetos de la instancia de CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Devuelve si la instancia contiene este objeto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene [VbaModule](../../com.aspose.diagram/vbamodule) en la lista por el índice. |
+| [get(String name)](#get-java.lang.String-) | Obtiene [VbaModule](../../com.aspose.diagram/vbamodule) en la lista por el nombre. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos contenidos en la instancia de CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+| [iterator()](#iterator--) | Devuelve un enumerador que recorre la instancia de CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Elimina el módulo de una página. |
+| [remove(String name)](#remove-java.lang.String-) | Eliminar el módulo por el nombre |
+| [removeAt(int index)](#removeAt-int-) | Elimina el elemento en el índice especificado. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Agrega módulo para una página.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | La página |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+Agrega módulo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| tipo | int | El tipo de módulo. |
+| nombre | java.lang.String | El nombre del módulo. |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Agrega un elemento a la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | El objeto a agregar a la instancia de CollectionBase. |
+
+**Returns:**
+int - La posición en la que se insertó el nuevo elemento.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los objetos de la instancia de CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Devuelve si la instancia contiene este objeto
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | objeto de prueba |
+
+**Returns:**
+boolean - Indica si la instancia contiene este objeto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+Obtiene [VbaModule](../../com.aspose.diagram/vbamodule) en la lista por el índice.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | El índice. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+Obtiene [VbaModule](../../com.aspose.diagram/vbamodule) en la lista por el nombre.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | El nombre del módulo. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos contenidos en la instancia de CollectionBase.
+
+**Returns:**
+int - El número de elementos contenidos en la instancia de CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina el índice de un elemento específico en la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+
+**Returns:**
+int - El índice del valor si se encuentra en la lista; de lo contrario, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Devuelve un enumerador que recorre la instancia de CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iterador para la instancia de CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Elimina el módulo de una página.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | La página |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+Eliminar el módulo por el nombre
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Elimina el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | El índice basado en cero del elemento a eliminar. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/spanish/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de módulo VBA.
+type: docs
+weight: 432
+url: /es/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+Representa el tipo de módulo VBA.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CLASS](#CLASS) | Representa un módulo de clase. |
+| [DESIGNER](#DESIGNER) | Representa un módulo de diseñador. |
+| [DOCUMENT](#DOCUMENT) | Representa un módulo de documento. |
+| [PROCEDURAL](#PROCEDURAL) | Representa un módulo procedural. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+Representa un módulo de clase.
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+Representa un módulo de diseñador.
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Representa un módulo de documento.
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+Representa un módulo procedural.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbaproject/_index.md
+++ b/spanish/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el proyecto VBA.
+type: docs
+weight: 433
+url: /es/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+Representa el proyecto VBA.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | Obtiene todos los objetos [VbaModule](../../com.aspose.diagram/vbamodule). |
+| [getName()](#getName--) | el nombre del proyecto VBA. |
+| [getReferences()](#getReferences--) | Obtiene todas las referencias del proyecto VBA. |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | Indica si VBAcode está firmado o no. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbaproject\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+Obtiene todos los objetos [VbaModule](../../com.aspose.diagram/vbamodule).
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+el nombre del proyecto VBA.
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+Obtiene todas las referencias del proyecto VBA.
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+Indica si VBAcode está firmado o no.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbaproject\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/spanish/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa la referencia del proyecto VBA.
+type: docs
+weight: 434
+url: /es/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+Representa la referencia del proyecto VBA.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | el Libid extendido de la referencia. |
+| [getLibid()](#getLibid--) | el Libid de la referencia. |
+| [getName()](#getName--) | el nombre de la referencia. |
+| [getRelativeLibid()](#getRelativeLibid--) | el identificador del proyecto VBA referenciado\\u9225\\u6a9a con una ruta relativa. |
+| [getTwiddledlibid()](#getTwiddledlibid--) | el Libid manipulado de la referencia. |
+| [getType()](#getType--) | Obtiene el tipo de esta referencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | Para la descripción de esta propiedad, consulte [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) |
+| [setLibid(String value)](#setLibid-java.lang.String-) | Para la descripción de esta propiedad, consulte [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) |
+| [setName(String value)](#setName-java.lang.String-) | Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | Para la descripción de esta propiedad, consulte [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | Para la descripción de esta propiedad, consulte [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+el Libid extendido de la referencia. Solo para referencia de control.
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+el Libid de la referencia.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+el nombre de la referencia.
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+el identificador del proyecto VBA referenciado\\u9225\\u6a9a con una ruta relativa. Solo para referencia de proyecto.
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+el Libid manipulado de la referencia. Solo para referencia de control.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Obtiene el tipo de esta referencia.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/spanish/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa todas las referencias del proyecto VBA.
+type: docs
+weight: 435
+url: /es/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+Representa todas las referencias del proyecto VBA.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Agrega un elemento a la instancia de CollectionBase. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | Agregar una referencia a una biblioteca de tipos retorcida y su biblioteca de tipos extendida. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | Agregar una referencia a un proyecto VBA externo. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Agregar una referencia a una biblioteca de tipos de Automatización. |
+| [clear()](#clear--) | Elimina todos los objetos de la instancia de CollectionBase. |
+| [contains(Object o)](#contains-java.lang.Object-) | Devuelve si la instancia contiene este objeto |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | Obtener la referencia en la lista por el índice. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Obtiene el número de elementos contenidos en la instancia de CollectionBase. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+| [iterator()](#iterator--) | Devuelve un enumerador que recorre la instancia de CollectionBase. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Elimina el elemento en el índice especificado. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Agrega un elemento a la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | El objeto a agregar a la instancia de CollectionBase. |
+
+**Returns:**
+int - La posición en la que se insertó el nuevo elemento.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+Agregar una referencia a una biblioteca de tipos retorcida y su biblioteca de tipos extendida.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | El nombre de la referencia. |
+| libid | java.lang.String | El identificador de una biblioteca de tipos de Automatización. |
+| twiddledlibid | java.lang.String | El identificador de una biblioteca de tipos retorcida |
+| extendedLibid | java.lang.String | El identificador de una biblioteca de tipos extendida |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+Agregar una referencia a un proyecto VBA externo.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | El nombre de la referencia. |
+| absoluteLibid | java.lang.String | El identificador del proyecto VBA referenciado\u9225\u6a9a con una ruta absoluta. |
+| relativeLibid | java.lang.String | El identificador del proyecto VBA referenciado\u9225\u6a9a con una ruta relativa. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Agregar una referencia a una biblioteca de tipos de Automatización.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| nombre | java.lang.String | El nombre de la referencia. |
+| libid | java.lang.String | El identificador de una biblioteca de tipos de Automatización. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los objetos de la instancia de CollectionBase.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Devuelve si la instancia contiene este objeto
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | objeto de prueba |
+
+**Returns:**
+boolean - Indica si la instancia contiene este objeto
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+Obtener la referencia en la lista por el índice.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| i | int | El índice. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos contenidos en la instancia de CollectionBase.
+
+**Returns:**
+int - El número de elementos contenidos en la instancia de CollectionBase.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Determina el índice de un elemento específico en la instancia de CollectionBase.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| o | java.lang.Object | Determina el índice de un elemento específico en la instancia de CollectionBase. |
+
+**Returns:**
+int - El índice del valor si se encuentra en la lista; de lo contrario, -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Devuelve un enumerador que recorre la instancia de CollectionBase.
+
+**Returns:**
+java.util.Iterator - Un iterador para la instancia de CollectionBase.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Elimina el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | El índice basado en cero del elemento a eliminar. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/spanish/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa el tipo de referencia del proyecto VBA.
+type: docs
+weight: 436
+url: /es/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+Representa el tipo de referencia del proyecto VBA.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CONTROL](#CONTROL) | Especifica una referencia a una biblioteca de tipos retorcida y su biblioteca de tipos extendida. |
+| [PROJECT](#PROJECT) | Especifica una referencia a un proyecto VBA externo. |
+| [REGISTERED](#REGISTERED) | Especifica una referencia a una biblioteca de tipos de Automatización. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Especifica una referencia a una biblioteca de tipos retorcida y su biblioteca de tipos extendida.
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+Especifica una referencia a un proyecto VBA externo.
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Especifica una referencia a una biblioteca de tipos de Automatización.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/verticalalign/_index.md
+++ b/spanish/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación vertical del texto dentro del bloque de texto.
+type: docs
+weight: 437
+url: /es/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+Especifica la alineación vertical del texto dentro del bloque de texto.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica la alineación vertical del texto dentro del bloque de texto. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/verticalalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica la alineación vertical del texto dentro del bloque de texto.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica la alineación vertical del texto dentro del bloque de texto.
+type: docs
+weight: 438
+url: /es/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+Especifica la alineación vertical del texto dentro del bloque de texto.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Inferior. |
+| [MIDDLE](#MIDDLE) | Medio. |
+| [TOP](#TOP) | Superior. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Inferior.
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+Medio.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Superior.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el contenido que define el objetivo de la regla de validación pasada y devuelta por la propiedad ValidationRule.TargetType.
+type: docs
+weight: 439
+url: /es/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+Especifica el contenido que define el objetivo de la regla de validación; se pasa y se devuelve mediante la propiedad ValidationRule.TargetType.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | La regla se aplica a las formas en el documento. |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | La regla se aplica a las páginas del documento. |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | La regla se aplica al propio documento. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+La regla se aplica a las formas en el documento.
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+La regla se aplica a las páginas del documento.
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+La regla se aplica al propio documento.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/walkpreference/_index.md
+++ b/spanish/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada usando pegamento dinámico cuando la forma se desplaza a una posición ambigua.
+type: docs
+weight: 440
+url: /es/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, por favor vea [getValue()](../../com.aspose.diagram/walkpreference\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, por favor vea [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada usando pegamento dinámico cuando la forma se desplaza a una posición ambigua.
+type: docs
+weight: 441
+url: /es/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+Especifica si un extremo de una forma 1-D se mueve a un punto de conexión horizontal o vertical en la forma a la que está pegada, usando pegado dinámico, cuando la forma se desplaza a una posición ambigua.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | El valor predeterminado. |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | El punto inicial de la forma 1-D se desplaza a un punto de conexión horizontal, y el punto final se desplaza a un punto de conexión vertical (conexiones de lado a arriba o de lado a abajo). |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | Ambos extremos de la forma 1-D se desplazan a puntos de conexión verticales (conexiones de arriba a abajo). |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | El punto inicial de la forma 1-D se desplaza a un punto de conexión vertical, y el punto final se desplaza a un punto de conexión horizontal (conexiones de arriba a lado o de abajo a lado). |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+El valor predeterminado. Ambos extremos de la forma 1-D se desplazan a puntos de conexión horizontales (conexiones de lado a lado).
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+El punto inicial de la forma 1-D se desplaza a un punto de conexión horizontal, y el punto final se desplaza a un punto de conexión vertical (conexiones de lado a arriba o de lado a abajo).
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+Ambos extremos de la forma 1-D se desplazan a puntos de conexión verticales (conexiones de arriba a abajo).
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+El punto inicial de la forma 1-D se desplaza a un punto de conexión vertical, y el punto final se desplaza a un punto de conexión horizontal (conexiones de arriba a lado o de abajo a lado).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/warninginfo/_index.md
+++ b/spanish/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Información de advertencia
+type: docs
+weight: 442
+url: /es/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+Información de advertencia
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | Crear información de advertencia. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Obtener descripción de la información de advertencia. |
+| [getWarningType()](#getWarningType--) | Obtener tipo de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+Crear información de advertencia.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| warningType | int | tipo de advertencia |
+| descripción | java.lang.String | descripción de la advertencia |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Obtener descripción de la información de advertencia.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+Obtener tipo de advertencia.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/warningtype/_index.md
+++ b/spanish/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: WarningType
+second_title: Referencia de API de Aspose.Diagram para Java
+description: WarningType
+type: docs
+weight: 443
+url: /es/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+WarningType
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | Tipo de advertencia de sustitución de fuente cuando no se encuentra una fuente, este tipo de advertencia se puede obtener. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+Tipo de advertencia de sustitución de fuente cuando no se encuentra una fuente, este tipo de advertencia se puede obtener.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/window/_index.md
+++ b/spanish/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: Window
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Representa una ventana abierta en una instancia de Microsoft Visio.
+type: docs
+weight: 444
+url: /es/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Representa una ventana abierta en una instancia de Microsoft Visio. Este elemento contiene la información necesaria para recrear exactamente una ventana de la interfaz de usuario en el espacio de trabajo de la aplicación cuando el archivo DatadiagramML se abre inicialmente por Visio.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [Window()](#Window--) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | ID del contenedor: Página, Hoja o Maestro. |
+| [getContainerType()](#getContainerType--) | Puede ser uno de los siguientes valores: Document, Page, o Master. |
+| [getDocument()](#getDocument--) | Ruta del archivo del documento mostrado en esta ventana. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Especifica si la función de cuadrícula dinámica está habilitada para un documento o ventana. |
+| [getGlueSettings()](#getGlueSettings--) | Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento. |
+| [getID()](#getID--) | El ID único del elemento dentro de su elemento padre. |
+| [getMaster()](#getMaster--) | ID del maestro si esta ventana muestra un maestro. |
+| [getPage()](#getPage--) | ID de la página si esta ventana muestra una página. |
+| [getParentWindow()](#getParentWindow--) | ID de la ventana en la que se contiene esta ventana de stencil. |
+| [getReadOnly()](#getReadOnly--) | Indicador de solo lectura si este stencil no es un stencil de documento. |
+| [getSheet()](#getSheet--) | ID de la hoja en el contenedor. |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | Especifica si los puntos de conexión se muestran en una ventana. |
+| [getShowGrid()](#getShowGrid--) | Especifica si se muestra una cuadrícula en la ventana de dibujo. |
+| [getShowGuides()](#getShowGuides--) | Especifica si se muestran guías en la ventana de dibujo. |
+| [getShowPageBreaks()](#getShowPageBreaks--) | Especifica si se muestran saltos de página en una ventana. |
+| [getShowRulers()](#getShowRulers--) | Especifica si se muestran reglas en la ventana de dibujo. |
+| [getSnapAngles()](#getSnapAngles--) | Contiene una colección de elementos SnapAngle. |
+| [getSnapExtensions()](#getSnapExtensions--) | Especifica si una configuración específica de extensión de ajuste está habilitada o deshabilitada para la ventana activa. |
+| [getSnapSettings()](#getSnapSettings--) | Especifica los objetos a los que las formas se ajustan cuando el ajuste está activo en la ventana. |
+| [getStencilGroup()](#getStencilGroup--) | Especifica el grupo de ventanas de stencil combinadas del cual la ventana es miembro. |
+| [getStencilGroupPos()](#getStencilGroupPos--) | Contiene un entero que especifica la posición relativa de un stencil dentro de un grupo en una ventana. |
+| [getTabSplitterPos()](#getTabSplitterPos--) | Especifica el ancho del control de pestaña de página de una ventana de dibujo (como una fracción del ancho total de la ventana de dibujo). |
+| [getViewCenterX()](#getViewCenterX--) | Doble opcional. |
+| [getViewCenterY()](#getViewCenterY--) | Doble opcional. |
+| [getViewScale()](#getViewScale--) | Doble opcional. |
+| [getWindowHeight()](#getWindowHeight--) | Altura del rectángulo de la ventana. |
+| [getWindowLeft()](#getWindowLeft--) | Coordenada izquierda del rectángulo de la ventana. |
+| [getWindowState()](#getWindowState--) | Este atributo puede ser una suma de los siguientes valores. |
+| [getWindowTop()](#getWindowTop--) | Coordenada superior del rectángulo de la ventana. |
+| [getWindowType()](#getWindowType--) | Un valor enumerado que puede ser uno de los siguientes: Drawing, Sheet, Stencil o Icon. Un elemento Window con WindowType='Stencil' debe aparecer después de su ventana de dibujo padre (WindowType='Drawing') y antes de cualquier otro elemento de ventana de dibujo. |
+| [getWindowWidth()](#getWindowWidth--) | Ancho del rectángulo de la ventana. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | Para la descripción de esta propiedad, consulte [getContainer()](../../com.aspose.diagram/window\#getContainer--) |
+| [setContainerType(int value)](#setContainerType-int-) | Para la descripción de esta propiedad, consulte [getContainerType()](../../com.aspose.diagram/window\#getContainerType--) |
+| [setDocument(String value)](#setDocument-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDocument()](../../com.aspose.diagram/window\#getDocument--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | Para la descripción de esta propiedad, consulte [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | Para la descripción de esta propiedad, consulte [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) |
+| [setID(int value)](#setID-int-) | Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/window\#getID--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | Para la descripción de esta propiedad, consulte [getMaster()](../../com.aspose.diagram/window\#getMaster--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | Para la descripción de esta propiedad, consulte [getPage()](../../com.aspose.diagram/window\#getPage--) |
+| [setParentWindow(int value)](#setParentWindow-int-) | Para la descripción de esta propiedad, consulte [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) |
+| [setReadOnly(int value)](#setReadOnly-int-) | Para la descripción de esta propiedad, consulte [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) |
+| [setSheet(int value)](#setSheet-int-) | Para la descripción de esta propiedad, consulte [getSheet()](../../com.aspose.diagram/window\#getSheet--) |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | Para la descripción de esta propiedad, consulte [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) |
+| [setShowGrid(int value)](#setShowGrid-int-) | Para la descripción de esta propiedad, consulte [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) |
+| [setShowGuides(int value)](#setShowGuides-int-) | Para la descripción de esta propiedad, consulte [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | Para la descripción de esta propiedad, consulte [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) |
+| [setShowRulers(int value)](#setShowRulers-int-) | Para la descripción de esta propiedad, consulte [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | Para la descripción de esta propiedad, consulte [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | Para la descripción de esta propiedad, consulte [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | Para la descripción de esta propiedad, consulte [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | Para la descripción de esta propiedad, consulte [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | Para la descripción de esta propiedad, consulte [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | Para la descripción de esta propiedad, consulte [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | Para la descripción de esta propiedad, consulte [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | Para la descripción de esta propiedad, consulte [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | Para la descripción de esta propiedad, consulte [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | Para la descripción de esta propiedad, consulte [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) |
+| [setWindowState(int value)](#setWindowState-int-) | Para la descripción de esta propiedad, consulte [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) |
+| [setWindowTop(int value)](#setWindowTop-int-) | Para la descripción de esta propiedad, consulte [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--) |
+| [setWindowType(int value)](#setWindowType-int-) | Para la descripción de esta propiedad, consulte [getWindowType()](../../com.aspose.diagram/window\#getWindowType--) |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | Para la descripción de esta propiedad, consulte [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+Constructor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+ID del contenedor: Page, Sheet o Master. Sólo relevante y necesario si se especifica ContainerType.
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+Puede ser uno de los siguientes valores: Document, Page o Master. Solo es relevante cuando WindowType se especifica como Drawing o Sheet.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+Ruta del archivo del documento mostrado en esta ventana. Este atributo es relevante para ventanas cuyo WindowType está especificado como Stencil.
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Especifica si la función de cuadrícula dinámica está habilitada para un documento o ventana.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Especifica los objetos a los que se adhieren las formas cuando el pegado está habilitado en el documento.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+El ID único del elemento dentro de su elemento padre.
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+ID del maestro si esta ventana muestra un maestro.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+ID de página si esta ventana está mostrando una página. Relevante sólo cuando WindowType está especificado como Drawing y ContainerType está especificado como Page.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+ID de la ventana en la que está contenida esta ventana de stencil. Relevante sólo cuando WindowType está especificado como Stencil.
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+Indicador de solo lectura si este stencil no es un stencil de documento.
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+ID de la hoja en el contenedor. Relevante sólo cuando Container está especificado como Sheet.
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+Especifica si los puntos de conexión se muestran en una ventana.
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+Especifica si se muestra una cuadrícula en la ventana de dibujo.
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+Especifica si se muestran guías en la ventana de dibujo.
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+Especifica si se muestran saltos de página en una ventana.
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+Especifica si se muestran reglas en la ventana de dibujo.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Contiene una colección de elementos SnapAngle.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Especifica si una configuración de extensión de ajuste específica está habilitada o deshabilitada para la ventana activa. El valor puede ser una suma de los valores en la tabla siguiente.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Especifica los objetos a los que los shapes se ajustan cuando el ajuste está activo en la ventana. El valor puede ser una suma de los valores en la tabla siguiente.
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+Especifica el grupo de ventanas de stencil combinadas del que la ventana es miembro. Este atributo es relevante sólo para elementos Window cuyo atributo WindowType es Stencil, y sólo si la ventana de stencil forma parte de un grupo combinado de ventanas de stencil. Todas las ventanas de stencil que forman parte del mismo grupo combinado tienen el mismo valor del elemento StencilGroup.
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+Contiene un entero que especifica la posición relativa de un stencil dentro de un grupo en una ventana.
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+Especifica el ancho del control de pestaña de página de una ventana de dibujo (como una fracción del ancho total de la ventana de dibujo).
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+Doble opcional.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+Doble opcional.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Doble opcional.
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+Altura del rectángulo de la ventana.
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+Coordenada izquierda del rectángulo de la ventana.
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+Este atributo puede ser una suma de los siguientes valores.
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+Coordenada superior del rectángulo de la ventana.
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+Un valor enumerado que puede ser uno de los siguientes: Drawing, Sheet, Stencil o Icon. Un elemento Window con WindowType='Stencil' debe aparecer después de su ventana de dibujo padre (WindowType='Drawing') y antes de cualquier otro elemento de ventana de dibujo.
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+Ancho del rectángulo de la ventana.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getContainer()](../../com.aspose.diagram/window\#getContainer--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDocument()](../../com.aspose.diagram/window\#getDocument--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getID()](../../com.aspose.diagram/window\#getID--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getMaster()](../../com.aspose.diagram/window\#getMaster--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPage()](../../com.aspose.diagram/window\#getPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSheet()](../../com.aspose.diagram/window\#getSheet--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getViewScale()](../../com.aspose.diagram/window\#getViewScale--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowState()](../../com.aspose.diagram/window\#getWindowState--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/windowcollection/_index.md
+++ b/spanish/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Colección de ventanas.
+type: docs
+weight: 445
+url: /es/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+Colección de ventanas.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | Agregue la ventana a la colección. |
+| [clear()](#clear--) | Elimina todos los elementos de la colección. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Obtiene el elemento en el índice especificado. |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | Entero opcional. |
+| [getClientWidth()](#getClientWidth--) | Entero opcional. |
+| [getCount()](#getCount--) | Obtiene el número de elementos realmente contenidos en la colección. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Existe un elemento en la colección. |
+| [iterator()](#iterator--) | Admite una iteración simple sobre una colección no genérica. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | Elimine la ventana de la colección. |
+| [setClientHeight(int value)](#setClientHeight-int-) | Para la descripción de esta propiedad, consulte [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) |
+| [setClientWidth(int value)](#setClientWidth-int-) | Para la descripción de esta propiedad, consulte [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+Agregue la ventana a la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Elimina todos los elementos de la colección.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+Obtiene el elemento en el índice especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+Entero opcional.
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+Entero opcional.
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Obtiene el número de elementos realmente contenidos en la colección.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Existe un elemento en la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| índice | int | índice del elemento. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Admite una iteración simple sobre una colección no genérica.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+Elimine la ventana de la colección.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Un entero que especifica banderas de bits.
+type: docs
+weight: 446
+url: /es/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+Un entero que especifica banderas de bits. Este atributo puede ser la suma de los siguientes valores.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | Activo. |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | Anclar inferior. |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | Anclar izquierda. |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | Anclar fusionado. |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | Anclar derecha. |
+| [ANCHOR_TOP](#ANCHOR-TOP) | Anclar superior. |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | Acoplado inferior. |
+| [DOCKED_LEFT](#DOCKED-LEFT) | Acoplado izquierda. |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | Acoplado derecha. |
+| [DOCKED_TOP](#DOCKED-TOP) | Acoplado superior. |
+| [DOUBLEING](#DOUBLEING) | Doblado. |
+| [MAXIMIZED](#MAXIMIZED) | Maximizado. |
+| [MINIMIZED](#MINIMIZED) | Minimizado. |
+| [RESTORED](#RESTORED) | Restaurado. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+Activo.
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+Anclar inferior.
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+Anclar izquierda.
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+Anclar fusionado.
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+Anclar derecha.
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+Anclar superior.
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+Acoplado inferior.
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+Acoplado izquierda.
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+Acoplado derecha.
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+Acoplado superior.
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+Doblado.
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+Maximizado.
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+Minimizado.
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+Restaurado.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/spanish/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Un valor enumerado que puede ser uno de los siguientes Dibujo Hoja Plantilla o Ícono.
+type: docs
+weight: 447
+url: /es/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+Un valor enumerado que puede ser uno de los siguientes: Dibujo, Hoja, Plantilla o Ícono. Un elemento Window con WindowType='Stencil' debe aparecer después de su ventana padre de dibujo (WindowType='Drawing') y antes de cualquier otro elemento de ventana de dibujo.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [DRAWING](#DRAWING) | Dibujo |
+| [ICON](#ICON) | Ícono. |
+| [SHEET](#SHEET) | Hoja |
+| [STENCIL](#STENCIL) | Plantilla. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Dibujo
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Ícono.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Hoja
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Plantilla.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagrama a XAML.
+type: docs
+weight: 448
+url: /es/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagrama a XAML.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar en XAML. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la primera página a renderizar. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si todas las páginas se guardarán en una imagen o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getStreamProvider()](#getStreamProvider--) | el IStreamProvider para exportar objetos. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | Para la descripción de esta propiedad, consulte [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar en XAML. El valor predeterminado es MaxValue, lo que significa que se renderizarán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la primera página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si todas las páginas se guardarán en la imagen o solo el primer plano. Si es true, se renderizan solo las páginas de primer plano (con fondo si está presente). Si es false, se renderizan las páginas de primer plano (con fondo si está presente) y luego esas páginas de fondo vacías. Solo puede devolver true cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. Solo puede ser Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+el IStreamProvider para exportar objetos.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xform/_index.md
+++ b/spanish/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene elementos que controlan los atributos de línea de una forma, como el peso y el color del patrón.
+type: docs
+weight: 449
+url: /es/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+Contiene elementos que controlan los atributos de línea de una forma, como el patrón, el grosor y el color. Estos elementos determinan si los extremos de la línea están formateados (por ejemplo, con una punta de flecha), el tamaño de los formatos de los extremos de la línea, el radio del círculo de redondeo aplicado a la línea y el estilo de terminación de la línea (redondo o cuadrado).
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | Representa el ángulo de rotación actual de la forma en relación con su elemento padre. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getFlipX()](#getFlipX--) | Indica si la forma ha sido volteada horizontalmente |
+| [getFlipY()](#getFlipY--) | Indica si la forma ha sido volteada verticalmente. |
+| [getHeight()](#getHeight--) | Especifica la altura de la forma en unidades de dibujo. |
+| [getLocPinX()](#getLocPinX--) | Especifica la coordenada x del eje de la forma (centro de rotación) en relación con el origen de la forma. |
+| [getLocPinY()](#getLocPinY--) | Especifica la coordenada y del eje de la forma (centro de rotación) en relación con el origen de la forma. |
+| [getPinPos()](#getPinPos--) | Especifica la posición del eje de la forma |
+| [getPinX()](#getPinX--) | Especifica la coordenada x del eje de la forma (centro de rotación) en relación con el origen de su elemento padre. |
+| [getPinY()](#getPinY--) | Especifica la coordenada y del eje de la forma (centro de rotación) en relación con el origen de su elemento padre. |
+| [getResizeMode()](#getResizeMode--) | Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo. |
+| [getWidth()](#getWidth--) | Contiene el ancho de la forma asociada en unidades de dibujo. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getAngle()](../../com.aspose.diagram/xform\#getAngle--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/xform\#getDel--) |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | Para la descripción de esta propiedad, consulte [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/xform\#getHeight--) |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) |
+| [setPinPos(int value)](#setPinPos-int-) | Para la descripción de esta propiedad, consulte [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getPinX()](../../com.aspose.diagram/xform\#getPinX--) |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getPinY()](../../com.aspose.diagram/xform\#getPinY--) |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | Para la descripción de esta propiedad, consulte [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/xform\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+Representa el ángulo de rotación actual de la forma en relación con su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+Indica si la forma ha sido volteada horizontalmente
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+Indica si la forma ha sido volteada verticalmente.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Especifica la altura de la forma en unidades de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+Especifica la coordenada x del eje de la forma (centro de rotación) en relación con el origen de la forma. La fórmula predeterminada para determinar LocPinX es: F='Width\* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+Especifica la coordenada y del eje de la forma (centro de rotación) en relación con el origen de la forma. La fórmula predeterminada para determinar LocPinY es: F='Height \* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+Especifica la posición del eje de la forma
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+Especifica la coordenada x del eje de la forma (centro de rotación) en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+Especifica la coordenada y del eje de la forma (centro de rotación) en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+Especifica la configuración actual del comportamiento de redimensionamiento para la forma cuando está contenida en un grupo.
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Contiene el ancho de la forma asociada en unidades de dibujo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getAngle()](../../com.aspose.diagram/xform\#getAngle--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/xform\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getHeight()](../../com.aspose.diagram/xform\#getHeight--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPinX()](../../com.aspose.diagram/xform\#getPinX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPinY()](../../com.aspose.diagram/xform\#getPinY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getWidth()](../../com.aspose.diagram/xform\#getWidth--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xform1d/_index.md
+++ b/spanish/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Contiene las coordenadas x e y del punto inicial y del punto final de una forma 1-D.
+type: docs
+weight: 450
+url: /es/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+Contiene las coordenadas x e y del punto inicial y del punto final de una forma 1-D. Este elemento aparece solo para formas 1-D.
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [deepClone()](#deepClone--) | Crea una copia profunda de esta instancia. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | Representa la coordenada x del punto inicial de la forma 1-D, en relación con el origen de su elemento padre. |
+| [getBeginY()](#getBeginY--) | Representa la coordenada y del punto inicial de la forma 1-D, en relación con el origen de su elemento padre. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | Una bandera que indica si el elemento ha sido eliminado localmente. |
+| [getEndX()](#getEndX--) | Representa la coordenada x del punto final de una forma 1-D en relación con el origen de su elemento padre. |
+| [getEndY()](#getEndY--) | Representa la coordenada y del punto final de una forma 1-D en relación con el origen de su elemento padre. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) |
+| [setDel(int value)](#setDel-int-) | Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/xform1d\#getDel--) |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | Para la descripción de esta propiedad, consulte [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Crea una copia profunda de esta instancia.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+Representa la coordenada x del punto inicial de la forma 1-D, en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+Representa la coordenada y del punto inicial de la forma 1-D, en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+Una bandera que indica si el elemento ha sido eliminado localmente. Un valor de 1 indica que el elemento fue eliminado localmente.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+Representa la coordenada x del punto final de una forma 1-D en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+Representa la coordenada y del punto final de una forma 1-D en relación con el origen de su elemento padre.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDel()](../../com.aspose.diagram/xform1d\#getDel--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xjustify/_index.md
+++ b/spanish/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+type: docs
+weight: 451
+url: /es/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/xjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/xjustify\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+type: docs
+weight: 452
+url: /es/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+El desplazamiento x del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [CENTERED](#CENTERED) | Centrado. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | Alineado a la izquierda (por defecto). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | Alineado a la derecha. |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrado.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+Alineado a la izquierda (por defecto).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+Alineado a la derecha.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/spanish/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Permite especificar opciones adicionales al renderizar páginas de diagrama a XPS.
+type: docs
+weight: 453
+url: /es/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+Permite especificar opciones adicionales al renderizar páginas de diagrama a XPS.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | Cuando los caracteres en el diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Define si es necesario exportar la página oculta o no. |
+| [getPageCount()](#getPageCount--) | el número de páginas a renderizar en XPS. |
+| [getPageIndex()](#getPageIndex--) | el índice basado en cero de la primera página a renderizar. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Especifica si todas las páginas se guardarán en una imagen o solo el primer plano. |
+| [getSaveFormat()](#getSaveFormat--) | Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. |
+| [getWarningCallback()](#getWarningCallback--) | callback de advertencia. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+Inicializa una nueva instancia de esta clase que puede usarse para guardar un documento en el formato Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Crea un objeto de opciones de guardado de una clase adecuada para el formato de guardado especificado.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| saveFormat | int | El Aspose.Diagram.SaveFileFormat para el cual crear un objeto de opciones de guardado. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+Cuando los caracteres del diagrama son Unicode y no se establecen con el valor de fuente correcto o la fuente no está instalada localmente, pueden aparecer como bloques en PDF, imagen o XPS. Establezca la DefaultFont, como MingLiu o MS Gothic, para mostrar estos caracteres.
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Define si es necesario exportar la página oculta o no. El valor predeterminado es verdadero.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+el número de páginas a renderizar en XPS. El valor predeterminado es MaxValue, lo que significa que se renderizarán todas las páginas del diagrama.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+el índice basado en cero de la primera página a renderizar. El valor predeterminado es 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Especifica si todas las páginas se guardarán en la imagen o solo el primer plano. Si es true, se renderizan solo las páginas de primer plano (con fondo si está presente). Si es false, se renderizan las páginas de primer plano (con fondo si está presente) y luego esas páginas de fondo vacías. Solo puede devolver true cuando PageCount > 1. El valor predeterminado es false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Especifica el formato en el que se guardarán las páginas del diagrama renderizado si se utiliza este objeto de opciones de guardado. Solo puede ser Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+callback de advertencia.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/yjustify/_index.md
+++ b/spanish/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+type: docs
+weight: 454
+url: /es/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+## Constructores
+
+| Constructor | Descripción |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | Constructor. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Los objetos son iguales. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Especifica los atributos de un elemento. |
+| [getValue()](#getValue--) | Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y. |
+| [hashCode()](#hashCode--) | Sirve como función hash para un tipo particular. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/yjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+Constructor.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Los objetos son iguales.
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Especifica los atributos de un elemento.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Sirve como función hash para un tipo particular.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+Para la descripción de esta propiedad, consulte [getValue()](../../com.aspose.diagram/yjustify\#getValue--)
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| valor | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/spanish/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/spanish/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Referencia de API de Aspose.Diagram para Java
+description: Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+type: docs
+weight: 455
+url: /es/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+Especifica el desplazamiento y del botón de etiqueta inteligente relativo al punto definido por los elementos X y Y.
+## Campos
+
+| Campo | Descripción |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | Justificado en la parte inferior. |
+| [CENTERED](#CENTERED) | Centrado. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | Justificado en la parte superior (por defecto). |
+| [UNDEFINED](#UNDEFINED) | Indefinido. |
+## Métodos
+
+| Método | Descripción |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+Justificado en la parte inferior.
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrado.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+Justificado en la parte superior (por defecto).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Indefinido.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `spanish/java`

🤖 Generated by RDA