### PR TITLE
[auto] Translate JAVA API Reference to Swedish

### DIFF
--- a/swedish/java/_index.md
+++ b/swedish/java/_index.md
@@ -1,0 +1,13 @@
+---
+title: Aspose.Diagram för Java
+type: docs
+weight: 11
+url: /sv/java/
+description: Aspose.Diagram för Java API-referenser innehåller exempel, kodsnuttar och API-dokumentation. Den tillhandahåller paket, klasser, gränssnitt och annan API-information.
+is_root: true
+---
+
+## Packages
+| Paket | Beskrivning |
+| --- | --- |
+| [com.aspose.diagram](./com.aspose.diagram) | Paketet com.aspose.diagram tillhandahåller klasser för att generera, konvertera, modifiera, rendera och skriva ut Microsoft Visio-dokument utan att använda Microsoft Visio. |

--- a/swedish/java/com.aspose.diagram/_index.md
+++ b/swedish/java/com.aspose.diagram/_index.md
@@ -1,0 +1,471 @@
+---
+title: com.aspose.diagram
+second_title: Aspose.Diagram för Java API-referens
+description: Paketet com.aspose.diagram tillhandahåller klasser för att generera, konvertera, modifiera, rendera och skriva ut Microsoft Visio-dokument utan att använda Microsoft Visio.
+type: docs
+weight: 10
+url: /sv/java/com.aspose.diagram/
+---
+
+
+Paketet com.aspose.diagram tillhandahåller klasser för att generera, konvertera, modifiera, rendera och skriva ut Microsoft Visio-dokument utan att använda Microsoft Visio.
+
+
+## Klasser
+
+| Klass | Beskrivning |
+| --- | --- |
+| [AbstractInterruptMonitor](../com.aspose.diagram/abstractinterruptmonitor) | Övervaka avbrottsförfrågningar i alla tidskrävande operationer. |
+| [Act](../com.aspose.diagram/act) | Definierar anpassade kommandonamn som visas i ett objekts snabbmeny och specificerar de åtgärder som kommandona utför. |
+| [ActCollection](../com.aspose.diagram/actcollection) | Act-samling. |
+| [ActiveXControl](../com.aspose.diagram/activexcontrol) | Representerar ActiveX-kontrollen. |
+| [ActiveXControlBase](../com.aspose.diagram/activexcontrolbase) | Representerar ActiveX-kontrollen. |
+| [ActiveXPersistenceType](../com.aspose.diagram/activexpersistencetype) | Representerar beständighetsmetoden för att bevara en ActiveX-kontroll. |
+| [Align](../com.aspose.diagram/align) | Anger justeringen av en form i förhållande till guiden eller guidepunkten som formen är fäst vid. |
+| [AlignNameValue](../com.aspose.diagram/alignnamevalue) | Valfri int. |
+| [Alignment](../com.aspose.diagram/alignment) | Specificerar flikjusteringen. |
+| [AlignmentValue](../com.aspose.diagram/alignmentvalue) | Specificerar flikjusteringen. |
+| [Annotation](../com.aspose.diagram/annotation) | Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida. |
+| [AnnotationCollection](../com.aspose.diagram/annotationcollection) | Annotation-samling. |
+| [ArcTo](../com.aspose.diagram/arcto) | Innehåller x- och y-koordinaterna samt bågen för en cirkulär båge som representeras respektive av elementen X, Y och A. |
+| [ArcToCollection](../com.aspose.diagram/arctocollection) | ArcTo-samling. |
+| [ArrowSize](../com.aspose.diagram/arrowsize) | Specificerar storleken på linjens pilspets. |
+| [ArrowSizeValue](../com.aspose.diagram/arrowsizevalue) | Specificerar storleken på linjens pilspets. |
+| [AsposeDiagramPrintDocument](../com.aspose.diagram/asposediagramprintdocument) | Dess egen version av .NET PrintDocument-klass som kan skickas till ett PrintPreviewDialog-formulär för att skriva ut och förhandsgranska ett diagram. |
+| [AutoLinkComparison](../com.aspose.diagram/autolinkcomparison) | Definierar en regel som jämför en kolumn i det överordnade DataRecordset-elementet med ett formdataobjekt från den senaste lyckade automatiska länkningsåtgärden som utförts i användargränssnittet. |
+| [AutoSpaceOptions](../com.aspose.diagram/autospaceoptions) | Representerar autospace-alternativ. |
+| [BOOL](../com.aspose.diagram/bool) | Boolesk. |
+| [Bevel](../com.aspose.diagram/bevel) | Representerar en fasning av en form |
+| [BevelLightingType](../com.aspose.diagram/bevellightingtype) | Anger typen av skugga för en form. |
+| [BevelLightingTypeValue](../com.aspose.diagram/bevellightingtypevalue) | Representerar en förinställd ljusrättning som kan tillämpas på en form |
+| [BevelMaterialType](../com.aspose.diagram/bevelmaterialtype) | Anger typen av skugga för en form. |
+| [BevelMaterialTypeValue](../com.aspose.diagram/bevelmaterialtypevalue) | Beskriver ytegenskaperna för en form. |
+| [BevelPresetType](../com.aspose.diagram/bevelpresettype) | Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D. |
+| [BevelType](../com.aspose.diagram/beveltype) | Anger typen av skugga för en form. |
+| [BevelTypeValue](../com.aspose.diagram/beveltypevalue) | Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D. |
+| [BoolValue](../com.aspose.diagram/boolvalue) | Booleskt värde. |
+| [Bullet](../com.aspose.diagram/bullet) | Bestämmer punktlistans stil. |
+| [BulletValue](../com.aspose.diagram/bulletvalue) | Bestämmer punktlistans stil. |
+| [Calendar](../com.aspose.diagram/calendar) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [CalendarValue](../com.aspose.diagram/calendarvalue) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [Case](../com.aspose.diagram/case) | Bestämmer skiftläget för en forms text. |
+| [CaseValue](../com.aspose.diagram/casevalue) | Bestämmer skiftläget för en forms text. |
+| [Char](../com.aspose.diagram/char) | Innehåller formateringsattributen för en forms text, såsom teckensnitt, färg, textstil, skiftläge, position relativt till baslinjen och punktstorlek. |
+| [CharCollection](../com.aspose.diagram/charcollection) | Teckensamling. |
+| [CheckBoxActiveXControl](../com.aspose.diagram/checkboxactivexcontrol) | Representerar en CheckBox ActiveX-kontroll. |
+| [CheckValueType](../com.aspose.diagram/checkvaluetype) | Representerar kontrollvärdestypen för kryssrutan. |
+| [Collection](../com.aspose.diagram/collection) | Det är basklass för samlingar. |
+| [CollectionBase](../com.aspose.diagram/collectionbase) | Tillhandahåller den abstrakta basklassen för en starkt typad samling. |
+| [Color](../com.aspose.diagram/color) | Representerar en ARGB-färg (alpha, röd, grön, blå). |
+| [ColorEntry](../com.aspose.diagram/colorentry) | Innehåller ett färgtabellpost. |
+| [ColorEntryCollection](../com.aspose.diagram/colorentrycollection) | Innehåller dokumentets färgtabell. |
+| [ColorValue](../com.aspose.diagram/colorvalue) | Representerar färgvärde |
+| [ComboBoxActiveXControl](../com.aspose.diagram/comboboxactivexcontrol) | Representerar en ComboBox ActiveX-kontroll. |
+| [CommandButtonActiveXControl](../com.aspose.diagram/commandbuttonactivexcontrol) | Representerar en kommandoknapp. |
+| [CompositingQuality](../com.aspose.diagram/compositingquality) | Anger kvalitetsnivån som ska användas vid sammansättning. |
+| [CompoundType](../com.aspose.diagram/compoundtype) | Specificerar storleken på linjens pilspets. |
+| [CompoundTypeValue](../com.aspose.diagram/compoundtypevalue) | Representerar stil för ritade linjer. |
+| [CompressionType](../com.aspose.diagram/compressiontype) | Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. |
+| [ConFixedCode](../com.aspose.diagram/confixedcode) | Bestämmer när en anslutning omdirigeras. |
+| [ConFixedCodeValue](../com.aspose.diagram/confixedcodevalue) | Bestämmer när en anslutning omdirigeras. |
+| [ConLineJumpCode](../com.aspose.diagram/conlinejumpcode) | Bestämmer om en anslutning hoppar när två anslutningar korsar varandra. |
+| [ConLineJumpCodeValue](../com.aspose.diagram/conlinejumpcodevalue) | Bestämmer om en anslutning hoppar när två anslutningar korsar varandra. |
+| [ConLineJumpDirX](../com.aspose.diagram/conlinejumpdirx) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning. |
+| [ConLineJumpDirXValue](../com.aspose.diagram/conlinejumpdirxvalue) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning. |
+| [ConLineJumpDirY](../com.aspose.diagram/conlinejumpdiry) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning. |
+| [ConLineJumpDirYValue](../com.aspose.diagram/conlinejumpdiryvalue) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning. |
+| [ConLineJumpStyle](../com.aspose.diagram/conlinejumpstyle) | Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning. |
+| [ConLineJumpStyleValue](../com.aspose.diagram/conlinejumpstylevalue) | Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning. |
+| [ConLineRouteExt](../com.aspose.diagram/conlinerouteext) | Bestämmer utseendet på en anslutning. |
+| [ConLineRouteExtValue](../com.aspose.diagram/conlinerouteextvalue) | Bestämmer utseendet på en anslutning. |
+| [ConType](../com.aspose.diagram/contype) | Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats. |
+| [ConValue](../com.aspose.diagram/convalue) | Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats. |
+| [Connect](../com.aspose.diagram/connect) | Representerar en anslutning mellan två former i en ritning, såsom en linje och en ruta i ett organisationsdiagram. |
+| [ConnectCollection](../com.aspose.diagram/connectcollection) | Anslut samling. |
+| [ConnectedShapesFlags](../com.aspose.diagram/connectedshapesflags) | Filtrerar arrayen med returnerade form-ID:n efter anslutningarnas riktning. |
+| [Connection](../com.aspose.diagram/connection) | Innehåller element för en anslutningspunkt som definierats för formen. |
+| [ConnectionABCD](../com.aspose.diagram/connectionabcd) | Elementet ConnectionABCD är en föråldrad version av Connection-elementet och finns endast för bakåtkompatibilitet. |
+| [ConnectionABCDCollection](../com.aspose.diagram/connectionabcdcollection) | ConnectionABCD-samling. |
+| [ConnectionCollection](../com.aspose.diagram/connectioncollection) | Connection-samling. |
+| [ConnectionPointPlace](../com.aspose.diagram/connectionpointplace) | Anger platsen på formen där anslutningen kommer att anslutas. |
+| [ConnectorRule](../com.aspose.diagram/connectorrule) | Representerar anslutningsregel mellan två former med en anslutning, inklusive vilken anslutningspunkt på vilken form den startar från, slutformen och dess anslutningspunkt. |
+| [ConnectorsTypeValue](../com.aspose.diagram/connectorstypevalue) | Kan vara ett av följande värden: RightAngle, StraightLines eller CurvedLines. |
+| [ContainerTypeValue](../com.aspose.diagram/containertypevalue) | Kan vara ett av följande värden: Document, Page eller Master. |
+| [ContextTypeValue](../com.aspose.diagram/contexttypevalue) | Anger egenskaper för gruppen eller formen som ska användas för jämförelsen. |
+| [Control](../com.aspose.diagram/control) | Innehåller element för x- och y-koordinaterna för varje kontrollhandtag som definierats för en form, samt element som anger hur kontrollhandtaget ska bete sig. |
+| [ControlBorderType](../com.aspose.diagram/controlbordertype) | Representerar kanttypen för ActiveX-kontrollen. |
+| [ControlCaptionAlignmentType](../com.aspose.diagram/controlcaptionalignmenttype) | Representerar positionen för bildtexten relativt kontrollen. |
+| [ControlCollection](../com.aspose.diagram/controlcollection) | Kontroll-samling. |
+| [ControlListStyle](../com.aspose.diagram/controlliststyle) | Representerar den visuella utformningen av listan i en ListBox eller ComboBox. |
+| [ControlMatchEntryType](../com.aspose.diagram/controlmatchentrytype) | Representerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver. |
+| [ControlMousePointerType](../com.aspose.diagram/controlmousepointertype) | Representerar typen av ikon som visas som muspekaren för kontrollen. |
+| [ControlPictureAlignmentType](../com.aspose.diagram/controlpicturealignmenttype) | Representerar bildens justering i formuläret eller bilden. |
+| [ControlPicturePositionType](../com.aspose.diagram/controlpicturepositiontype) | Representerar kontrollens bilds placering relativt dess rubrik. |
+| [ControlPictureSizeMode](../com.aspose.diagram/controlpicturesizemode) | Representerar hur bilden ska visas. |
+| [ControlScrollBarType](../com.aspose.diagram/controlscrollbartype) | Representerar typen av rullningslist. |
+| [ControlScrollOrientation](../com.aspose.diagram/controlscrollorientation) | Representerar typ av rullningsorientering |
+| [ControlSpecialEffectType](../com.aspose.diagram/controlspecialeffecttype) | Representerar typen av specialeffekt. |
+| [ControlType](../com.aspose.diagram/controltype) | Representerar alla typer av ActiveX-kontroller. |
+| [Coordinate](../com.aspose.diagram/coordinate) | Abstrakt klass för x- och y-koordinaterna. |
+| [CoordinateCollection](../com.aspose.diagram/coordinatecollection) | Koordinatsamling. |
+| [CountryCode](../com.aspose.diagram/countrycode) | Representerar diagrammets landsidentifierare. |
+| [Cp](../com.aspose.diagram/cp) | Markerar början på ett teckenegenskapsintervall som är formaterat enligt motsvarande Char-element. |
+| [CustomProp](../com.aspose.diagram/customprop) | CustomProp-struktur. |
+| [CustomPropCollection](../com.aspose.diagram/custompropcollection) | CustomProps-samling. |
+| [CustomValue](../com.aspose.diagram/customvalue) | Egenskapens värde. |
+| [DataColumn](../com.aspose.diagram/datacolumn) | Definierar hur en datakolumn visas i fönstret Externa data i Visios användargränssnitt och kvalificerar data i kolumnen genom att ange dess datatyp och formatering. |
+| [DataColumnCollection](../com.aspose.diagram/datacolumncollection) | DataColumn-samling. |
+| [DataConnection](../com.aspose.diagram/dataconnection) | Abstraherar kommunikationen mellan ett eller flera DataRecordset-element och en icke-XML-datakälla. |
+| [DataConnectionCollection](../com.aspose.diagram/dataconnectioncollection) | DataConnection-samling. |
+| [DataConnectionType](../com.aspose.diagram/dataconnectiontype) | Tillåter att konfigurera alternativ för anslutningarna till databasen. |
+| [DataRecordSet](../com.aspose.diagram/datarecordset) | Lagrar, formaterar, uppdaterar och exponerar data som hämtats från en databas i Microsoft Visio. |
+| [DataRecordSetCollection](../com.aspose.diagram/datarecordsetcollection) | DataRecordSet-samling. |
+| [DateTime](../com.aspose.diagram/datetime) | Representerar ett ögonblick i tiden, vanligtvis uttryckt som ett datum och en tid på dagen. |
+| [DateValue](../com.aspose.diagram/datevalue) | Datum- och tidsvärde. |
+| [Diagram](../com.aspose.diagram/diagram) | Rot-element för Visio-objekthierarkin. |
+| [DiagramException](../com.aspose.diagram/diagramexception) | Bas-klass för alla Aspose.Diagram-undantag. |
+| [DiagramSaveOptions](../com.aspose.diagram/diagramsaveoptions) | Kan användas för att ange ytterligare alternativ när diagram sparas i Visio-formatet (VDX\VSX). |
+| [DisplayMode](../com.aspose.diagram/displaymode) | När den finns i ett Group-element anger DisplayMode-elementet hur en gruppform och dess medlemmar visas. |
+| [DisplayModeSmartTagDef](../com.aspose.diagram/displaymodesmarttagdef) | DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden. |
+| [DisplayModeSmartTagDefValue](../com.aspose.diagram/displaymodesmarttagdefvalue) | DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden. |
+| [DisplayModeValue](../com.aspose.diagram/displaymodevalue) | När den finns i ett Group-element anger DisplayMode-elementet hur en gruppform och dess medlemmar visas. |
+| [DocProps](../com.aspose.diagram/docprops) | Innehåller element som styr dokumentets förhandsgranskningskvalitet, omfattning och utdataformat. |
+| [DocumentProperties](../com.aspose.diagram/documentproperties) | Innehåller element för dokumentegenskaper såsom dokumentets titel, författare osv. |
+| [DocumentSettings](../com.aspose.diagram/documentsettings) | Innehåller element som specificerar dokumentinställningar. |
+| [DocumentSheet](../com.aspose.diagram/documentsheet) | Anger ett dokuments ShapeSheet-struktur. |
+| [DoubleValue](../com.aspose.diagram/doublevalue) | Dubbelvärde |
+| [DrawingResizeType](../com.aspose.diagram/drawingresizetype) | Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet. |
+| [DrawingResizeTypeValue](../com.aspose.diagram/drawingresizetypevalue) | Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet. |
+| [DrawingScaleType](../com.aspose.diagram/drawingscaletype) | Anger vilken typ av ritningsskala som ska användas för en sida. |
+| [DrawingScaleTypeValue](../com.aspose.diagram/drawingscaletypevalue) | Anger vilken typ av ritningsskala som ska användas för en sida. |
+| [DrawingSizeType](../com.aspose.diagram/drawingsizetype) | Anger ritningsstorleken för en sida. |
+| [DrawingSizeTypeValue](../com.aspose.diagram/drawingsizetypevalue) | Anger ritningsstorleken för en sida. |
+| [DropButtonStyle](../com.aspose.diagram/dropbuttonstyle) | Representerar symbolen som visas på nedrullningsknappen. |
+| [DynFeedback](../com.aspose.diagram/dynfeedback) | Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutare. |
+| [DynFeedbackValue](../com.aspose.diagram/dynfeedbackvalue) | Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutare. |
+| [Ellipse](../com.aspose.diagram/ellipse) | Innehåller element som specificerar x- och y-koordinaterna för ellipsens mittpunkt samt två punkter på ellipsen. |
+| [EllipseCollection](../com.aspose.diagram/ellipsecollection) | Ellips-samling. |
+| [EllipticalArcTo](../com.aspose.diagram/ellipticalarcto) | Innehåller element som specificerar information om en elliptisk båge. |
+| [EllipticalArcToCollection](../com.aspose.diagram/ellipticalarctocollection) | EllipticalArcTo-samling. |
+| [EmfRenderSetting](../com.aspose.diagram/emfrendersetting) | Inställning för rendering av Emf-metafil. |
+| [Encoding](../com.aspose.diagram/encoding) | Representerar en teckenkodning. |
+| [Event](../com.aspose.diagram/event) | Innehåller element som specificerar formler som styr formhändelser. |
+| [EventItem](../com.aspose.diagram/eventitem) | Inkapslar en händelsekod. |
+| [EventItemCollection](../com.aspose.diagram/eventitemcollection) | EventItem-samling. |
+| [Field](../com.aspose.diagram/field) | Innehåller element som specificerar funktioner och formler som infogas i formens text. |
+| [FieldCollection](../com.aspose.diagram/fieldcollection) | Fältkollektion. |
+| [FileFontSource](../com.aspose.diagram/filefontsource) | Representerar den enda TrueType-typsnittsfilen som lagras i filsystemet. |
+| [FileFormatInfo](../com.aspose.diagram/fileformatinfo) | Innehåller data som returneras av [FileFormatUtil](../com.aspose.diagram/fileformatutil) filformatdetekteringsmetoder. |
+| [FileFormatType](../com.aspose.diagram/fileformattype) | Enumererar filformattyper för kalkylblad |
+| [FileFormatUtil](../com.aspose.diagram/fileformatutil) | Tillhandahåller hjälpfunktioner för att konvertera filformat‑enum till strängar eller filändelser och tillbaka. |
+| [Fill](../com.aspose.diagram/fill) | Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg. |
+| [FillType](../com.aspose.diagram/filltype) | Fyllningsformattyp. |
+| [Fld](../com.aspose.diagram/fld) | Anger en textfältsinsättningspunkt för motsvarande Field‑element. |
+| [FloatPointNumCollection](../com.aspose.diagram/floatpointnumcollection) | Innehåller en samling av dubbleringspunktsnummer |
+| [FolderFontSource](../com.aspose.diagram/folderfontsource) | Representerar mappen som innehåller TrueType-typsnittsfiler. |
+| [Font](../com.aspose.diagram/font) | Innehåller information om ett typsnitt. |
+| [FontCollection](../com.aspose.diagram/fontcollection) | Innehåller en samling av Font‑element. |
+| [FontConfigs](../com.aspose.diagram/fontconfigs) | Specificerar typsnittsinställningar |
+| [FontSourceBase](../com.aspose.diagram/fontsourcebase) | Detta är en abstrakt basklass för de klasser som låter användaren ange olika typsnittskällor |
+| [FontSourceType](../com.aspose.diagram/fontsourcetype) | Specificerar typen av en typsnittskälla. |
+| [Foreign](../com.aspose.diagram/foreign) | Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. |
+| [ForeignData](../com.aspose.diagram/foreigndata) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [ForeignType](../com.aspose.diagram/foreigntype) | Datatyp. |
+| [FormatTxt](../com.aspose.diagram/formattxt) | Abstrakt klass för formatering av text |
+| [FormatTxtCollection](../com.aspose.diagram/formattxtcollection) | FormatTxt‑samling som innehåller texten för en form. |
+| [FromPartValue](../com.aspose.diagram/frompartvalue) | Den del av en form varifrån en anslutning startar. |
+| [Geom](../com.aspose.diagram/geom) | Innehåller element som specificerar koordinaterna för hörnen på linjerna och bågarna som utgör formen. |
+| [GeomCollection](../com.aspose.diagram/geomcollection) | Geom‑samling. |
+| [GlowEffect](../com.aspose.diagram/gloweffect) | Denna klass specificerar en glödeffekt, där en färgad suddig kontur läggs till utanför objektets kanter. |
+| [GlueSettings](../com.aspose.diagram/gluesettings) | Bitvärdena indikerar att en specifik liminställning är på eller av. |
+| [GlueSettingsValue](../com.aspose.diagram/gluesettingsvalue) | Anger de objekt som former limmas till när lim är aktiverat i dokumentet. |
+| [GlueType](../com.aspose.diagram/gluetype) | Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form. |
+| [GlueTypeValue](../com.aspose.diagram/gluetypevalue) | Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form. |
+| [GluedShapesFlags](../com.aspose.diagram/gluedshapesflags) | Anger konstanter som identifierar vilka former som ska returneras, baserat på dimensionen och riktningen för anslutningspunkterna som är limmade till en viss form; skickas till metoden Shape.GluedShapes. |
+| [GradientDirectionType](../com.aspose.diagram/gradientdirectiontype) | Representerar alla riktningstyper för gradient. |
+| [GradientFill](../com.aspose.diagram/gradientfill) | Representerar gradientfyllningen. |
+| [GradientFillDir](../com.aspose.diagram/gradientfilldir) | Anger typen av färggradient för en forms fyllning |
+| [GradientFillType](../com.aspose.diagram/gradientfilltype) | Representerar alla gradientfyllningstyper. |
+| [GradientStop](../com.aspose.diagram/gradientstop) | Representerar gradientstoppet. |
+| [GradientStopCollection](../com.aspose.diagram/gradientstopcollection) | Representerar samlingen av gradientstopp. |
+| [GradientStyleType](../com.aspose.diagram/gradientstyletype) | Representerar gradientskuggningsstil. |
+| [GridDensity](../com.aspose.diagram/griddensity) | Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida. |
+| [GridDensityValue](../com.aspose.diagram/griddensityvalue) | Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida. |
+| [Group](../com.aspose.diagram/group) | Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper. |
+| [HTMLSaveOptions](../com.aspose.diagram/htmlsaveoptions) | Tillåter att ange ytterligare alternativ när diagramssidor renderas till HTML. |
+| [HeaderFooter](../com.aspose.diagram/headerfooter) | Innehåller element för ett dokuments sidhuvud och sidfot. |
+| [HeaderFooterFont](../com.aspose.diagram/headerfooterfont) | Anger teckensnittet som används för sidhuvud- och sidfotstexten. |
+| [Help](../com.aspose.diagram/help) | Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation. |
+| [HorzAlign](../com.aspose.diagram/horzalign) | Anger den horisontella justeringen av text i formens textblock. |
+| [HorzAlignValue](../com.aspose.diagram/horzalignvalue) | Anger den horisontella justeringen av text i formens textblock. |
+| [Hyperlink](../com.aspose.diagram/hyperlink) | Innehåller element för att skapa flera hopp mellan en form eller ritningssida och en annan ritningssida, en annan fil eller en webbplats. |
+| [HyperlinkCollection](../com.aspose.diagram/hyperlinkcollection) | Hyperlänksamling. |
+| [IconSizeValue](../com.aspose.diagram/iconsizevalue) | Valfri int. |
+| [Image](../com.aspose.diagram/image) | Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap. |
+| [ImageActiveXControl](../com.aspose.diagram/imageactivexcontrol) | Representerar bildkontrollen. |
+| [ImageColorMode](../com.aspose.diagram/imagecolormode) | Anger färgläget för de genererade bilderna av dokumentsidor. |
+| [ImageFormat](../com.aspose.diagram/imageformat) | Anger bildens filformat. |
+| [ImageSaveOptions](../com.aspose.diagram/imagesaveoptions) | Tillåter att ange ytterligare alternativ när diagramssidor renderas till bilder. |
+| [IndividualFontConfigs](../com.aspose.diagram/individualfontconfigs) | Teckensnittskonfigurationer för varje [Diagram](../com.aspose.diagram/diagram)-objekt. |
+| [InfiniteLine](../com.aspose.diagram/infiniteline) | Innehåller element som specificerar x- och y-koordinaterna för två punkter på en oändlig linje. |
+| [InfiniteLineCollection](../com.aspose.diagram/infinitelinecollection) | InfiniteLine-samling. |
+| [InputMethodEditorMode](../com.aspose.diagram/inputmethodeditormode) | Representerar standardkörningsläget för Input Method Editor. |
+| [IntValue](../com.aspose.diagram/intvalue) | Heltalsvärde |
+| [InterpolationMode](../com.aspose.diagram/interpolationmode) | InterpolationMode‑enumerationen specificerar den algoritm som används när bilder skalas eller roteras. |
+| [InterruptMonitor](../com.aspose.diagram/interruptmonitor) | Representerar alla operatörer för avbrottet. |
+| [Issue](../com.aspose.diagram/issue) | Representerar ett enskilt valideringsproblem i dokumentet. |
+| [IssueCollection](../com.aspose.diagram/issuecollection) | Issue‑samling. |
+| [IssueTarget](../com.aspose.diagram/issuetarget) | Beroende på målet för det överordnade valideringsproblemet specificeras antingen sidan, eller både sidan och formen, som det överordnade valideringsproblemet är associerat med. |
+| [LabelActiveXControl](../com.aspose.diagram/labelactivexcontrol) | Representerar etikett‑ActiveX‑kontrollen. |
+| [Layer](../com.aspose.diagram/layer) | Innehåller element som definierar ett enskilt lager och dess egenskaper för en sida. |
+| [LayerCollection](../com.aspose.diagram/layercollection) | Layer‑samling. |
+| [LayerMem](../com.aspose.diagram/layermem) | Innehåller LayerMember‑elementet, som specificerar varje lager som formen tilldelas. |
+| [Layout](../com.aspose.diagram/layout) | Innehåller element som styr formplacering och inställningar för anslutningsruttning. |
+| [LayoutDirection](../com.aspose.diagram/layoutdirection) | Används för att ange layoutens riktning. |
+| [LayoutOptions](../com.aspose.diagram/layoutoptions) | Används för att specificera stil och ytterligare alternativ för layout av former för att utföra om‑layout av sida(sidor). |
+| [LayoutStyle](../com.aspose.diagram/layoutstyle) | Används för att specificera layoutstil. |
+| [License](../com.aspose.diagram/license) | Tillhandahåller metoder för att licensiera komponenten. |
+| [LightRigDirectionType](../com.aspose.diagram/lightrigdirectiontype) | Representerar typen av ljusrigg‑riktning. |
+| [Line](../com.aspose.diagram/line) | Innehåller element som specificerar generell placeringsinformation om en form. |
+| [LineAdjustFrom](../com.aspose.diagram/lineadjustfrom) | Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra. |
+| [LineAdjustFromValue](../com.aspose.diagram/lineadjustfromvalue) | Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra. |
+| [LineAdjustTo](../com.aspose.diagram/lineadjustto) | Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra. |
+| [LineAdjustToValue](../com.aspose.diagram/lineadjusttovalue) | Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra. |
+| [LineJumpCode](../com.aspose.diagram/linejumpcode) | Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för. |
+| [LineJumpCodeValue](../com.aspose.diagram/linejumpcodevalue) | Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för. |
+| [LineJumpStyle](../com.aspose.diagram/linejumpstyle) | Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil. |
+| [LineJumpStyleValue](../com.aspose.diagram/linejumpstylevalue) | Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil. |
+| [LineRouteExt](../com.aspose.diagram/linerouteext) | Specificerar standardutseendet för alla anslutningar på en sida. |
+| [LineRouteExtValue](../com.aspose.diagram/linerouteextvalue) | Specificerar standardutseendet för alla anslutningar på en sida. |
+| [LineTo](../com.aspose.diagram/lineto) | Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment. |
+| [LineToCollection](../com.aspose.diagram/linetocollection) | LineTo-samling. |
+| [ListBoxActiveXControl](../com.aspose.diagram/listboxactivexcontrol) | Representerar en ListBox ActiveX‑kontroll. |
+| [LoadFileFormat](../com.aspose.diagram/loadfileformat) | Enumeration för val av diagramformat vid inläsning. |
+| [LoadOptions](../com.aspose.diagram/loadoptions) | Tillåter att ange ytterligare alternativ när ett diagram läses in i ett Diagram‑objekt. |
+| [LocalizeFont](../com.aspose.diagram/localizefont) | Anger om formtexten ska lokaliseras (översättas till ett annat språk). |
+| [LocalizeFontValue](../com.aspose.diagram/localizefontvalue) | Anger om formtexten ska lokaliseras (översättas till ett annat språk). |
+| [Margin](../com.aspose.diagram/margin) | Anger marginalen. |
+| [Master](../com.aspose.diagram/master) | Innehåller element som definierar en master för dokumentet. |
+| [MasterCollection](../com.aspose.diagram/mastercollection) | Master‑samling. |
+| [MasterShortcut](../com.aspose.diagram/mastershortcut) | Anger en master‑genväg som definierats i dokumentet. |
+| [MasterShortcutCollection](../com.aspose.diagram/mastershortcutcollection) | MasterShortcut‑samling. |
+| [MeasureConst](../com.aspose.diagram/measureconst) | Enheter av\\ mått. |
+| [MemoryFontSource](../com.aspose.diagram/memoryfontsource) | Representerar den enda TrueType‑teckensnittsfilen som lagras i minnet. |
+| [MilestoneHelper](../com.aspose.diagram/milestonehelper) | MilestoneHelper för att ange egenskap för milstolpsformen. |
+| [Misc](../com.aspose.diagram/misc) | Innehåller olika element för former och grupper, såsom de som styr markeringsframhävning och synlighet. |
+| [MoveTo](../com.aspose.diagram/moveto) | Innehåller x- och y-koordinaterna för den första hörnpunkten i en form, eller x- och y-koordinaterna för den första hörnpunkten efter ett avbrott i en bana. |
+| [MoveToCollection](../com.aspose.diagram/movetocollection) | MoveTo‑samling. |
+| [NURBSTo](../com.aspose.diagram/nurbsto) | Innehåller x- och y-koordinaterna, positionen för den näst sista knuten, positionen för den sista vikten, positionen för den första knuten, positionen för den första vikten samt formeln för en icke‑uniform rationell B-spline (NURBS). |
+| [NURBSToCollection](../com.aspose.diagram/nurbstocollection) | NURBSTo‑samling. |
+| [ObjType](../com.aspose.diagram/objtype) | Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [ObjTypeValue](../com.aspose.diagram/objtypevalue) | Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [ObjectKind](../com.aspose.diagram/objectkind) | Anger typen av textfält. |
+| [ObjectKindValue](../com.aspose.diagram/objectkindvalue) | Anger typen av textfält. |
+| [ObjectType](../com.aspose.diagram/objecttype) | Om attributet ForeignType är "Object" måste ForeignData‑elementet också ha ett ObjectType‑attribut. |
+| [OptionsValue](../com.aspose.diagram/optionsvalue) | Valfritt osignerat heltal. |
+| [OutputFormat](../com.aspose.diagram/outputformat) | Anger utdataformatet för en ritning. |
+| [OutputFormatValue](../com.aspose.diagram/outputformatvalue) | Anger utdataformatet för en ritning. |
+| [Page](../com.aspose.diagram/page) | Innehåller element som definierar en sida i dokumentet. |
+| [PageCollection](../com.aspose.diagram/pagecollection) | Sidcollection. |
+| [PageEndSavingArgs](../com.aspose.diagram/pageendsavingargs) | Information för en sida avslutar sparningsprocessen. |
+| [PageLayout](../com.aspose.diagram/pagelayout) | Innehåller celler som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan. |
+| [PageLineJumpDirX](../com.aspose.diagram/pagelinejumpdirx) | Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [PageLineJumpDirXValue](../com.aspose.diagram/pagelinejumpdirxvalue) | Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [PageLineJumpDirY](../com.aspose.diagram/pagelinejumpdiry) | Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [PageLineJumpDirYValue](../com.aspose.diagram/pagelinejumpdiryvalue) | Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [PageProps](../com.aspose.diagram/pageprops) | Innehåller celler som styr sidattribut, såsom sidbredd, höjd och skala. |
+| [PageSavingArgs](../com.aspose.diagram/pagesavingargs) | Information för en sidas sparningsprocess. |
+| [PageSheet](../com.aspose.diagram/pagesheet) | Innehåller element som definierar sidbladet för ett Page- eller Master-element. |
+| [PageSize](../com.aspose.diagram/pagesize) | Innehåller information om sidstorlek för de genererade bilderna. |
+| [PageStartSavingArgs](../com.aspose.diagram/pagestartsavingargs) | Information för en sida påbörjar sparningsprocessen. |
+| [PaperSizeFormat](../com.aspose.diagram/papersizeformat) | Enumeration för val av pappersstorleksformat vid sparande. |
+| [Para](../com.aspose.diagram/para) | Innehåller styckeformateringselement för figurens text, såsom indrag, radavstånd, punktlistor och horisontell justering av stycken. |
+| [ParaCollection](../com.aspose.diagram/paracollection) | Styckesamling. |
+| [PdfCompliance](../com.aspose.diagram/pdfcompliance) | Anger PDF‑kompatibilitetsnivån för utdatafilen. |
+| [PdfDigitalSignatureHashAlgorithm](../com.aspose.diagram/pdfdigitalsignaturehashalgorithm) | Anger den digitala hash‑algoritmen som används av digital signatur. |
+| [PdfEncryptionAlgorithm](../com.aspose.diagram/pdfencryptionalgorithm) | Anger krypteringsalgoritmen som ska användas för att kryptera ett PDF‑dokument. |
+| [PdfEncryptionDetails](../com.aspose.diagram/pdfencryptiondetails) | Innehåller detaljer för en PDF‑kryptering. |
+| [PdfPermissions](../com.aspose.diagram/pdfpermissions) | Anger användarbehörigheter för PDF‑dokumentet. |
+| [PdfSaveOptions](../com.aspose.diagram/pdfsaveoptions) | Tillåter att ange ytterligare alternativ vid rendering av diagramssidor till PDF. |
+| [PdfTextCompression](../com.aspose.diagram/pdftextcompression) | Anger en komprimeringstyp som tillämpas på allt innehåll i PDF‑filen förutom bilder. |
+| [PinPosValue](../com.aspose.diagram/pinposvalue) | Anger nålpositionen för formen. |
+| [PixelOffsetMode](../com.aspose.diagram/pixeloffsetmode) | Anger hur pixlar förskjuts under rendering. |
+| [PlaceDepth](../com.aspose.diagram/placedepth) | För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen. |
+| [PlaceDepthValue](../com.aspose.diagram/placedepthvalue) | För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen. |
+| [PlaceFlip](../com.aspose.diagram/placeflip) | Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio. |
+| [PlaceFlipValue](../com.aspose.diagram/placeflipvalue) | Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio. |
+| [PlaceStyle](../com.aspose.diagram/placestyle) | Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form). |
+| [PlaceStyleValue](../com.aspose.diagram/placestylevalue) | Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form). |
+| [PolylineTo](../com.aspose.diagram/polylineto) | Innehåller x- och y-koordinater för den sista punkten i en polylinje samt en polylinjeformel. |
+| [PolylineToCollection](../com.aspose.diagram/polylinetocollection) | PolylineTo-samling. |
+| [Pos](../com.aspose.diagram/pos) | Anger textens position i formen relativt till baslinjen. |
+| [PosValue](../com.aspose.diagram/posvalue) | Anger textens position i formen relativt till baslinjen. |
+| [Pp](../com.aspose.diagram/pp) | Anger början på en körning av styckeegenskaper. |
+| [PresetCameraType](../com.aspose.diagram/presetcameratype) | Representerar olika algoritmiska metoder för att ställa in alla kamerainställningar, inklusive position. |
+| [PresetColorMatricsValue](../com.aspose.diagram/presetcolormatricsvalue) | Används för att ställa in färgegenskapen för formens temastil. |
+| [PresetQuickStyleValue](../com.aspose.diagram/presetquickstylevalue) | Anger värdet för temats snabbstil. |
+| [PresetShadowType](../com.aspose.diagram/presetshadowtype) | Representerar förinställd skuggtyp. |
+| [PresetStyleMatricsValue](../com.aspose.diagram/presetstylematricsvalue) | Används för att ställa in formens temastil‑egenskap. |
+| [PresetThemeValue](../com.aspose.diagram/presetthemevalue) | Anger temavärdet. |
+| [PresetThemeVariantValue](../com.aspose.diagram/presetthemevariantvalue) | Anger värdet för temavarianten. |
+| [PreviewScope](../com.aspose.diagram/previewscope) | Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet. |
+| [PreviewScopeValue](../com.aspose.diagram/previewscopevalue) | Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet. |
+| [PrintPageOrientation](../com.aspose.diagram/printpageorientation) | Bestämmer om sidan skrivs ut i stående eller liggande orientering. |
+| [PrintPageOrientationValue](../com.aspose.diagram/printpageorientationvalue) | Bestämmer om sidan skrivs ut i stående eller liggande orientering. |
+| [PrintProps](../com.aspose.diagram/printprops) | Innehåller element som styr hur ritningssidan formateras (visas) på utskriftssidan. |
+| [PrintSaveOptions](../com.aspose.diagram/printsaveoptions) | Tillåter att ange ytterligare alternativ vid utskrift av diagram. |
+| [Prop](../com.aspose.diagram/prop) | Innehåller element för att definiera anpassade egenskaper och element för att associera data med en form. |
+| [PropCollection](../com.aspose.diagram/propcollection) | Prop‑samling. |
+| [PropType](../com.aspose.diagram/proptype) | Typ av egenskap. |
+| [Protection](../com.aspose.diagram/protection) | Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. |
+| [RadioButtonActiveXControl](../com.aspose.diagram/radiobuttonactivexcontrol) | Representerar en RadioButton ActiveX‑kontroll. |
+| [RectangleAlignmentType](../com.aspose.diagram/rectanglealignmenttype) | Representerar hur två rektanglar placeras relativt till varandra. |
+| [ReflectionEffectType](../com.aspose.diagram/reflectioneffecttype) |  |
+| [RelCubBezTo](../com.aspose.diagram/relcubbezto) | Innehåller x- och y-koordinater för en RelCubBezTo:s punkter. |
+| [RelCubBezToCollection](../com.aspose.diagram/relcubbeztocollection) | RelCubBezTo‑samling. |
+| [RelEllipticalArcTo](../com.aspose.diagram/relellipticalarcto) | Innehåller element som specificerar information om en elliptisk båge. Koordinaterna anges som relativa koordinater. |
+| [RelEllipticalArcToCollection](../com.aspose.diagram/relellipticalarctocollection) | RelEllipticalArcTo‑samling. |
+| [RelLineTo](../com.aspose.diagram/rellineto) | Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment. |
+| [RelLineToCollection](../com.aspose.diagram/rellinetocollection) | RelLineTo-samling. |
+| [RelMoveTo](../com.aspose.diagram/relmoveto) | Innehåller x- och y-koordinaterna för den första vertexen i en form, eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana. Koordinaterna anges som relativa koordinater. |
+| [RelMoveToCollection](../com.aspose.diagram/relmovetocollection) | RelMoveTo-samling. |
+| [RelQuadBezTo](../com.aspose.diagram/relquadbezto) | Innehåller x- och y-koordinater för en RelQuadBezTo:s punkter. |
+| [RelQuadBezToCollection](../com.aspose.diagram/relquadbeztocollection) | RelQuadBezTo-samling. |
+| [RemoveHiddenInfoItem](../com.aspose.diagram/removehiddeninfoitem) | Anger borttagning av dold information för diagrammet. |
+| [RenderingSaveOptions](../com.aspose.diagram/renderingsaveoptions) | Detta är en abstrakt basklass för klasser som låter användaren ange ytterligare alternativ när ett diagram sparas i ett specifikt format. |
+| [ResizeMode](../com.aspose.diagram/resizemode) | Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp. |
+| [ResizeModeValue](../com.aspose.diagram/resizemodevalue) | Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp. |
+| [Reviewer](../com.aspose.diagram/reviewer) | Innehåller element som innehåller identifierande information om en dokumentgranskare. |
+| [ReviewerCollection](../com.aspose.diagram/reviewercollection) | Granskare-samling. |
+| [RotationType](../com.aspose.diagram/rotationtype) | Anger typen av skugga för en form. |
+| [RotationTypeValue](../com.aspose.diagram/rotationtypevalue) | Anger typen av projektion av effekt‑egenskaperna för en form |
+| [RouteStyle](../com.aspose.diagram/routestyle) | Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil. |
+| [RouteStyleValue](../com.aspose.diagram/routestylevalue) | Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil. |
+| [Row](../com.aspose.diagram/row) | Indikerar en rad i dataresultatuppsättningen. |
+| [RowCollection](../com.aspose.diagram/rowcollection) | Rad-samling. |
+| [Rule](../com.aspose.diagram/rule) | Representerar en enskild valideringsregel i en diagramvalideringsregeluppsättning. |
+| [RuleCollection](../com.aspose.diagram/rulecollection) | Regel-samling. |
+| [RuleInfo](../com.aspose.diagram/ruleinfo) | Anger information om valideringsregeln som det överordnade valideringsproblemet avser. |
+| [RuleSet](../com.aspose.diagram/ruleset) | Representerar en uppsättning diagramvalideringsregler. |
+| [RuleSetCollection](../com.aspose.diagram/rulesetcollection) | RuleSet-samling. |
+| [RuleValue](../com.aspose.diagram/rulevalue) | Regelvärde. |
+| [RulerDensity](../com.aspose.diagram/rulerdensity) | Anger de horisontella indelningarna på linjalen för sidan. |
+| [RulerDensityValue](../com.aspose.diagram/rulerdensityvalue) | Anger de horisontella indelningarna på linjalen för sidan. |
+| [RulerGrid](../com.aspose.diagram/rulergrid) | Innehåller element som specificerar inställningarna för sidans linjaler och rutnät. |
+| [SVGSaveOptions](../com.aspose.diagram/svgsaveoptions) | Tillåter att ange ytterligare alternativ när diagramssidor renderas till SVG. |
+| [SaveFileFormat](../com.aspose.diagram/savefileformat) | Enumeration för att spara diagramformatval. |
+| [SaveOptions](../com.aspose.diagram/saveoptions) | Detta är en abstrakt basklass för klasser som låter användaren ange ytterligare alternativ när ett diagram sparas i ett specifikt format. |
+| [Scratch](../com.aspose.diagram/scratch) | Innehåller ett arbetsområde för att ange och testa formler som refereras till av andra element. |
+| [ScratchCollection](../com.aspose.diagram/scratchcollection) | Scratch-samling. |
+| [ScrollBarActiveXControl](../com.aspose.diagram/scrollbaractivexcontrol) | Representerar ScrollBar-kontrollen. |
+| [SelectMode](../com.aspose.diagram/selectmode) | Specificerar hur användaren väljer en gruppform och dess medlemmar. |
+| [SelectModeValue](../com.aspose.diagram/selectmodevalue) | Specificerar hur användaren väljer en gruppform och dess medlemmar. |
+| [Shape](../com.aspose.diagram/shape) | Innehåller element som definierar en form i ett Master-, Page- eller gruppformselement. |
+| [ShapeCollection](../com.aspose.diagram/shapecollection) | Samling av former. |
+| [ShapeFixedCode](../com.aspose.diagram/shapefixedcode) | Specificerar placeringsbeteende för en placerbar form. |
+| [ShapeFixedCodeValue](../com.aspose.diagram/shapefixedcodevalue) | Specificerar placeringsbeteende för en placerbar form. |
+| [ShapePlaceFlip](../com.aspose.diagram/shapeplaceflip) | Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn). |
+| [ShapePlaceFlipValue](../com.aspose.diagram/shapeplaceflipvalue) | Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn). |
+| [ShapePlaceStyle](../com.aspose.diagram/shapeplacestyle) | Bestämmer placeringsstil för underordnade. |
+| [ShapePlaceStyleValue](../com.aspose.diagram/shapeplacestylevalue) | Bestämmer placeringsstil för underordnade. |
+| [ShapePlowCode](../com.aspose.diagram/shapeplowcode) | Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan. |
+| [ShapePlowCodeValue](../com.aspose.diagram/shapeplowcodevalue) | Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan. |
+| [ShapeRouteStyle](../com.aspose.diagram/shaperoutestyle) | Specificerar routningsstil och riktning för en anslutning på ritningssidan. |
+| [ShapeRouteStyleValue](../com.aspose.diagram/shaperoutestylevalue) | Specificerar routningsstil och riktning för en anslutning på ritningssidan. |
+| [ShapeShdwShow](../com.aspose.diagram/shapeshdwshow) | Anger typen av skugga för en form. |
+| [ShapeShdwShowValue](../com.aspose.diagram/shapeshdwshowvalue) | Anger typen av skugga för en form. |
+| [ShapeShdwType](../com.aspose.diagram/shapeshdwtype) | Anger typen av skugga för en form. |
+| [ShapeShdwTypeValue](../com.aspose.diagram/shapeshdwtypevalue) | Anger typen av skugga för en form. |
+| [ShdwType](../com.aspose.diagram/shdwtype) | Anger standardskuggtyp för en sida. |
+| [ShdwTypeValue](../com.aspose.diagram/shdwtypevalue) | Anger standardskuggtyp för en sida. |
+| [ShowDropButtonType](../com.aspose.diagram/showdropbuttontype) | Specificerar när droppknappen ska visas |
+| [SmartTagDef](../com.aspose.diagram/smarttagdef) | Innehåller element som innehåller information för varje smart tag som definierats för en form eller sida. |
+| [SmartTagDefCollection](../com.aspose.diagram/smarttagdefcollection) | SmartTagDef-samling. |
+| [SmoothingMode](../com.aspose.diagram/smoothingmode) | Specificerar om jämning (antialiasing) tillämpas på linjer och kurvor samt kanterna på fyllda områden. |
+| [SnapExtensions](../com.aspose.diagram/snapextensions) | Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret. |
+| [SnapExtensionsValue](../com.aspose.diagram/snapextensionsvalue) | Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret. |
+| [SnapSettings](../com.aspose.diagram/snapsettings) | Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret. |
+| [SnapSettingsValue](../com.aspose.diagram/snapsettingsvalue) | Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret |
+| [SolutionXML](../com.aspose.diagram/solutionxml) | Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument. |
+| [SolutionXMLCollection](../com.aspose.diagram/solutionxmlcollection) | SolutionXML-samling. |
+| [SpinButtonActiveXControl](../com.aspose.diagram/spinbuttonactivexcontrol) | Representerar SpinButton-kontrollen. |
+| [SplineKnot](../com.aspose.diagram/splineknot) | Innehåller x- och y-koordinater för en splines kontrollpunkt och en splines knut, representerade av X-, Y- och A-elementen respektive. |
+| [SplineKnotCollection](../com.aspose.diagram/splineknotcollection) | SplineKnot-samling. |
+| [SplineStart](../com.aspose.diagram/splinestart) | Innehåller x- och y-koordinater för en splines andra kontrollpunkt, dess andra knut, dess första knut, den sista knuten och splinens grad. |
+| [SplineStartCollection](../com.aspose.diagram/splinestartcollection) | SplineStart-samling. |
+| [Str2Value](../com.aspose.diagram/str2value) | Strängvärde. |
+| [StrValue](../com.aspose.diagram/strvalue) | Strängvärde |
+| [StreamProviderOptions](../com.aspose.diagram/streamprovideroptions) | Representerar strömalternativen. |
+| [Style](../com.aspose.diagram/style) | Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock. |
+| [StyleProp](../com.aspose.diagram/styleprop) | Innehåller element som styr stilbeteende, såsom om en stil inkluderar text-, linje- och fyllnadsattribut. |
+| [StyleSheet](../com.aspose.diagram/stylesheet) | Representerar en stil som definierats i ett dokument. |
+| [StyleSheetCollection](../com.aspose.diagram/stylesheetcollection) | Samling av stilmallar. |
+| [StyleValue](../com.aspose.diagram/stylevalue) | Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock. |
+| [Tab](../com.aspose.diagram/tab) | Innehåller en samling av Tab‑element. |
+| [TabCollection](../com.aspose.diagram/tabcollection) | Innehåller en samling av Tab‑element |
+| [TabsCollection](../com.aspose.diagram/tabscollection) | Innehåller en samling av TabCollection‑element |
+| [Text](../com.aspose.diagram/text) | Innehåller texten för en figur. |
+| [TextBlock](../com.aspose.diagram/textblock) | Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock. |
+| [TextBoxActiveXControl](../com.aspose.diagram/textboxactivexcontrol) | Representerar en textlåda ActiveX‑kontroll. |
+| [TextCollection](../com.aspose.diagram/textcollection) | Innehåller texten för en figur. |
+| [TextDirection](../com.aspose.diagram/textdirection) | Anger teckenriktningen i ett textblock. |
+| [TextDirectionValue](../com.aspose.diagram/textdirectionvalue) | Anger teckenriktningen i ett textblock. |
+| [TextXForm](../com.aspose.diagram/textxform) | Innehåller element som specificerar placeringsinformation om en figurs textblock. |
+| [ThreeDFormat](../com.aspose.diagram/threedformat) | Representerar en figurs tredimensionella formatering. |
+| [TiffCompression](../com.aspose.diagram/tiffcompression) | Anger vilken typ av komprimering som ska tillämpas när sidor sparas i TIFF‑format. |
+| [TimeLineHelper](../com.aspose.diagram/timelinehelper) | TimeLineHelper för att sätta egenskap på tidslinjefigur. |
+| [ToPartValue](../com.aspose.diagram/topartvalue) | Den del av en figur som en anslutning görs till. |
+| [ToggleButtonActiveXControl](../com.aspose.diagram/togglebuttonactivexcontrol) | Representerar en ToggleButton ActiveX‑kontroll. |
+| [Tp](../com.aspose.diagram/tp) | Anger början på en sekvens av tabb‑egenskaper. |
+| [Txt](../com.aspose.diagram/txt) | Figurens text |
+| [TypeConnection](../com.aspose.diagram/typeconnection) | Anger olika typer, baserat på elementet som den finns i. |
+| [TypeConnectionValue](../com.aspose.diagram/typeconnectionvalue) | Anger olika typer, baserat på elementet som den finns i. |
+| [TypeField](../com.aspose.diagram/typefield) | Typ anger en datatyp för textfältets värde. |
+| [TypeFieldValue](../com.aspose.diagram/typefieldvalue) | Typ anger en datatyp för textfältets värde. |
+| [TypeProp](../com.aspose.diagram/typeprop) | Typ anger en datatyp för det anpassade egenskapsvärdet. |
+| [TypePropValue](../com.aspose.diagram/typepropvalue) | Typ anger en datatyp för det anpassade egenskapsvärdet. |
+| [TypeValue](../com.aspose.diagram/typevalue) | Valfri uppräkning. |
+| [UIVisibility](../com.aspose.diagram/uivisibility) | Specificerar flikjusteringen. |
+| [UIVisibilityValue](../com.aspose.diagram/uivisibilityvalue) | Specificerar flikjusteringen. |
+| [UnitFormulaErr](../com.aspose.diagram/unitformulaerr) | Anger attribut för ett element. |
+| [UnitFormulaErrV](../com.aspose.diagram/unitformulaerrv) | Angivna attribut för ett element. |
+| [UnknownControl](../com.aspose.diagram/unknowncontrol) | Okänd kontroll. |
+| [User](../com.aspose.diagram/user) | Innehåller ett arbetsområde för att ange formler i användarspecifika element som refereras till av andra element och tilläggsverktyg. |
+| [UserCollection](../com.aspose.diagram/usercollection) | Användarsamling. |
+| [Validation](../com.aspose.diagram/validation) | Lagrar information om diagramvalidering för dokumentet. |
+| [ValidationProperties](../com.aspose.diagram/validationproperties) | Inkapslar egenskaper relaterade till validering för dokumentet. |
+| [Value](../com.aspose.diagram/value) | Värde. |
+| [VbaModule](../com.aspose.diagram/vbamodule) | Representerar modul som finns i VBA-projektet. |
+| [VbaModuleCollection](../com.aspose.diagram/vbamodulecollection) | Representerar listan över [VbaModule](../com.aspose.diagram/vbamodule) |
+| [VbaModuleType](../com.aspose.diagram/vbamoduletype) | Representerar typen av VBA-modul. |
+| [VbaProject](../com.aspose.diagram/vbaproject) | Representerar VBA-projektet. |
+| [VbaProjectReference](../com.aspose.diagram/vbaprojectreference) | Representerar referensen till VBA-projektet. |
+| [VbaProjectReferenceCollection](../com.aspose.diagram/vbaprojectreferencecollection) | Representerar alla referenser till VBA-projektet. |
+| [VbaProjectReferenceType](../com.aspose.diagram/vbaprojectreferencetype) | Representerar typen av VBA-projektreferens. |
+| [VerticalAlign](../com.aspose.diagram/verticalalign) | Anger vertikal justering av text inom textblocket. |
+| [VerticalAlignValue](../com.aspose.diagram/verticalalignvalue) | Anger vertikal justering av text inom textblocket. |
+| [VisRuleTargetsValue](../com.aspose.diagram/visruletargetsvalue) | Anger innehåll som definierar målet för valideringsregeln; skickas till och returneras av egenskapen ValidationRule.TargetType. |
+| [WalkPreference](../com.aspose.diagram/walkpreference) | Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position. |
+| [WalkPreferenceValue](../com.aspose.diagram/walkpreferencevalue) | Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position. |
+| [WarningInfo](../com.aspose.diagram/warninginfo) | Varningsinformation |
+| [WarningType](../com.aspose.diagram/warningtype) | WarningType |
+| [Window](../com.aspose.diagram/window) | Representerar ett öppet fönster i en Microsoft Visio-instans. |
+| [WindowCollection](../com.aspose.diagram/windowcollection) | Fönstersamling. |
+| [WindowStateValue](../com.aspose.diagram/windowstatevalue) | Ett heltal som specificerar bitflaggor. |
+| [WindowTypeValue](../com.aspose.diagram/windowtypevalue) | Ett uppräknat värde som kan vara något av följande: Drawing, Sheet, Stencil eller Icon. |
+| [XAMLSaveOptions](../com.aspose.diagram/xamlsaveoptions) | Tillåter att ange ytterligare alternativ när diagramssidor renderas till XAML. |
+| [XForm](../com.aspose.diagram/xform) | Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. |
+| [XForm1D](../com.aspose.diagram/xform1d) | Innehåller x- och y-koordinater för startpunkten och slutpunkten av en 1‑D-form. |
+| [XJustify](../com.aspose.diagram/xjustify) | X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [XJustifyValue](../com.aspose.diagram/xjustifyvalue) | X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [XPSSaveOptions](../com.aspose.diagram/xpssaveoptions) | Tillåter att ange ytterligare alternativ när diagramssidor renderas till XPS. |
+| [YJustify](../com.aspose.diagram/yjustify) | Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [YJustifyValue](../com.aspose.diagram/yjustifyvalue) | Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+
+## Gränssnitt
+
+| Gränssnitt | Beskrivning |
+| --- | --- |
+| [IPageSavingCallback](../com.aspose.diagram/ipagesavingcallback) | Styr/indikera framsteg för sidlagringsprocessen. |
+| [IStreamProvider](../com.aspose.diagram/istreamprovider) | Representerar den exporterade strömleverantören. |
+| [IWarningCallback](../com.aspose.diagram/iwarningcallback) | Återuppringningsgränssnitt för varning. |

--- a/swedish/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
+++ b/swedish/java/com.aspose.diagram/abstractinterruptmonitor/_index.md
@@ -1,0 +1,147 @@
+---
+title: AbstractInterruptMonitor
+second_title: Aspose.Diagram för Java API-referens
+description: Övervaka avbrottsförfrågningar i alla tidskrävande operationer.
+type: docs
+weight: 10
+url: /sv/java/com.aspose.diagram/abstractinterruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class AbstractInterruptMonitor
+```
+
+Övervaka avbrottsförfrågningar i alla tidskrävande operationer.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AbstractInterruptMonitor()](#AbstractInterruptMonitor--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Indikerar om avbrott begärs för den aktuella operationen. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbstractInterruptMonitor() {#AbstractInterruptMonitor--}
+```
+public AbstractInterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public abstract boolean isInterruptionRequested()
+```
+
+
+Indikerar om avbrott begärs för den aktuella operationen. Om true avbryts den aktuella operationen.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/act/_index.md
+++ b/swedish/java/com.aspose.diagram/act/_index.md
@@ -1,0 +1,395 @@
+---
+title: Act
+second_title: Aspose.Diagram för Java API-referens
+description: Definierar anpassade kommandonamn som visas i ett objekts snabbmeny och specificerar de åtgärder som kommandona utför.
+type: docs
+weight: 11
+url: /sv/java/com.aspose.diagram/act/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Act
+```
+
+Definierar anpassade kommandonamn som visas i ett objekts snabbmeny och specificerar de åtgärder som kommandona utför.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Act()](#Act--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Innehåller formeln som ska köras när en användare klickar på kommandonamnet som definierats i motsvarande Menu‑element. |
+| [getBeginGroup()](#getBeginGroup--) | Anger om en avgränsare ska infogas i menyn ovanför denna åtgärd. |
+| [getButtonFace()](#getButtonFace--) | Den identifierar ikonen som visas bredvid ett objekt i en snabbmeny. |
+| [getChecked()](#getChecked--) | Bestämmer om en bockmarkering visas bredvid kommandonamnet i en formes snabbmeny. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDisabled()](#getDisabled--) | Inaktiverat element avgör om kommandonamnet visas i snabbmenyn. |
+| [getFlyoutChild()](#getFlyoutChild--) | Bestämmer om åtgärdsraden är en undermeny till den sista raden ovanför den som inte är ett flyout‑barn. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getInvisible()](#getInvisible--) | Osynligt element indikerar om åtgärden är synlig på smart‑taggen eller snabbmenyn. |
+| [getMenu()](#getMenu--) | Specificerar namnet på kommandot som visas i snabbmenyn för en form eller sida. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getReadOnly()](#getReadOnly--) | Bestämmer om åtgärden på en smart‑tagg eller snabbmeny är skrivskyddad. |
+| [getSortKey()](#getSortKey--) | Den specificerar ett nummer som bestämmer ordningen på åtgärder som visas i en snabbmeny eller smart‑taggmeny. |
+| [getTagName()](#getTagName--) | Den innehåller namnet på smarttaggen som åtgärden är associerad med. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/act\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/act\#getID--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/act\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/act\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/act\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Act() {#Act--}
+```
+public Act()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public DoubleValue getAction()
+```
+
+
+Innehåller formeln som ska köras när en användare klickar på kommandonamnet som definierats i motsvarande Menu‑element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginGroup() {#getBeginGroup--}
+```
+public BoolValue getBeginGroup()
+```
+
+
+Anger om en avgränsare ska infogas i menyn ovanför denna åtgärd.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Den identifierar ikonen som visas bredvid ett objekt i en snabbmeny.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getChecked() {#getChecked--}
+```
+public BoolValue getChecked()
+```
+
+
+Bestämmer om en bockmarkering visas bredvid kommandonamnet i en formes snabbmeny.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Inaktiverat element avgör om kommandonamnet visas i snabbmenyn.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlyoutChild() {#getFlyoutChild--}
+```
+public BoolValue getFlyoutChild()
+```
+
+
+Bestämmer om åtgärdsraden är en undermeny till den sista raden ovanför den som inte är ett flyout‑barn.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Osynligt element indikerar om åtgärden är synlig på smart‑taggen eller snabbmenyn.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getMenu() {#getMenu--}
+```
+public Str2Value getMenu()
+```
+
+
+Specificerar namnet på kommandot som visas i snabbmenyn för en form eller sida.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getReadOnly() {#getReadOnly--}
+```
+public BoolValue getReadOnly()
+```
+
+
+Bestämmer om åtgärden på en smart‑tagg eller snabbmeny är skrivskyddad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Den specificerar ett nummer som bestämmer ordningen på åtgärder som visas i en snabbmeny eller smart‑taggmeny.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Den innehåller namnet på smarttaggen som åtgärden är associerad med.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/act\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/act\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/act\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/act\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/act\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/actcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/actcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ActCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Act-samling.
+type: docs
+weight: 12
+url: /sv/java/com.aspose.diagram/actcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ActCollection extends Collection
+```
+
+Act-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Act item)](#add-com.aspose.diagram.Act-) | Lägg till Act‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getAct(int ID)](#getAct-int-) | Hämtar elementet med angivet ID. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Act item)](#remove-com.aspose.diagram.Act-) | Ta bort Act‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Act item) {#add-com.aspose.diagram.Act-}
+```
+public int add(Act item)
+```
+
+
+Lägg till Act‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Act get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getAct(int ID) {#getAct-int-}
+```
+public Act getAct(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Act](../../com.aspose.diagram/act) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Act item) {#remove-com.aspose.diagram.Act-}
+```
+public void remove(Act item)
+```
+
+
+Ta bort Act‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Act](../../com.aspose.diagram/act) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/activexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/activexcontrol/_index.md
@@ -1,0 +1,422 @@
+---
+title: ActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ActiveX-kontrollen.
+type: docs
+weight: 13
+url: /sv/java/com.aspose.diagram/activexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase)
+```
+public abstract class ActiveXControl extends ActiveXControlBase
+```
+
+Representerar ActiveX-kontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/activexcontrolbase/_index.md
+++ b/swedish/java/com.aspose.diagram/activexcontrolbase/_index.md
@@ -1,0 +1,297 @@
+---
+title: ActiveXControlBase
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ActiveX-kontrollen.
+type: docs
+weight: 14
+url: /sv/java/com.aspose.diagram/activexcontrolbase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class ActiveXControlBase
+```
+
+Representerar ActiveX-kontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/activexpersistencetype/_index.md
+++ b/swedish/java/com.aspose.diagram/activexpersistencetype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ActiveXPersistenceType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar beständighetsmetoden för att bevara en ActiveX-kontroll.
+type: docs
+weight: 15
+url: /sv/java/com.aspose.diagram/activexpersistencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ActiveXPersistenceType
+```
+
+Representerar beständighetsmetoden för att bevara en ActiveX-kontroll.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [PROPERTY_BAG](#PROPERTY-BAG) | Data lagras som xml‑data. |
+| [STORAGE](#STORAGE) | Data lagras som lagringsbinär data. |
+| [STREAM](#STREAM) | Data lagras som strömbinär data. |
+| [STREAM_INIT](#STREAM-INIT) | Data lagras som streaminit‑binär data. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PROPERTY_BAG {#PROPERTY-BAG}
+```
+public static final int PROPERTY_BAG
+```
+
+
+Data lagras som xml‑data.
+
+### STORAGE {#STORAGE}
+```
+public static final int STORAGE
+```
+
+
+Data lagras som lagringsbinär data.
+
+### STREAM {#STREAM}
+```
+public static final int STREAM
+```
+
+
+Data lagras som strömbinär data.
+
+### STREAM_INIT {#STREAM-INIT}
+```
+public static final int STREAM_INIT
+```
+
+
+Data lagras som streaminit‑binär data.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/align/_index.md
+++ b/swedish/java/com.aspose.diagram/align/_index.md
@@ -1,0 +1,227 @@
+---
+title: Align
+second_title: Aspose.Diagram för Java API-referens
+description: Anger justeringen av en form i förhållande till guiden eller guidepunkten som formen är fäst vid.
+type: docs
+weight: 16
+url: /sv/java/com.aspose.diagram/align/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Align
+```
+
+Anger justeringen av en form i förhållande till guiden eller guidepunkten som formen är fäst vid. Align-elementet visas endast för former som är fästa vid guider eller guidepunkter.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignBottom()](#getAlignBottom--) | Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som formens nedre kant är justerad mot. |
+| [getAlignCenter()](#getAlignCenter--) | Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som formens horisontella centrum är justerat mot. |
+| [getAlignLeft()](#getAlignLeft--) | Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som formens vänstra kant är justerad mot. |
+| [getAlignMiddle()](#getAlignMiddle--) | Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som figurens vertikala centrum är justerat med. |
+| [getAlignRight()](#getAlignRight--) | Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som figurens högra kant är justerad med. |
+| [getAlignTop()](#getAlignTop--) | Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som figurens övre kant är justerad med. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/align\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignBottom() {#getAlignBottom--}
+```
+public DoubleValue getAlignBottom()
+```
+
+
+Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som formens nedre kant är justerad mot.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignCenter() {#getAlignCenter--}
+```
+public DoubleValue getAlignCenter()
+```
+
+
+Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som formens horisontella centrum är justerat mot.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignLeft() {#getAlignLeft--}
+```
+public DoubleValue getAlignLeft()
+```
+
+
+Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som formens vänstra kant är justerad mot.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignMiddle() {#getAlignMiddle--}
+```
+public DoubleValue getAlignMiddle()
+```
+
+
+Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som figurens vertikala centrum är justerat med.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignRight() {#getAlignRight--}
+```
+public DoubleValue getAlignRight()
+```
+
+
+Bestämmer den horisontella positionen, relativt ursprunget för dess förälder, för en vertikal guide eller guidepunkt som figurens högra kant är justerad med.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAlignTop() {#getAlignTop--}
+```
+public DoubleValue getAlignTop()
+```
+
+
+Bestämmer den vertikala positionen, relativt ursprunget för dess förälder, för en horisontell guide eller guidepunkt som figurens övre kant är justerad med.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/align\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/alignment/_index.md
+++ b/swedish/java/com.aspose.diagram/alignment/_index.md
@@ -1,0 +1,179 @@
+---
+title: Alignment
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar flikjusteringen.
+type: docs
+weight: 18
+url: /sv/java/com.aspose.diagram/alignment/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Alignment
+```
+
+Specificerar flikjusteringen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Alignment(int value)](#Alignment-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar flikjusteringen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/alignment\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Alignment(int value) {#Alignment-int-}
+```
+public Alignment(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar flikjusteringen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/alignment\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/alignmentvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/alignmentvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: AlignmentValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar flikjusteringen.
+type: docs
+weight: 19
+url: /sv/java/com.aspose.diagram/alignmentvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignmentValue
+```
+
+Specificerar flikjusteringen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CENTER](#CENTER) | Centrerad. |
+| [DECIMAL](#DECIMAL) | Decimal. |
+| [LEFT](#LEFT) | Vänster. |
+| [RIGHT](#RIGHT) | Höger. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centrerad.
+
+### DECIMAL {#DECIMAL}
+```
+public static final int DECIMAL
+```
+
+
+Decimal.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Vänster.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Höger.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/alignnamevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/alignnamevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: AlignNameValue
+second_title: Aspose.Diagram för Java API-referens
+description: Valfri int.
+type: docs
+weight: 17
+url: /sv/java/com.aspose.diagram/alignnamevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class AlignNameValue
+```
+
+Valfri int. Anger om mastertexten i stencil-fönstret är vänster-, höger- eller centrerad.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALIGN_TEXT_CENTER](#ALIGN-TEXT-CENTER) | Justera texten centrerat. |
+| [ALIGN_TEXT_LEFT](#ALIGN-TEXT-LEFT) | Justera texten åt vänster. |
+| [ALIGN_TEXT_RIGHT](#ALIGN-TEXT-RIGHT) | Justera texten åt höger. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGN_TEXT_CENTER {#ALIGN-TEXT-CENTER}
+```
+public static final int ALIGN_TEXT_CENTER
+```
+
+
+Justera texten centrerat.
+
+### ALIGN_TEXT_LEFT {#ALIGN-TEXT-LEFT}
+```
+public static final int ALIGN_TEXT_LEFT
+```
+
+
+Justera texten åt vänster.
+
+### ALIGN_TEXT_RIGHT {#ALIGN-TEXT-RIGHT}
+```
+public static final int ALIGN_TEXT_RIGHT
+```
+
+
+Justera texten åt höger.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/annotation/_index.md
+++ b/swedish/java/com.aspose.diagram/annotation/_index.md
@@ -1,0 +1,288 @@
+---
+title: Annotation
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida.
+type: docs
+weight: 20
+url: /sv/java/com.aspose.diagram/annotation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Annotation
+```
+
+Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Innehåller kommentartexten i strängformat för en form. |
+| [getDate()](#getDate--) | anger när en kommentar skapades |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getEditDate()](#getEditDate--) | Anger när en kommentar senast ändrades |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getLangID()](#getLangID--) | Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i. |
+| [getMarkerIndex()](#getMarkerIndex--) | Anger indexnumret som tilldelats en kommentarmarkör. |
+| [getReviewerID()](#getReviewerID--) | Innehåller ID‑numret för granskaren som lägger till markup i dokumentet. |
+| [getShapeID()](#getShapeID--) | Formens ID för kommentaren. |
+| [getX()](#getX--) | X‑koordinaten för kommentarmarkören i sidkoordinater. |
+| [getY()](#getY--) | Y‑koordinaten för kommentarmarkören i sidkoordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/annotation\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/annotation\#getIX--) |
+| [setShapeID(int value)](#setShapeID-int-) | För beskrivningen av denna egenskap, se [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Innehåller kommentartexten i strängformat för en form.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDate() {#getDate--}
+```
+public DateValue getDate()
+```
+
+
+anger när en kommentar skapades
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getEditDate() {#getEditDate--}
+```
+public DateValue getEditDate()
+```
+
+
+Anger när en kommentar senast ändrades
+
+**Returns:**
+[DateValue](../../com.aspose.diagram/datevalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getMarkerIndex() {#getMarkerIndex--}
+```
+public IntValue getMarkerIndex()
+```
+
+
+Anger indexnumret som tilldelats en kommentarmarkör.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Innehåller ID‑numret för granskaren som lägger till markup i dokumentet.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getShapeID() {#getShapeID--}
+```
+public int getShapeID()
+```
+
+
+Formens ID för kommentaren.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X‑koordinaten för kommentarmarkören i sidkoordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y‑koordinaten för kommentarmarkören i sidkoordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/annotation\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/annotation\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShapeID(int value) {#setShapeID-int-}
+```
+public void setShapeID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeID()](../../com.aspose.diagram/annotation\#getShapeID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/annotationcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/annotationcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: AnnotationCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Annotation-samling.
+type: docs
+weight: 21
+url: /sv/java/com.aspose.diagram/annotationcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class AnnotationCollection extends Collection
+```
+
+Annotation-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Annotation item)](#add-com.aspose.diagram.Annotation-) | Lägg till Annotation-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Annotation item)](#remove-com.aspose.diagram.Annotation-) | Ta bort Annotation-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Annotation item) {#add-com.aspose.diagram.Annotation-}
+```
+public int add(Annotation item)
+```
+
+
+Lägg till Annotation-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Annotation get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Annotation](../../com.aspose.diagram/annotation) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Annotation item) {#remove-com.aspose.diagram.Annotation-}
+```
+public void remove(Annotation item)
+```
+
+
+Ta bort Annotation-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Annotation](../../com.aspose.diagram/annotation) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/arcto/_index.md
+++ b/swedish/java/com.aspose.diagram/arcto/_index.md
@@ -1,0 +1,274 @@
+---
+title: ArcTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinaterna samt bågen för en cirkulär båge som representeras respektive av elementen X Y och A.
+type: docs
+weight: 22
+url: /sv/java/com.aspose.diagram/arcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class ArcTo extends Coordinate
+```
+
+Innehåller x- och y-koordinaterna samt bågen för en cirkulär båge som representeras respektive av elementen X, Y och A.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ArcTo()](#ArcTo--) | Skapar en instans av klassen [ArcTo](../../com.aspose.diagram/arcto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Avståndet från bågens mittpunkt till mittpunkten av dess kord. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för den avslutande vertexen av en båge. |
+| [getY()](#getY--) | y-koordinaten för den avslutande vertexen av en båge. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/arcto\#getA--). |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/arcto\#getDel--). |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/arcto\#getIX--). |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/arcto\#getX--). |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/arcto\#getY--). |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArcTo() {#ArcTo--}
+```
+public ArcTo()
+```
+
+
+Skapar en instans av klassen [ArcTo](../../com.aspose.diagram/arcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Avståndet från bågens mittpunkt till mittpunkten av dess kord.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för den avslutande vertexen av en båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för den avslutande vertexen av en båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/arcto\#getA--).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/arcto\#getDel--).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/arcto\#getIX--).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/arcto\#getX--).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/arcto\#getY--).
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/arctocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/arctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: ArcToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: ArcTo-samling.
+type: docs
+weight: 23
+url: /sv/java/com.aspose.diagram/arctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ArcToCollection extends Collection
+```
+
+ArcTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ArcTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[ArcTo](../../com.aspose.diagram/arcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/arrowsize/_index.md
+++ b/swedish/java/com.aspose.diagram/arrowsize/_index.md
@@ -1,0 +1,204 @@
+---
+title: ArrowSize
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar storleken på linjens pilspets.
+type: docs
+weight: 24
+url: /sv/java/com.aspose.diagram/arrowsize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ArrowSize
+```
+
+Specificerar storleken på linjens pilspets.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ArrowSize(int value)](#ArrowSize-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar storleken på linjens pilspets. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/arrowsize\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArrowSize(int value) {#ArrowSize-int-}
+```
+public ArrowSize(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar storleken på linjens pilspets.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/arrowsize\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/arrowsize\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/arrowsizevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/arrowsizevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ArrowSizeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar storleken på linjens pilspets.
+type: docs
+weight: 25
+url: /sv/java/com.aspose.diagram/arrowsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ArrowSizeValue
+```
+
+Specificerar storleken på linjens pilspets.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [COLOSSAL](#COLOSSAL) | Kolossal. |
+| [EXTRA_LARGE](#EXTRA-LARGE) | ExtraStor. |
+| [JUMBO](#JUMBO) | Jumbo. |
+| [LARGE](#LARGE) | Stor. |
+| [MEDIUM](#MEDIUM) | Mellan. |
+| [SMALL](#SMALL) | Liten. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VERY_SMALL](#VERY-SMALL) | MycketLiten. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOSSAL {#COLOSSAL}
+```
+public static final int COLOSSAL
+```
+
+
+Kolossal.
+
+### EXTRA_LARGE {#EXTRA-LARGE}
+```
+public static final int EXTRA_LARGE
+```
+
+
+ExtraStor.
+
+### JUMBO {#JUMBO}
+```
+public static final int JUMBO
+```
+
+
+Jumbo.
+
+### LARGE {#LARGE}
+```
+public static final int LARGE
+```
+
+
+Stor.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Mellan.
+
+### SMALL {#SMALL}
+```
+public static final int SMALL
+```
+
+
+Liten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VERY_SMALL {#VERY-SMALL}
+```
+public static final int VERY_SMALL
+```
+
+
+MycketLiten.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/asposediagramprintdocument/_index.md
+++ b/swedish/java/com.aspose.diagram/asposediagramprintdocument/_index.md
@@ -1,0 +1,143 @@
+---
+title: AsposeDiagramPrintDocument
+second_title: Aspose.Diagram för Java API-referens
+description: Dess egen version av .NET  PrintDocument  klass som kan skickas till ett  PrintPreviewDialog  formulär för att skriva ut och förhandsgranska ett diagram.
+type: docs
+weight: 26
+url: /sv/java/com.aspose.diagram/asposediagramprintdocument/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AsposeDiagramPrintDocument
+```
+
+Dess egen version av .NET PrintDocument-klass som kan skickas till ett PrintPreviewDialog-formulär för att skriva ut och förhandsgranska ett diagram.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AsposeDiagramPrintDocument(Diagram diagram)](#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-) | Initierar en ny instans av den här klassen som kan skickas till ett PrintPreviewDialog‑formulär för att skriva ut och förhandsgranska ett diagram. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AsposeDiagramPrintDocument(Diagram diagram) {#AsposeDiagramPrintDocument-com.aspose.diagram.Diagram-}
+```
+public AsposeDiagramPrintDocument(Diagram diagram)
+```
+
+
+Initierar en ny instans av den här klassen som kan skickas till ett PrintPreviewDialog‑formulär för att skriva ut och förhandsgranska ett diagram.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| diagram | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/autolinkcomparison/_index.md
+++ b/swedish/java/com.aspose.diagram/autolinkcomparison/_index.md
@@ -1,0 +1,200 @@
+---
+title: AutoLinkComparison
+second_title: Aspose.Diagram för Java API-referens
+description: Definierar en regel som jämför en kolumn i det överordnade DataRecordset-elementet med ett formdataobjekt från den senaste lyckade automatiska länkningsåtgärden som utförts i användargränssnittet.
+type: docs
+weight: 27
+url: /sv/java/com.aspose.diagram/autolinkcomparison/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoLinkComparison
+```
+
+Definierar en regel som jämför en kolumn i det överordnade DataRecordset-elementet med ett formdataobjekt från den senaste lyckade automatiska länkningsåtgärden som utförts i användargränssnittet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColumnName()](#getColumnName--) | Motsvarar ett kolumnnamn i ADO-recordsetet. |
+| [getContextType()](#getContextType--) | Anger egenskaper för gruppen eller formen som ska användas för jämförelsen. |
+| [getContextTypeLabel()](#getContextTypeLabel--) | Om ContextType‑värdet är 2 eller 3 krävs detta attribut för att definiera en jämförelse. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColumnName(String value)](#setColumnName-java.lang.String-) | För beskrivningen av denna egenskap, se [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--) |
+| [setContextType(int value)](#setContextType-int-) | För beskrivningen av denna egenskap, se [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--) |
+| [setContextTypeLabel(String value)](#setContextTypeLabel-java.lang.String-) | För beskrivningen av denna egenskap, se [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnName() {#getColumnName--}
+```
+public String getColumnName()
+```
+
+
+Motsvarar ett kolumnnamn i ADO-recordsetet.
+
+**Returns:**
+java.lang.String
+### getContextType() {#getContextType--}
+```
+public int getContextType()
+```
+
+
+Anger egenskaper för gruppen eller formen som ska användas för jämförelsen. Möjliga värden visas i följande tabell.
+
+**Returns:**
+int
+### getContextTypeLabel() {#getContextTypeLabel--}
+```
+public String getContextTypeLabel()
+```
+
+
+Om ContextType‑värdet är 2 eller 3 krävs detta attribut för att definiera en jämförelse. För ContextType = 2 måste ContextTypeLabel vara etiketten för formdataobjektet, och om ContextType = 3 måste ContextTypeLabel vara det lokala radnamnet.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColumnName(String value) {#setColumnName-java.lang.String-}
+```
+public void setColumnName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getColumnName()](../../com.aspose.diagram/autolinkcomparison\#getColumnName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setContextType(int value) {#setContextType-int-}
+```
+public void setContextType(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getContextType()](../../com.aspose.diagram/autolinkcomparison\#getContextType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setContextTypeLabel(String value) {#setContextTypeLabel-java.lang.String-}
+```
+public void setContextTypeLabel(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getContextTypeLabel()](../../com.aspose.diagram/autolinkcomparison\#getContextTypeLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/autospaceoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/autospaceoptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: AutoSpaceOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar autospace-alternativ.
+type: docs
+weight: 28
+url: /sv/java/com.aspose.diagram/autospaceoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class AutoSpaceOptions
+```
+
+Representerar autospace-alternativ.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [AutoSpaceOptions()](#AutoSpaceOptions--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDistanceInHorizontal()](#getDistanceInHorizontal--) | Definierar avståndet mellan formerna i horisontell riktning i tum. |
+| [getDistanceInVertical()](#getDistanceInVertical--) | Definierar avståndet mellan formerna i vertikal riktning i tum. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDistanceInHorizontal(double value)](#setDistanceInHorizontal-double-) | För beskrivningen av den här egenskapen, se [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--) |
+| [setDistanceInVertical(double value)](#setDistanceInVertical-double-) | För beskrivningen av den här egenskapen, se [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AutoSpaceOptions() {#AutoSpaceOptions--}
+```
+public AutoSpaceOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceInHorizontal() {#getDistanceInHorizontal--}
+```
+public double getDistanceInHorizontal()
+```
+
+
+Definierar avståndet mellan formerna i horisontell riktning i tum. Standardvärde 0,375 tum.
+
+**Returns:**
+double
+### getDistanceInVertical() {#getDistanceInVertical--}
+```
+public double getDistanceInVertical()
+```
+
+
+Definierar avståndet mellan formerna i vertikal riktning i tum. Standardvärde 0,375 tum.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDistanceInHorizontal(double value) {#setDistanceInHorizontal-double-}
+```
+public void setDistanceInHorizontal(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDistanceInHorizontal()](../../com.aspose.diagram/autospaceoptions\#getDistanceInHorizontal--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setDistanceInVertical(double value) {#setDistanceInVertical-double-}
+```
+public void setDistanceInVertical(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDistanceInVertical()](../../com.aspose.diagram/autospaceoptions\#getDistanceInVertical--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevel/_index.md
+++ b/swedish/java/com.aspose.diagram/bevel/_index.md
@@ -1,0 +1,175 @@
+---
+title: Bevel
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en fasning av en form
+type: docs
+weight: 30
+url: /sv/java/com.aspose.diagram/bevel/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bevel
+```
+
+Representerar en fasning av en form
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | Höjden på avfasningen, eller hur långt ovanför formen den appliceras. |
+| [getWidth()](#getWidth--) | Bredden på avfasningen, eller hur långt in i formen den appliceras. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/bevel\#getHeight--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/bevel\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Höjden på avfasningen, eller hur långt ovanför formen den appliceras. I enheten Points.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Bredden på avfasningen, eller hur långt in i formen den appliceras.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/bevel\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/bevel\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevellightingtype/_index.md
+++ b/swedish/java/com.aspose.diagram/bevellightingtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelLightingType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 31
+url: /sv/java/com.aspose.diagram/bevellightingtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelLightingType
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [BevelLightingType(int value)](#BevelLightingType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av fasning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelLightingType(int value) {#BevelLightingType-int-}
+```
+public BevelLightingType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av fasning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/bevellightingtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevellightingtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/bevellightingtypevalue/_index.md
@@ -1,0 +1,381 @@
+---
+title: BevelLightingTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en förinställd ljusrättning som kan tillämpas på en form
+type: docs
+weight: 32
+url: /sv/java/com.aspose.diagram/bevellightingtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelLightingTypeValue
+```
+
+Representerar en förinställd ljusrättning som kan tillämpas på en form
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BALANCED](#BALANCED) | Balanserad |
+| [BRIGHT_ROOM](#BRIGHT-ROOM) | Ljust rum |
+| [CHILLY](#CHILLY) | Kylig |
+| [CONTRASTING](#CONTRASTING) | Kontrasterande |
+| [FLAT](#FLAT) | Flat |
+| [FLOOD](#FLOOD) | Flod |
+| [FREEZING](#FREEZING) | Frysande |
+| [GLOW](#GLOW) | Glöd |
+| [HARSH](#HARSH) | Skarp |
+| [LEGACY_FLAT_1](#LEGACY-FLAT-1) | LegacyFlat1 |
+| [LEGACY_FLAT_2](#LEGACY-FLAT-2) | LegacyFlat2 |
+| [LEGACY_FLAT_3](#LEGACY-FLAT-3) | LegacyFlat3 |
+| [LEGACY_FLAT_4](#LEGACY-FLAT-4) | LegacyFlat4 |
+| [LEGACY_HARSH_1](#LEGACY-HARSH-1) | LegacyHarsh1 |
+| [LEGACY_HARSH_2](#LEGACY-HARSH-2) | LegacyHarsh2 |
+| [LEGACY_HARSH_3](#LEGACY-HARSH-3) | LegacyHarsh3 |
+| [LEGACY_HARSH_4](#LEGACY-HARSH-4) | LegacyHarsh4 |
+| [LEGACY_NORMAL_1](#LEGACY-NORMAL-1) | LegacyNormal1 |
+| [LEGACY_NORMAL_2](#LEGACY-NORMAL-2) | LegacyNormal2 |
+| [LEGACY_NORMAL_3](#LEGACY-NORMAL-3) | LegacyNormal3 |
+| [LEGACY_NORMAL_4](#LEGACY-NORMAL-4) | LegacyNormal4 |
+| [MORNING](#MORNING) | Morgon |
+| [SOFT](#SOFT) | Mjuk |
+| [SUNRISE](#SUNRISE) | Soluppgång |
+| [SUNSET](#SUNSET) | Solnedgång |
+| [THREE_POINT](#THREE-POINT) | Tre punkter |
+| [TWO_POINT](#TWO-POINT) | Två punkter |
+| [UNDEFINED](#UNDEFINED) | Ingen ljusrigg. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BALANCED {#BALANCED}
+```
+public static final int BALANCED
+```
+
+
+Balanserad
+
+### BRIGHT_ROOM {#BRIGHT-ROOM}
+```
+public static final int BRIGHT_ROOM
+```
+
+
+Ljust rum
+
+### CHILLY {#CHILLY}
+```
+public static final int CHILLY
+```
+
+
+Kylig
+
+### CONTRASTING {#CONTRASTING}
+```
+public static final int CONTRASTING
+```
+
+
+Kontrasterande
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### FLOOD {#FLOOD}
+```
+public static final int FLOOD
+```
+
+
+Flod
+
+### FREEZING {#FREEZING}
+```
+public static final int FREEZING
+```
+
+
+Frysande
+
+### GLOW {#GLOW}
+```
+public static final int GLOW
+```
+
+
+Glöd
+
+### HARSH {#HARSH}
+```
+public static final int HARSH
+```
+
+
+Skarp
+
+### LEGACY_FLAT_1 {#LEGACY-FLAT-1}
+```
+public static final int LEGACY_FLAT_1
+```
+
+
+LegacyFlat1
+
+### LEGACY_FLAT_2 {#LEGACY-FLAT-2}
+```
+public static final int LEGACY_FLAT_2
+```
+
+
+LegacyFlat2
+
+### LEGACY_FLAT_3 {#LEGACY-FLAT-3}
+```
+public static final int LEGACY_FLAT_3
+```
+
+
+LegacyFlat3
+
+### LEGACY_FLAT_4 {#LEGACY-FLAT-4}
+```
+public static final int LEGACY_FLAT_4
+```
+
+
+LegacyFlat4
+
+### LEGACY_HARSH_1 {#LEGACY-HARSH-1}
+```
+public static final int LEGACY_HARSH_1
+```
+
+
+LegacyHarsh1
+
+### LEGACY_HARSH_2 {#LEGACY-HARSH-2}
+```
+public static final int LEGACY_HARSH_2
+```
+
+
+LegacyHarsh2
+
+### LEGACY_HARSH_3 {#LEGACY-HARSH-3}
+```
+public static final int LEGACY_HARSH_3
+```
+
+
+LegacyHarsh3
+
+### LEGACY_HARSH_4 {#LEGACY-HARSH-4}
+```
+public static final int LEGACY_HARSH_4
+```
+
+
+LegacyHarsh4
+
+### LEGACY_NORMAL_1 {#LEGACY-NORMAL-1}
+```
+public static final int LEGACY_NORMAL_1
+```
+
+
+LegacyNormal1
+
+### LEGACY_NORMAL_2 {#LEGACY-NORMAL-2}
+```
+public static final int LEGACY_NORMAL_2
+```
+
+
+LegacyNormal2
+
+### LEGACY_NORMAL_3 {#LEGACY-NORMAL-3}
+```
+public static final int LEGACY_NORMAL_3
+```
+
+
+LegacyNormal3
+
+### LEGACY_NORMAL_4 {#LEGACY-NORMAL-4}
+```
+public static final int LEGACY_NORMAL_4
+```
+
+
+LegacyNormal4
+
+### MORNING {#MORNING}
+```
+public static final int MORNING
+```
+
+
+Morgon
+
+### SOFT {#SOFT}
+```
+public static final int SOFT
+```
+
+
+Mjuk
+
+### SUNRISE {#SUNRISE}
+```
+public static final int SUNRISE
+```
+
+
+Soluppgång
+
+### SUNSET {#SUNSET}
+```
+public static final int SUNSET
+```
+
+
+Solnedgång
+
+### THREE_POINT {#THREE-POINT}
+```
+public static final int THREE_POINT
+```
+
+
+Tre punkter
+
+### TWO_POINT {#TWO-POINT}
+```
+public static final int TWO_POINT
+```
+
+
+Två punkter
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Ingen ljusrigg.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevelmaterialtype/_index.md
+++ b/swedish/java/com.aspose.diagram/bevelmaterialtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelMaterialType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 33
+url: /sv/java/com.aspose.diagram/bevelmaterialtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelMaterialType
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [BevelMaterialType(int value)](#BevelMaterialType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av fasning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelMaterialType(int value) {#BevelMaterialType-int-}
+```
+public BevelMaterialType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av fasning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/bevelmaterialtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/bevelmaterialtypevalue/_index.md
@@ -1,0 +1,271 @@
+---
+title: BevelMaterialTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Beskriver ytegenskaperna för en form.
+type: docs
+weight: 34
+url: /sv/java/com.aspose.diagram/bevelmaterialtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelMaterialTypeValue
+```
+
+Beskriver ytegenskaperna för en form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CLEAR](#CLEAR) | Rensa |
+| [DARK_EDGE](#DARK-EDGE) | Mörk kant |
+| [FLAT](#FLAT) | Flat |
+| [LEGACY_MATTE](#LEGACY-MATTE) | Äldre matt |
+| [LEGACY_METAL](#LEGACY-METAL) | Äldre metall |
+| [LEGACY_PLASTIC](#LEGACY-PLASTIC) | Äldre plast |
+| [LEGACY_WIREFRAME](#LEGACY-WIREFRAME) | Äldre trådram |
+| [MATTE](#MATTE) | Matt |
+| [METAL](#METAL) | Metall |
+| [PLASTIC](#PLASTIC) | Plast |
+| [POWDER](#POWDER) | Pulver |
+| [SOFT_EDGE](#SOFT-EDGE) | Mjuk kant |
+| [SOFT_METAL](#SOFT-METAL) | Mjuk metall |
+| [TRANSLUCENT_POWDER](#TRANSLUCENT-POWDER) | Genomskinligt pulver |
+| [UNDEFINED](#UNDEFINED) |  |
+| [WARM_MATTE](#WARM-MATTE) | Varm matt |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLEAR {#CLEAR}
+```
+public static final int CLEAR
+```
+
+
+Rensa
+
+### DARK_EDGE {#DARK-EDGE}
+```
+public static final int DARK_EDGE
+```
+
+
+Mörk kant
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### LEGACY_MATTE {#LEGACY-MATTE}
+```
+public static final int LEGACY_MATTE
+```
+
+
+Äldre matt
+
+### LEGACY_METAL {#LEGACY-METAL}
+```
+public static final int LEGACY_METAL
+```
+
+
+Äldre metall
+
+### LEGACY_PLASTIC {#LEGACY-PLASTIC}
+```
+public static final int LEGACY_PLASTIC
+```
+
+
+Äldre plast
+
+### LEGACY_WIREFRAME {#LEGACY-WIREFRAME}
+```
+public static final int LEGACY_WIREFRAME
+```
+
+
+Äldre trådram
+
+### MATTE {#MATTE}
+```
+public static final int MATTE
+```
+
+
+Matt
+
+### METAL {#METAL}
+```
+public static final int METAL
+```
+
+
+Metall
+
+### PLASTIC {#PLASTIC}
+```
+public static final int PLASTIC
+```
+
+
+Plast
+
+### POWDER {#POWDER}
+```
+public static final int POWDER
+```
+
+
+Pulver
+
+### SOFT_EDGE {#SOFT-EDGE}
+```
+public static final int SOFT_EDGE
+```
+
+
+Mjuk kant
+
+### SOFT_METAL {#SOFT-METAL}
+```
+public static final int SOFT_METAL
+```
+
+
+Mjuk metall
+
+### TRANSLUCENT_POWDER {#TRANSLUCENT-POWDER}
+```
+public static final int TRANSLUCENT_POWDER
+```
+
+
+Genomskinligt pulver
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+### WARM_MATTE {#WARM-MATTE}
+```
+public static final int WARM_MATTE
+```
+
+
+Varm matt
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bevelpresettype/_index.md
+++ b/swedish/java/com.aspose.diagram/bevelpresettype/_index.md
@@ -1,0 +1,246 @@
+---
+title: BevelPresetType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D.
+type: docs
+weight: 35
+url: /sv/java/com.aspose.diagram/bevelpresettype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelPresetType
+```
+
+Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ANGLE](#ANGLE) | Vinkel |
+| [ART_DECO](#ART-DECO) | Art deco |
+| [CIRCLE](#CIRCLE) | Cirkel |
+| [CONVEX](#CONVEX) | Konvex |
+| [COOL_SLANT](#COOL-SLANT) | Cool lutning |
+| [CROSS](#CROSS) | Kors |
+| [DIVOT](#DIVOT) | Grop |
+| [HARD_EDGE](#HARD-EDGE) | Hård kant |
+| [NONE](#NONE) | Ingen avfasning |
+| [RELAXED_INSET](#RELAXED-INSET) | Avslappnad infogning |
+| [RIBLET](#RIBLET) | Ribba |
+| [SLOPE](#SLOPE) | Lutning |
+| [SOFT_ROUND](#SOFT-ROUND) | Mjuk rundning |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Vinkel
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art deco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Cirkel
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Konvex
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Cool lutning
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Kors
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Grop
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Hård kant
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen avfasning
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Avslappnad infogning
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Ribba
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Lutning
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Mjuk rundning
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/beveltype/_index.md
+++ b/swedish/java/com.aspose.diagram/beveltype/_index.md
@@ -1,0 +1,179 @@
+---
+title: BevelType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 36
+url: /sv/java/com.aspose.diagram/beveltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BevelType
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [BevelType(int value)](#BevelType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av fasning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/beveltype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BevelType(int value) {#BevelType-int-}
+```
+public BevelType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av fasning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/beveltype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/beveltypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/beveltypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: BevelTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D.
+type: docs
+weight: 37
+url: /sv/java/com.aspose.diagram/beveltypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BevelTypeValue
+```
+
+Representerar en förinställning för en typ av fasning som kan tillämpas på en form i 3D.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ANGLE](#ANGLE) | Vinkel |
+| [ART_DECO](#ART-DECO) | Art deco |
+| [CIRCLE](#CIRCLE) | Cirkel |
+| [CONVEX](#CONVEX) | Konvex |
+| [COOL_SLANT](#COOL-SLANT) | Cool lutning |
+| [CROSS](#CROSS) | Kors |
+| [DIVOT](#DIVOT) | Grop |
+| [HARD_EDGE](#HARD-EDGE) | Hård kant |
+| [NONE](#NONE) | Ingen avfasning |
+| [RELAXED_INSET](#RELAXED-INSET) | Avslappnad infogning |
+| [RIBLET](#RIBLET) | Ribba |
+| [SLOPE](#SLOPE) | Lutning |
+| [SOFT_ROUND](#SOFT-ROUND) | Mjuk rundning |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANGLE {#ANGLE}
+```
+public static final int ANGLE
+```
+
+
+Vinkel
+
+### ART_DECO {#ART-DECO}
+```
+public static final int ART_DECO
+```
+
+
+Art deco
+
+### CIRCLE {#CIRCLE}
+```
+public static final int CIRCLE
+```
+
+
+Cirkel
+
+### CONVEX {#CONVEX}
+```
+public static final int CONVEX
+```
+
+
+Konvex
+
+### COOL_SLANT {#COOL-SLANT}
+```
+public static final int COOL_SLANT
+```
+
+
+Cool lutning
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Kors
+
+### DIVOT {#DIVOT}
+```
+public static final int DIVOT
+```
+
+
+Grop
+
+### HARD_EDGE {#HARD-EDGE}
+```
+public static final int HARD_EDGE
+```
+
+
+Hård kant
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen avfasning
+
+### RELAXED_INSET {#RELAXED-INSET}
+```
+public static final int RELAXED_INSET
+```
+
+
+Avslappnad infogning
+
+### RIBLET {#RIBLET}
+```
+public static final int RIBLET
+```
+
+
+Ribba
+
+### SLOPE {#SLOPE}
+```
+public static final int SLOPE
+```
+
+
+Lutning
+
+### SOFT_ROUND {#SOFT-ROUND}
+```
+public static final int SOFT_ROUND
+```
+
+
+Mjuk rundning
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bool/_index.md
+++ b/swedish/java/com.aspose.diagram/bool/_index.md
@@ -1,0 +1,156 @@
+---
+title: BOOL
+second_title: Aspose.Diagram för Java API-referens
+description: Boolesk.
+type: docs
+weight: 29
+url: /sv/java/com.aspose.diagram/bool/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BOOL
+```
+
+Boolesk.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FALSE](#FALSE) | Falskt. |
+| [TRUE](#TRUE) | Sant. |
+| [UNDEFINED](#UNDEFINED) | Odefinierat tillstånd. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FALSE {#FALSE}
+```
+public static final int FALSE
+```
+
+
+Falskt.
+
+### TRUE {#TRUE}
+```
+public static final int TRUE
+```
+
+
+Sant.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierat tillstånd.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/boolvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/boolvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: BoolValue
+second_title: Aspose.Diagram för Java API-referens
+description: Booleskt värde.
+type: docs
+weight: 38
+url: /sv/java/com.aspose.diagram/boolvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class BoolValue
+```
+
+Booleskt värde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [BoolValue(int value, int unit)](#BoolValue-int-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Booleskt värde |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/boolvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoolValue(int value, int unit) {#BoolValue-int-int-}
+```
+public BoolValue(int value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+| enhet | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Booleskt värde
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/boolvalue\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/boolvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/boolvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bullet/_index.md
+++ b/swedish/java/com.aspose.diagram/bullet/_index.md
@@ -1,0 +1,179 @@
+---
+title: Bullet
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer punktlistans stil.
+type: docs
+weight: 39
+url: /sv/java/com.aspose.diagram/bullet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Bullet
+```
+
+Bestämmer punktlistans stil.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Bullet(int value)](#Bullet-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer punktlistans stil. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/bullet\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bullet(int value) {#Bullet-int-}
+```
+public Bullet(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer punktlistans stil.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/bullet\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/bulletvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/bulletvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: BulletValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer punktlistans stil.
+type: docs
+weight: 40
+url: /sv/java/com.aspose.diagram/bulletvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class BulletValue
+```
+
+Bestämmer punktlistans stil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NONE](#NONE) | Ingen. |
+| [STYLE_1](#STYLE-1) | Punkt. |
+| [STYLE_2](#STYLE-2) | Romb. |
+| [STYLE_3](#STYLE-3) | Fyrkant. |
+| [STYLE_4](#STYLE-4) | Stor kvadrat. |
+| [STYLE_5](#STYLE-5) | Rombar. |
+| [STYLE_6](#STYLE-6) | Pil. |
+| [STYLE_7](#STYLE-7) | Kryss. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen.
+
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Punkt.
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Romb.
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Fyrkant.
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Stor kvadrat.
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Rombar.
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Pil.
+
+### STYLE_7 {#STYLE-7}
+```
+public static final int STYLE_7
+```
+
+
+Kryss.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/calendar/_index.md
+++ b/swedish/java/com.aspose.diagram/calendar/_index.md
@@ -1,0 +1,204 @@
+---
+title: Calendar
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer den kalender som används för anpassade egenskapers textfält och elementformler.
+type: docs
+weight: 41
+url: /sv/java/com.aspose.diagram/calendar/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Calendar
+```
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Calendar(int value)](#Calendar-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/calendar\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/calendar\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Calendar(int value) {#Calendar-int-}
+```
+public Calendar(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/calendar\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/calendar\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/calendarvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/calendarvalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: Kalendervärde
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer den kalender som används för anpassade egenskapers textfält och elementformler.
+type: docs
+weight: 42
+url: /sv/java/com.aspose.diagram/calendarvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CalendarValue
+```
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ARABIC_HIJIRI](#ARABIC-HIJIRI) | Arabisk hijri. |
+| [ENGLISH_TRANSLITERATED](#ENGLISH-TRANSLITERATED) | Engelsk translittererad. |
+| [FRENCH_TRANSLITERATED](#FRENCH-TRANSLITERATED) | Fransk translittererad. |
+| [HEBREW_LUNAR](#HEBREW-LUNAR) | Hebreisk lunar. |
+| [JAPANESE_EMPEROR_REIGN](#JAPANESE-EMPEROR-REIGN) | Japansk kejsarperiod. |
+| [KOREAN_DANKI](#KOREAN-DANKI) | Koreansk Danki. |
+| [SAKA_ERA](#SAKA-ERA) | Saka-eran. |
+| [TAIWAN_CALENDAR](#TAIWAN-CALENDAR) | Taiwan-kalender. |
+| [THAI_BUDDHIST](#THAI-BUDDHIST) | Thai buddhist. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [WESTERN](#WESTERN) | Västlig. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARABIC_HIJIRI {#ARABIC-HIJIRI}
+```
+public static final int ARABIC_HIJIRI
+```
+
+
+Arabisk hijri.
+
+### ENGLISH_TRANSLITERATED {#ENGLISH-TRANSLITERATED}
+```
+public static final int ENGLISH_TRANSLITERATED
+```
+
+
+Engelsk translittererad.
+
+### FRENCH_TRANSLITERATED {#FRENCH-TRANSLITERATED}
+```
+public static final int FRENCH_TRANSLITERATED
+```
+
+
+Fransk translittererad.
+
+### HEBREW_LUNAR {#HEBREW-LUNAR}
+```
+public static final int HEBREW_LUNAR
+```
+
+
+Hebreisk lunar.
+
+### JAPANESE_EMPEROR_REIGN {#JAPANESE-EMPEROR-REIGN}
+```
+public static final int JAPANESE_EMPEROR_REIGN
+```
+
+
+Japansk kejsarperiod.
+
+### KOREAN_DANKI {#KOREAN-DANKI}
+```
+public static final int KOREAN_DANKI
+```
+
+
+Koreansk Danki.
+
+### SAKA_ERA {#SAKA-ERA}
+```
+public static final int SAKA_ERA
+```
+
+
+Saka-eran.
+
+### TAIWAN_CALENDAR {#TAIWAN-CALENDAR}
+```
+public static final int TAIWAN_CALENDAR
+```
+
+
+Taiwan-kalender.
+
+### THAI_BUDDHIST {#THAI-BUDDHIST}
+```
+public static final int THAI_BUDDHIST
+```
+
+
+Thai buddhist.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### WESTERN {#WESTERN}
+```
+public static final int WESTERN
+```
+
+
+Västlig.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/case/_index.md
+++ b/swedish/java/com.aspose.diagram/case/_index.md
@@ -1,0 +1,204 @@
+---
+title: Case
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer skiftläget för en shapes-text.
+type: docs
+weight: 43
+url: /sv/java/com.aspose.diagram/case/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Case
+```
+
+Bestämmer skiftläget för en forms text.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Case(int value)](#Case-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer skiftläget för en forms text. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/case\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/case\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Case(int value) {#Case-int-}
+```
+public Case(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer skiftläget för en forms text.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/case\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/case\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/casevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/casevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: CaseValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer skiftläget för en shapes-text.
+type: docs
+weight: 44
+url: /sv/java/com.aspose.diagram/casevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CaseValue
+```
+
+Bestämmer skiftläget för en shapes text. Alla versala (stora) bokstäver (1) och inledande versala bokstäver (2) ändrar inte utseendet på text som har skrivits med enbart versaler. Texten måste skrivas med gemena bokstäver för att dessa alternativ ska ha någon effekt.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALL_CAPITAL_LETTERS](#ALL-CAPITAL-LETTERS) | Alla versala (stora) bokstäver. |
+| [INITIAL_CAPITAL_LETTERS_ONLY](#INITIAL-CAPITAL-LETTERS-ONLY) | Endast inledande versala bokstäver. |
+| [NORMAL_CASE](#NORMAL-CASE) | Normal skrift. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_CAPITAL_LETTERS {#ALL-CAPITAL-LETTERS}
+```
+public static final int ALL_CAPITAL_LETTERS
+```
+
+
+Alla versala (stora) bokstäver.
+
+### INITIAL_CAPITAL_LETTERS_ONLY {#INITIAL-CAPITAL-LETTERS-ONLY}
+```
+public static final int INITIAL_CAPITAL_LETTERS_ONLY
+```
+
+
+Endast inledande versala bokstäver.
+
+### NORMAL_CASE {#NORMAL-CASE}
+```
+public static final int NORMAL_CASE
+```
+
+
+Normal skrift.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/char/_index.md
+++ b/swedish/java/com.aspose.diagram/char/_index.md
@@ -1,0 +1,937 @@
+---
+title: Char
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller formateringsattributen för figurens text, såsom teckensnittsfärg, textstil, versal-/gemenform, position relativt till baslinjen och punktstorlek.
+type: docs
+weight: 45
+url: /sv/java/com.aspose.diagram/char/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Char
+```
+
+Innehåller formateringsattributen för en forms text, såsom teckensnitt, färg, textstil, skiftläge, position relativt till baslinjen och punktstorlek.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Char()](#Char--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAsianFont()](#getAsianFont--) | Anger ID-numret för det teckensnitt som används för att formatera text som innehåller asiatiska tecken. |
+| [getAsianFontName()](#getAsianFontName--) | Den specificerar det asiatiska teckensnittets namn som används för att formatera texten. Den används för Visio 2013. |
+| [getCase()](#getCase--) | Bestämmer skiftläget för en forms text. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | När den finns i ett Char-element, färgelementet. |
+| [getColorTrans()](#getColorTrans--) | Bestämmer graden av transparens för ett lager eller en figurs textfärg, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig). |
+| [getComplexScriptFont()](#getComplexScriptFont--) | Innehåller numret på det teckensnitt som används för att formatera text bestående av komplexa skripttecken. |
+| [getComplexScriptFontName()](#getComplexScriptFontName--) | Den specificerar namnet på ComplexScript-teckensnittet som används för att formatera texten. Den används för Visio 2013. |
+| [getComplexScriptSize()](#getComplexScriptSize--) | Storleken på det teckensnitt som används för att formatera text bestående av komplexa skripttecken. |
+| [getDblUnderline()](#getDblUnderline--) | Anger om textområdet har en dubbel understrykning under sig. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDoubleStrikethrough()](#getDoubleStrikethrough--) | Bestämmer om text är formaterad som dubbel genomstrykning. |
+| [getFont()](#getFont--) | Anger ID-numret för teckensnittet som används för att formatera texten. |
+| [getFontName()](#getFontName--) | Det specificerade teckensnittets namn som används för att formatera texten. Det används för Visio 2013 |
+| [getFontScale()](#getFontScale--) | Anger teckensnittets bredd. |
+| [getHighlight()](#getHighlight--) | Det specificerade markering. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getLangID()](#getLangID--) | Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i. |
+| [getLetterspace()](#getLetterspace--) | Anger mängden utrymme mellan två eller fler tecken. |
+| [getLocale()](#getLocale--) | Det specificerade språkinställningen för textsekvensen för stavningskontroll. |
+| [getLocalizeFont()](#getLocalizeFont--) | Anger om formtexten ska lokaliseras (översättas till ett annat språk). |
+| [getOverline()](#getOverline--) | Anger om texten har en linje ovanför den. |
+| [getPerpendicular()](#getPerpendicular--) | Det specificerade om ett textfält visas vinkelrätt mot den andra texten i ett textblock. |
+| [getPos()](#getPos--) | Anger textens position i formen relativt till baslinjen. |
+| [getRTLText()](#getRTLText--) | Bestämmer om textriktningen för den aktuella teckensekvensen är från vänster till höger eller från höger till vänster. |
+| [getSize()](#getSize--) | Anger storleken på texten i figurens textblock. |
+| [getStrikethru()](#getStrikethru--) | Anger om texten är formaterad som genomstrykning. |
+| [getStyle()](#getStyle--) | Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock. |
+| [getUseVertical()](#getUseVertical--) | Bestämmer om teckensekvensen är vertikal eller horisontell. |
+| [hashCode()](#hashCode--) |  |
+| [isBold()](#isBold--) | Anger om teckensnittet är fetstil. |
+| [isDoubleStrikethrough()](#isDoubleStrikethrough--) | Anger om teckensnittet har dubbel genomstrykning. |
+| [isDoubleUnderline()](#isDoubleUnderline--) | Anger om teckensnittet har dubbel understrykning. |
+| [isItalic()](#isItalic--) | Anger om teckensnittet är kursivt. |
+| [isStrikethrough()](#isStrikethrough--) | Anger om teckensnittet är genomstruket. |
+| [isSubscript()](#isSubscript--) | Anger om teckensnittet är nedsänkt. |
+| [isSuperscript()](#isSuperscript--) | Anger om teckensnittet är upphöjt. |
+| [isUnderline()](#isUnderline--) | Anger om teckensnittet är understruket. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAsianFont(IntValue value)](#setAsianFont-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--) |
+| [setAsianFontName(StrValue value)](#setAsianFontName-com.aspose.diagram.StrValue-) | För beskrivningen av denna egenskap, se [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--) |
+| [setCase(Case value)](#setCase-com.aspose.diagram.Case-) | För beskrivningen av denna egenskap, se [getCase()](../../com.aspose.diagram/char\#getCase--) |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/char\#getColor--) |
+| [setColorTrans(DoubleValue value)](#setColorTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--) |
+| [setComplexScriptFont(IntValue value)](#setComplexScriptFont-com.aspose.diagram.IntValue-) | För beskrivningen av den här egenskapen, se [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--) |
+| [setComplexScriptFontName(StrValue value)](#setComplexScriptFontName-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--) |
+| [setComplexScriptSize(DoubleValue value)](#setComplexScriptSize-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--) |
+| [setDblUnderline(BoolValue value)](#setDblUnderline-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/char\#getDel--) |
+| [setDoubleStrikethrough(BoolValue value)](#setDoubleStrikethrough-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--) |
+| [setFont(IntValue value)](#setFont-com.aspose.diagram.IntValue-) | För beskrivningen av den här egenskapen, se [getFont()](../../com.aspose.diagram/char\#getFont--) |
+| [setFontName(StrValue value)](#setFontName-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getFontName()](../../com.aspose.diagram/char\#getFontName--) |
+| [setFontScale(DoubleValue value)](#setFontScale-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getFontScale()](../../com.aspose.diagram/char\#getFontScale--) |
+| [setHighlight(BoolValue value)](#setHighlight-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getHighlight()](../../com.aspose.diagram/char\#getHighlight--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/char\#getIX--) |
+| [setLangID(IntValue value)](#setLangID-com.aspose.diagram.IntValue-) | För beskrivningen av den här egenskapen, se [getLangID()](../../com.aspose.diagram/char\#getLangID--) |
+| [setLetterspace(DoubleValue value)](#setLetterspace-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--) |
+| [setLocale(StrValue value)](#setLocale-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getLocale()](../../com.aspose.diagram/char\#getLocale--) |
+| [setLocalizeFont(LocalizeFont value)](#setLocalizeFont-com.aspose.diagram.LocalizeFont-) | För beskrivningen av den här egenskapen, se [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--) |
+| [setOverline(BoolValue value)](#setOverline-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getOverline()](../../com.aspose.diagram/char\#getOverline--) |
+| [setPerpendicular(StrValue value)](#setPerpendicular-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--) |
+| [setPos(Pos value)](#setPos-com.aspose.diagram.Pos-) | För beskrivningen av den här egenskapen, se [getPos()](../../com.aspose.diagram/char\#getPos--) |
+| [setRTLText(BoolValue value)](#setRTLText-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getRTLText()](../../com.aspose.diagram/char\#getRTLText--) |
+| [setSize(DoubleValue value)](#setSize-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getSize()](../../com.aspose.diagram/char\#getSize--) |
+| [setStrikethru(BoolValue value)](#setStrikethru-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--) |
+| [setStyle(Style value)](#setStyle-com.aspose.diagram.Style-) | För beskrivningen av den här egenskapen, se [getStyle()](../../com.aspose.diagram/char\#getStyle--) |
+| [setUseVertical(BoolValue value)](#setUseVertical-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Char() {#Char--}
+```
+public Char()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAsianFont() {#getAsianFont--}
+```
+public IntValue getAsianFont()
+```
+
+
+Anger ID-numret för det teckensnitt som används för att formatera text som innehåller asiatiska tecken.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getAsianFontName() {#getAsianFontName--}
+```
+public StrValue getAsianFontName()
+```
+
+
+Den specificerar det asiatiska teckensnittets namn som används för att formatera texten. Den används för Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getCase() {#getCase--}
+```
+public Case getCase()
+```
+
+
+Bestämmer skiftläget för en forms text.
+
+**Returns:**
+[Case](../../com.aspose.diagram/case)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+När den finns i ett Char-element, färgelementet.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Bestämmer graden av transparens för ett lager eller en figurs textfärg, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getComplexScriptFont() {#getComplexScriptFont--}
+```
+public IntValue getComplexScriptFont()
+```
+
+
+Innehåller numret på det teckensnitt som används för att formatera text bestående av komplexa skripttecken. Komplexa skript är språk vars tecken kräver ligatur eller formning, såsom höger‑till‑vänster‑språk (arabiska, persiska, hebreiska och urdu) och flera sydasiatiska språk.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getComplexScriptFontName() {#getComplexScriptFontName--}
+```
+public StrValue getComplexScriptFontName()
+```
+
+
+Den specificerar namnet på ComplexScript-teckensnittet som används för att formatera texten. Den används för Visio 2013.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getComplexScriptSize() {#getComplexScriptSize--}
+```
+public DoubleValue getComplexScriptSize()
+```
+
+
+Storleken på teckensnittet som används för att formatera text bestående av komplexa skripttecken. Komplexa skript är språk vars tecken kräver ligatur eller formning, såsom höger‑till‑vänster‑språken (arabiska, persiska, hebreiska och urdu) och flera sydasiatiska språk.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDblUnderline() {#getDblUnderline--}
+```
+public BoolValue getDblUnderline()
+```
+
+
+Anger om textområdet har en dubbel understrykning under sig.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDoubleStrikethrough() {#getDoubleStrikethrough--}
+```
+public BoolValue getDoubleStrikethrough()
+```
+
+
+Bestämmer om text är formaterad som dubbel genomstrykning.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFont() {#getFont--}
+```
+public IntValue getFont()
+```
+
+
+Anger ID-numret för teckensnittet som används för att formatera texten.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getFontName() {#getFontName--}
+```
+public StrValue getFontName()
+```
+
+
+Det specificerade teckensnittets namn som används för att formatera texten. Det används för Visio 2013
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getFontScale() {#getFontScale--}
+```
+public DoubleValue getFontScale()
+```
+
+
+Anger teckensnittets bredd.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getHighlight() {#getHighlight--}
+```
+public BoolValue getHighlight()
+```
+
+
+Det specificerade markering.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Anger lokalkod‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren skrevs in i. För en lista över språk som stöds av Microsoft Office‑program och deras motsvarande språk‑ID:n, se elementet DocLangID.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLetterspace() {#getLetterspace--}
+```
+public DoubleValue getLetterspace()
+```
+
+
+Anger mängden utrymme mellan två eller fler tecken. Utrymmet kan läggas till eller dras bort i steg om 1/20 punkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocale() {#getLocale--}
+```
+public StrValue getLocale()
+```
+
+
+Det specificerade språkinställningen för textsekvensen för stavningskontroll.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getLocalizeFont() {#getLocalizeFont--}
+```
+public LocalizeFont getLocalizeFont()
+```
+
+
+Anger om formtexten ska lokaliseras (översättas till ett annat språk).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getOverline() {#getOverline--}
+```
+public BoolValue getOverline()
+```
+
+
+Anger om texten har en linje ovanför den.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerpendicular() {#getPerpendicular--}
+```
+public StrValue getPerpendicular()
+```
+
+
+Det specificerade om ett textfält visas vinkelrätt mot den andra texten i ett textblock.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPos() {#getPos--}
+```
+public Pos getPos()
+```
+
+
+Anger textens position i formen relativt till baslinjen.
+
+**Returns:**
+[Pos](../../com.aspose.diagram/pos)
+### getRTLText() {#getRTLText--}
+```
+public BoolValue getRTLText()
+```
+
+
+Bestämmer om textriktningen för den aktuella teckensekvensen är från vänster till höger eller från höger till vänster.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSize() {#getSize--}
+```
+public DoubleValue getSize()
+```
+
+
+Anger storleken på texten i figurens textblock.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getStrikethru() {#getStrikethru--}
+```
+public BoolValue getStrikethru()
+```
+
+
+Anger om texten är formaterad som genomstrykning.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStyle() {#getStyle--}
+```
+public Style getStyle()
+```
+
+
+Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock.
+
+**Returns:**
+[Style](../../com.aspose.diagram/style)
+### getUseVertical() {#getUseVertical--}
+```
+public BoolValue getUseVertical()
+```
+
+
+Bestämmer om teckensekvensen är vertikal eller horisontell.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isBold() {#isBold--}
+```
+public boolean isBold()
+```
+
+
+Anger om teckensnittet är fetstil.
+
+**Returns:**
+boolean
+### isDoubleStrikethrough() {#isDoubleStrikethrough--}
+```
+public boolean isDoubleStrikethrough()
+```
+
+
+Anger om teckensnittet har dubbel genomstrykning.
+
+**Returns:**
+boolean
+### isDoubleUnderline() {#isDoubleUnderline--}
+```
+public boolean isDoubleUnderline()
+```
+
+
+Anger om teckensnittet har dubbel understrykning.
+
+**Returns:**
+boolean
+### isItalic() {#isItalic--}
+```
+public boolean isItalic()
+```
+
+
+Anger om teckensnittet är kursivt.
+
+**Returns:**
+boolean
+### isStrikethrough() {#isStrikethrough--}
+```
+public boolean isStrikethrough()
+```
+
+
+Anger om teckensnittet är genomstruket.
+
+**Returns:**
+boolean
+### isSubscript() {#isSubscript--}
+```
+public boolean isSubscript()
+```
+
+
+Anger om teckensnittet är nedsänkt.
+
+**Returns:**
+boolean
+### isSuperscript() {#isSuperscript--}
+```
+public boolean isSuperscript()
+```
+
+
+Anger om teckensnittet är upphöjt.
+
+**Returns:**
+boolean
+### isUnderline() {#isUnderline--}
+```
+public boolean isUnderline()
+```
+
+
+Anger om teckensnittet är understruket.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAsianFont(IntValue value) {#setAsianFont-com.aspose.diagram.IntValue-}
+```
+public void setAsianFont(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAsianFont()](../../com.aspose.diagram/char\#getAsianFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setAsianFontName(StrValue value) {#setAsianFontName-com.aspose.diagram.StrValue-}
+```
+public void setAsianFontName(StrValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAsianFontName()](../../com.aspose.diagram/char\#getAsianFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setCase(Case value) {#setCase-com.aspose.diagram.Case-}
+```
+public void setCase(Case value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCase()](../../com.aspose.diagram/char\#getCase--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Case](../../com.aspose.diagram/case) |  |
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/char\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setColorTrans(DoubleValue value) {#setColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setColorTrans(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getColorTrans()](../../com.aspose.diagram/char\#getColorTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setComplexScriptFont(IntValue value) {#setComplexScriptFont-com.aspose.diagram.IntValue-}
+```
+public void setComplexScriptFont(IntValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getComplexScriptFont()](../../com.aspose.diagram/char\#getComplexScriptFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setComplexScriptFontName(StrValue value) {#setComplexScriptFontName-com.aspose.diagram.StrValue-}
+```
+public void setComplexScriptFontName(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getComplexScriptFontName()](../../com.aspose.diagram/char\#getComplexScriptFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setComplexScriptSize(DoubleValue value) {#setComplexScriptSize-com.aspose.diagram.DoubleValue-}
+```
+public void setComplexScriptSize(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getComplexScriptSize()](../../com.aspose.diagram/char\#getComplexScriptSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDblUnderline(BoolValue value) {#setDblUnderline-com.aspose.diagram.BoolValue-}
+```
+public void setDblUnderline(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDblUnderline()](../../com.aspose.diagram/char\#getDblUnderline--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/char\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDoubleStrikethrough(BoolValue value) {#setDoubleStrikethrough-com.aspose.diagram.BoolValue-}
+```
+public void setDoubleStrikethrough(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDoubleStrikethrough()](../../com.aspose.diagram/char\#getDoubleStrikethrough--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFont(IntValue value) {#setFont-com.aspose.diagram.IntValue-}
+```
+public void setFont(IntValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFont()](../../com.aspose.diagram/char\#getFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setFontName(StrValue value) {#setFontName-com.aspose.diagram.StrValue-}
+```
+public void setFontName(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFontName()](../../com.aspose.diagram/char\#getFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setFontScale(DoubleValue value) {#setFontScale-com.aspose.diagram.DoubleValue-}
+```
+public void setFontScale(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFontScale()](../../com.aspose.diagram/char\#getFontScale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setHighlight(BoolValue value) {#setHighlight-com.aspose.diagram.BoolValue-}
+```
+public void setHighlight(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHighlight()](../../com.aspose.diagram/char\#getHighlight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/char\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLangID(IntValue value) {#setLangID-com.aspose.diagram.IntValue-}
+```
+public void setLangID(IntValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLangID()](../../com.aspose.diagram/char\#getLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLetterspace(DoubleValue value) {#setLetterspace-com.aspose.diagram.DoubleValue-}
+```
+public void setLetterspace(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLetterspace()](../../com.aspose.diagram/char\#getLetterspace--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocale(StrValue value) {#setLocale-com.aspose.diagram.StrValue-}
+```
+public void setLocale(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLocale()](../../com.aspose.diagram/char\#getLocale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setLocalizeFont(LocalizeFont value) {#setLocalizeFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeFont(LocalizeFont value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLocalizeFont()](../../com.aspose.diagram/char\#getLocalizeFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setOverline(BoolValue value) {#setOverline-com.aspose.diagram.BoolValue-}
+```
+public void setOverline(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getOverline()](../../com.aspose.diagram/char\#getOverline--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerpendicular(StrValue value) {#setPerpendicular-com.aspose.diagram.StrValue-}
+```
+public void setPerpendicular(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPerpendicular()](../../com.aspose.diagram/char\#getPerpendicular--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPos(Pos value) {#setPos-com.aspose.diagram.Pos-}
+```
+public void setPos(Pos value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPos()](../../com.aspose.diagram/char\#getPos--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Pos](../../com.aspose.diagram/pos) |  |
+
+### setRTLText(BoolValue value) {#setRTLText-com.aspose.diagram.BoolValue-}
+```
+public void setRTLText(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRTLText()](../../com.aspose.diagram/char\#getRTLText--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setSize(DoubleValue value) {#setSize-com.aspose.diagram.DoubleValue-}
+```
+public void setSize(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSize()](../../com.aspose.diagram/char\#getSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setStrikethru(BoolValue value) {#setStrikethru-com.aspose.diagram.BoolValue-}
+```
+public void setStrikethru(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStrikethru()](../../com.aspose.diagram/char\#getStrikethru--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setStyle(Style value) {#setStyle-com.aspose.diagram.Style-}
+```
+public void setStyle(Style value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStyle()](../../com.aspose.diagram/char\#getStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Style](../../com.aspose.diagram/style) |  |
+
+### setUseVertical(BoolValue value) {#setUseVertical-com.aspose.diagram.BoolValue-}
+```
+public void setUseVertical(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUseVertical()](../../com.aspose.diagram/char\#getUseVertical--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/charcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/charcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: CharCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Teckensamling.
+type: docs
+weight: 46
+url: /sv/java/com.aspose.diagram/charcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CharCollection extends Collection
+```
+
+Teckensamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Char item)](#add-com.aspose.diagram.Char-) | Lägg till Char-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getChar(int IX)](#getChar-int-) | Hämtar elementet vid den angivna IX. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Char item)](#remove-com.aspose.diagram.Char-) | Ta bort Char-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Char item) {#add-com.aspose.diagram.Char-}
+```
+public int add(Char item)
+```
+
+
+Lägg till Char-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Char get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - 
+### getChar(int IX) {#getChar-int-}
+```
+public Char getChar(int IX)
+```
+
+
+Hämtar elementet vid den angivna IX.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int | intDet nollbaserade indexet för elementet inom dess föräldraelement. |
+
+**Returns:**
+[Char](../../com.aspose.diagram/char) - [Char](../../com.aspose.diagram/char)Char.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Char item) {#remove-com.aspose.diagram.Char-}
+```
+public void remove(Char item)
+```
+
+
+Ta bort Char-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Char](../../com.aspose.diagram/char) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/checkboxactivexcontrol/_index.md
@@ -1,0 +1,704 @@
+---
+title: CheckBoxActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en CheckBox ActiveX-kontroll.
+type: docs
+weight: 47
+url: /sv/java/com.aspose.diagram/checkboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CheckBoxActiveXControl extends ActiveXControl
+```
+
+Representerar en CheckBox ActiveX-kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Acceleratortangenten för kontrollen. |
+| [getAlignment()](#getAlignment--) | Positionen för Caption relativt kontrollen. |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getCaption()](#getCaption--) | Den beskrivande texten som visas på en kontroll. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getGroupName()](#getGroupName--) | Gruppens namn. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPicturePosition()](#getPicturePosition--) | platsen för kontrollens bild relativt dess rubrik. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getValue()](#getValue--) | Anger om kontrollen är markerad eller inte. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isChecked()](#isChecked--) | Anger om rutan är markerad. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isTripleState()](#isTripleState--) | Anger hur den angivna kontrollen kommer att visa Null‑värden. |
+| [isWordWrapped()](#isWordWrapped--) | Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | För beskrivningen av den här egenskapen, se [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | För beskrivningen av den här egenskapen, se [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | För beskrivningen av den här egenskapen, se [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--) |
+| [setChecked(boolean value)](#setChecked-boolean-) | För beskrivningen av den här egenskapen, se [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | För beskrivningen av den här egenskapen, se [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | För beskrivningen av den här egenskapen, se [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | För beskrivningen av den här egenskapen, se [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Acceleratortangenten för kontrollen.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Positionen för Caption relativt kontrollen.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Den beskrivande texten som visas på en kontroll.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+Gruppens namn.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+platsen för kontrollens bild relativt dess rubrik.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om kontrollen är markerad eller inte.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isChecked() {#isChecked--}
+```
+public boolean isChecked()
+```
+
+
+Anger om rutan är markerad.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Anger hur den angivna kontrollen kommer att visa Null‑värden.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inställning | Beskrivning                                                                                                                                     |
+| True    | Kontrollen kommer att cykla genom tillstånd för Ja, Nej och Null‑värden. Kontrollen visas nedtonad (grå) när dess Value‑egenskap är satt till Null. |
+| False   | (Standard) Kontrollen kommer att cykla genom tillstånd för Ja och Nej‑värden. Null‑värden visas som om de vore Nej‑värden.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAccelerator()](../../com.aspose.diagram/checkboxactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAlignment()](../../com.aspose.diagram/checkboxactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getCaption()](../../com.aspose.diagram/checkboxactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setChecked(boolean value) {#setChecked-boolean-}
+```
+public void setChecked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isChecked()](../../com.aspose.diagram/checkboxactivexcontrol\#isChecked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getGroupName()](../../com.aspose.diagram/checkboxactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPicturePosition()](../../com.aspose.diagram/checkboxactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/checkboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTripleState()](../../com.aspose.diagram/checkboxactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/checkboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isWordWrapped()](../../com.aspose.diagram/checkboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/checkvaluetype/_index.md
+++ b/swedish/java/com.aspose.diagram/checkvaluetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: CheckValueType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar kontrollvärdestypen för kryssrutan.
+type: docs
+weight: 48
+url: /sv/java/com.aspose.diagram/checkvaluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CheckValueType
+```
+
+Representerar kontrollvärdestypen för kryssrutan.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CHECKED](#CHECKED) | Checked |
+| [MIXED](#MIXED) | Mixed |
+| [UN_CHECKED](#UN-CHECKED) | UnChecked |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECKED {#CHECKED}
+```
+public static final int CHECKED
+```
+
+
+Checked
+
+### MIXED {#MIXED}
+```
+public static final int MIXED
+```
+
+
+Mixed
+
+### UN_CHECKED {#UN-CHECKED}
+```
+public static final int UN_CHECKED
+```
+
+
+UnChecked
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/collection/_index.md
+++ b/swedish/java/com.aspose.diagram/collection/_index.md
@@ -1,0 +1,188 @@
+---
+title: Samling
+second_title: Aspose.Diagram för Java API-referens
+description: Det är basklass för samlingar.
+type: docs
+weight: 49
+url: /sv/java/com.aspose.diagram/collection/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class Collection implements Iterable
+```
+
+Det är basklass för samlingar.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Collection()](#Collection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collection() {#Collection--}
+```
+public Collection()
+```
+
+
+Konstruktor.
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/collectionbase/_index.md
+++ b/swedish/java/com.aspose.diagram/collectionbase/_index.md
@@ -1,0 +1,264 @@
+---
+title: CollectionBase
+second_title: Aspose.Diagram för Java API-referens
+description: Tillhandahåller den abstrakta basklassen för en starkt typad samling.
+type: docs
+weight: 50
+url: /sv/java/com.aspose.diagram/collectionbase/
+---
+
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class CollectionBase implements Iterable
+```
+
+Tillhandahåller den abstrakta basklassen för en starkt typad samling.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CollectionBase()](#CollectionBase--) | Initierar en ny instans av klassen CollectionBase med standardinitialkapacitet. |
+| [CollectionBase(int capacity)](#CollectionBase-int-) | Initierar en ny instans av klassen CollectionBase med den angivna kapaciteten. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Lägger till ett objekt i CollectionBase-instansen. |
+| [clear()](#clear--) | Tar bort alla objekt från CollectionBase-instansen. |
+| [contains(Object o)](#contains-java.lang.Object-) | Returnerar huruvida instansen innehåller detta objekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämta ett objekt på angiven position. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som finns i CollectionBase-instansen. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+| [iterator()](#iterator--) | Returnerar en enumerator som itererar genom CollectionBase-instansen. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Tar bort objektet på det angivna indexet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CollectionBase() {#CollectionBase--}
+```
+public CollectionBase()
+```
+
+
+Initierar en ny instans av klassen CollectionBase med standardinitialkapacitet.
+
+### CollectionBase(int capacity) {#CollectionBase-int-}
+```
+public CollectionBase(int capacity)
+```
+
+
+Initierar en ny instans av klassen CollectionBase med den angivna kapaciteten.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| kapacitet | int | Antalet element som den nya listan initialt kan lagra. |
+
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Lägger till ett objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Objektet som ska läggas till i CollectionBase-instansen. |
+
+**Returns:**
+int - Positionen där det nya elementet infördes.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla objekt från CollectionBase-instansen.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Returnerar huruvida instansen innehåller detta objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | testobjekt |
+
+**Returns:**
+boolean - Om instansen innehåller detta objekt
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Object get(int index)
+```
+
+
+Hämta ett objekt på angiven position.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Angivet positionsindex. |
+
+**Returns:**
+java.lang.Object - Objektet på angiven position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som finns i CollectionBase-instansen.
+
+**Returns:**
+int - Antalet element som finns i CollectionBase‑instansen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+
+**Returns:**
+int - Indexet för värdet om det hittas i listan; annars -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returnerar en enumerator som itererar genom CollectionBase-instansen.
+
+**Returns:**
+java.util.Iterator - En iterator för CollectionBase‑instansen.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Tar bort objektet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Det nollbaserade indexet för objektet som ska tas bort. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/color/_index.md
+++ b/swedish/java/com.aspose.diagram/color/_index.md
@@ -1,0 +1,1819 @@
+---
+title: Color
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en ARGB alfa röd grön blå färg.
+type: docs
+weight: 51
+url: /sv/java/com.aspose.diagram/color/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Color
+```
+
+Representerar en ARGB-färg (alpha, röd, grön, blå).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Color()](#Color--) | konstruktionsfunktion |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Testar om det angivna objektet är ett Color-objekt och är ekvivalent med detta objekt. |
+| [fromArgb(int argb)](#fromArgb-int-) | Skapar ett Color-objekt från ett 32-bitars ARGB-värde. |
+| [fromArgb(int red, int green, int blue)](#fromArgb-int-int-int-) | Skapar ett Color-objekt från de angivna 8-bitars färgvärdena (röd, grön och blå). |
+| [fromArgb(int alpha, int red, int green, int blue)](#fromArgb-int-int-int-int-) | Skapar ett Color-objekt från de fyra ARGB-komponentvärdena (alfa, röd, grön och blå). |
+| [getA()](#getA--) | Hämtar alfa-komponentens värde för detta Color-objekt. |
+| [getAliceBlue()](#getAliceBlue--) | Hämta en systemdefinierad färg. |
+| [getAntiqueWhite()](#getAntiqueWhite--) | Hämta en systemdefinierad färg. |
+| [getAqua()](#getAqua--) | Hämta en systemdefinierad färg. |
+| [getAquamarine()](#getAquamarine--) | Hämta en systemdefinierad färg. |
+| [getAzure()](#getAzure--) | Hämta en systemdefinierad färg. |
+| [getB()](#getB--) | Hämtar blå-komponentens värde för detta Color-objekt. |
+| [getBeige()](#getBeige--) | Hämta en systemdefinierad färg. |
+| [getBisque()](#getBisque--) | Hämta en systemdefinierad färg. |
+| [getBlack()](#getBlack--) | Hämta en systemdefinierad färg. |
+| [getBlanchedAlmond()](#getBlanchedAlmond--) | Hämta en systemdefinierad färg. |
+| [getBlue()](#getBlue--) | Hämta en systemdefinierad färg. |
+| [getBlueViolet()](#getBlueViolet--) | Hämta en systemdefinierad färg. |
+| [getBrown()](#getBrown--) | Hämta en systemdefinierad färg. |
+| [getBurlyWood()](#getBurlyWood--) | Hämta en systemdefinierad färg. |
+| [getCadetBlue()](#getCadetBlue--) | Hämta en systemdefinierad färg. |
+| [getChartreuse()](#getChartreuse--) | Hämta en systemdefinierad färg. |
+| [getChocolate()](#getChocolate--) | Hämta en systemdefinierad färg. |
+| [getClass()](#getClass--) |  |
+| [getCoral()](#getCoral--) | Hämta en systemdefinierad färg. |
+| [getCornflowerBlue()](#getCornflowerBlue--) | Hämta en systemdefinierad färg. |
+| [getCornsilk()](#getCornsilk--) | Hämta en systemdefinierad färg. |
+| [getCrimson()](#getCrimson--) | Hämta en systemdefinierad färg. |
+| [getCyan()](#getCyan--) | Hämta en systemdefinierad färg. |
+| [getDarkBlue()](#getDarkBlue--) | Hämta en systemdefinierad färg. |
+| [getDarkCyan()](#getDarkCyan--) | Hämta en systemdefinierad färg. |
+| [getDarkGoldenrod()](#getDarkGoldenrod--) | Hämta en systemdefinierad färg. |
+| [getDarkGray()](#getDarkGray--) | Hämta en systemdefinierad färg. |
+| [getDarkGreen()](#getDarkGreen--) | Hämta en systemdefinierad färg. |
+| [getDarkKhaki()](#getDarkKhaki--) | Hämta en systemdefinierad färg. |
+| [getDarkMagenta()](#getDarkMagenta--) | Hämta en systemdefinierad färg. |
+| [getDarkOliveGreen()](#getDarkOliveGreen--) | Hämta en systemdefinierad färg. |
+| [getDarkOrange()](#getDarkOrange--) | Hämta en systemdefinierad färg. |
+| [getDarkOrchid()](#getDarkOrchid--) | Hämta en systemdefinierad färg. |
+| [getDarkRed()](#getDarkRed--) | Hämta en systemdefinierad färg. |
+| [getDarkSalmon()](#getDarkSalmon--) | Hämta en systemdefinierad färg. |
+| [getDarkSeaGreen()](#getDarkSeaGreen--) | Hämta en systemdefinierad färg. |
+| [getDarkSlateBlue()](#getDarkSlateBlue--) | Hämta en systemdefinierad färg. |
+| [getDarkSlateGray()](#getDarkSlateGray--) | Hämta en systemdefinierad färg. |
+| [getDarkTurquoise()](#getDarkTurquoise--) | Hämta en systemdefinierad färg. |
+| [getDarkViolet()](#getDarkViolet--) | Hämta en systemdefinierad färg. |
+| [getDeepPink()](#getDeepPink--) | Hämta en systemdefinierad färg. |
+| [getDeepSkyBlue()](#getDeepSkyBlue--) | Hämta en systemdefinierad färg. |
+| [getDimGray()](#getDimGray--) | Hämta en systemdefinierad färg. |
+| [getDodgerBlue()](#getDodgerBlue--) | Hämta en systemdefinierad färg. |
+| [getEmpty()](#getEmpty--) | Hämta en systemdefinierad tom färg. |
+| [getFirebrick()](#getFirebrick--) | Hämta en systemdefinierad färg. |
+| [getFloralWhite()](#getFloralWhite--) | Hämta en systemdefinierad färg. |
+| [getForestGreen()](#getForestGreen--) | Hämta en systemdefinierad färg. |
+| [getFuchsia()](#getFuchsia--) | Hämta en systemdefinierad färg. |
+| [getG()](#getG--) | Hämtar grön-komponentens värde för detta Color-objekt. |
+| [getGainsboro()](#getGainsboro--) | Hämta en systemdefinierad färg. |
+| [getGhostWhite()](#getGhostWhite--) | Hämta en systemdefinierad färg. |
+| [getGold()](#getGold--) | Hämta en systemdefinierad färg. |
+| [getGoldenrod()](#getGoldenrod--) | Hämta en systemdefinierad färg. |
+| [getGray()](#getGray--) | Hämta en systemdefinierad färg. |
+| [getGreen()](#getGreen--) | Hämta en systemdefinierad färg. |
+| [getGreenYellow()](#getGreenYellow--) | Hämta en systemdefinierad färg. |
+| [getHoneydew()](#getHoneydew--) | Hämta en systemdefinierad färg. |
+| [getHotPink()](#getHotPink--) | Hämta en systemdefinierad färg. |
+| [getIndianRed()](#getIndianRed--) | Hämta en systemdefinierad färg. |
+| [getIndigo()](#getIndigo--) | Hämta en systemdefinierad färg. |
+| [getIvory()](#getIvory--) | Hämta en systemdefinierad färg. |
+| [getKhaki()](#getKhaki--) | Hämta en systemdefinierad färg. |
+| [getLavender()](#getLavender--) | Hämta en systemdefinierad färg. |
+| [getLavenderBlush()](#getLavenderBlush--) | Hämta en systemdefinierad färg. |
+| [getLawnGreen()](#getLawnGreen--) | Hämta en systemdefinierad färg. |
+| [getLemonChiffon()](#getLemonChiffon--) | Hämta en systemdefinierad färg. |
+| [getLightBlue()](#getLightBlue--) | Hämta en systemdefinierad färg. |
+| [getLightCoral()](#getLightCoral--) | Hämta en systemdefinierad färg. |
+| [getLightCyan()](#getLightCyan--) | Hämta en systemdefinierad färg. |
+| [getLightGoldenrodYellow()](#getLightGoldenrodYellow--) | Hämta en systemdefinierad färg. |
+| [getLightGray()](#getLightGray--) | Hämta en systemdefinierad färg. |
+| [getLightGreen()](#getLightGreen--) | Hämta en systemdefinierad färg. |
+| [getLightPink()](#getLightPink--) | Hämta en systemdefinierad färg. |
+| [getLightSalmon()](#getLightSalmon--) | Hämta en systemdefinierad färg. |
+| [getLightSeaGreen()](#getLightSeaGreen--) | Hämta en systemdefinierad färg. |
+| [getLightSkyBlue()](#getLightSkyBlue--) | Hämta en systemdefinierad färg. |
+| [getLightSlateGray()](#getLightSlateGray--) | Hämta en systemdefinierad färg. |
+| [getLightSteelBlue()](#getLightSteelBlue--) | Hämta en systemdefinierad färg. |
+| [getLightYellow()](#getLightYellow--) | Hämta en systemdefinierad färg. |
+| [getLime()](#getLime--) | Hämta en systemdefinierad färg. |
+| [getLimeGreen()](#getLimeGreen--) | Hämta en systemdefinierad färg. |
+| [getLinen()](#getLinen--) | Hämta en systemdefinierad färg. |
+| [getMagenta()](#getMagenta--) | Hämta en systemdefinierad färg. |
+| [getMaroon()](#getMaroon--) | Hämta en systemdefinierad färg. |
+| [getMediumAquamarine()](#getMediumAquamarine--) | Hämta en systemdefinierad färg. |
+| [getMediumBlue()](#getMediumBlue--) | Hämta en systemdefinierad färg. |
+| [getMediumOrchid()](#getMediumOrchid--) | Hämta en systemdefinierad färg. |
+| [getMediumPurple()](#getMediumPurple--) | Hämta en systemdefinierad färg. |
+| [getMediumSeaGreen()](#getMediumSeaGreen--) | Hämta en systemdefinierad färg. |
+| [getMediumSlateBlue()](#getMediumSlateBlue--) | Hämta en systemdefinierad färg. |
+| [getMediumSpringGreen()](#getMediumSpringGreen--) | Hämta en systemdefinierad färg. |
+| [getMediumTurquoise()](#getMediumTurquoise--) | Hämta en systemdefinierad färg. |
+| [getMediumVioletRed()](#getMediumVioletRed--) | Hämta en systemdefinierad färg. |
+| [getMidnightBlue()](#getMidnightBlue--) | Hämta en systemdefinierad färg. |
+| [getMintCream()](#getMintCream--) | Hämta en systemdefinierad färg. |
+| [getMistyRose()](#getMistyRose--) | Hämta en systemdefinierad färg. |
+| [getMoccasin()](#getMoccasin--) | Hämta en systemdefinierad färg. |
+| [getNavajoWhite()](#getNavajoWhite--) | Hämta en systemdefinierad färg. |
+| [getNavy()](#getNavy--) | Hämta en systemdefinierad färg. |
+| [getOldLace()](#getOldLace--) | Hämta en systemdefinierad färg. |
+| [getOlive()](#getOlive--) | Hämta en systemdefinierad färg. |
+| [getOliveDrab()](#getOliveDrab--) | Hämta en systemdefinierad färg. |
+| [getOrange()](#getOrange--) | Hämta en systemdefinierad färg. |
+| [getOrangeRed()](#getOrangeRed--) | Hämta en systemdefinierad färg. |
+| [getOrchid()](#getOrchid--) | Hämta en systemdefinierad färg. |
+| [getPaleGoldenrod()](#getPaleGoldenrod--) | Hämta en systemdefinierad färg. |
+| [getPaleGreen()](#getPaleGreen--) | Hämta en systemdefinierad färg. |
+| [getPaleTurquoise()](#getPaleTurquoise--) | Hämta en systemdefinierad färg. |
+| [getPaleVioletRed()](#getPaleVioletRed--) | Hämta en systemdefinierad färg. |
+| [getPapayaWhip()](#getPapayaWhip--) | Hämta en systemdefinierad färg. |
+| [getPeachPuff()](#getPeachPuff--) | Hämta en systemdefinierad färg. |
+| [getPeru()](#getPeru--) | Hämta en systemdefinierad färg. |
+| [getPink()](#getPink--) | Hämta en systemdefinierad färg. |
+| [getPlum()](#getPlum--) | Hämta en systemdefinierad färg. |
+| [getPowderBlue()](#getPowderBlue--) | Hämta en systemdefinierad färg. |
+| [getPurple()](#getPurple--) | Hämta en systemdefinierad färg. |
+| [getR()](#getR--) | Hämtar röd-komponentens värde för detta Color-objekt. |
+| [getRed()](#getRed--) | Hämta en systemdefinierad färg. |
+| [getRosyBrown()](#getRosyBrown--) | Hämta en systemdefinierad färg. |
+| [getRoyalBlue()](#getRoyalBlue--) | Hämta en systemdefinierad färg. |
+| [getSaddleBrown()](#getSaddleBrown--) | Hämta en systemdefinierad färg. |
+| [getSalmon()](#getSalmon--) | Hämta en systemdefinierad färg. |
+| [getSandyBrown()](#getSandyBrown--) | Hämta en systemdefinierad färg. |
+| [getSeaGreen()](#getSeaGreen--) | Hämta en systemdefinierad färg. |
+| [getSeaShell()](#getSeaShell--) | Hämta en systemdefinierad färg. |
+| [getSienna()](#getSienna--) | Hämta en systemdefinierad färg. |
+| [getSilver()](#getSilver--) | Hämta en systemdefinierad färg. |
+| [getSkyBlue()](#getSkyBlue--) | Hämta en systemdefinierad färg. |
+| [getSlateBlue()](#getSlateBlue--) | Hämta en systemdefinierad färg. |
+| [getSlateGray()](#getSlateGray--) | Hämta en systemdefinierad färg. |
+| [getSnow()](#getSnow--) | Hämta en systemdefinierad färg. |
+| [getSpringGreen()](#getSpringGreen--) | Hämta en systemdefinierad färg. |
+| [getSteelBlue()](#getSteelBlue--) | Hämta en systemdefinierad färg. |
+| [getTan()](#getTan--) | Hämta en systemdefinierad färg. |
+| [getTeal()](#getTeal--) | Hämta en systemdefinierad färg. |
+| [getThistle()](#getThistle--) | Hämta en systemdefinierad färg. |
+| [getTomato()](#getTomato--) | Hämta en systemdefinierad färg. |
+| [getTransparent()](#getTransparent--) | Hämta en systemdefinierad färg. |
+| [getTurquoise()](#getTurquoise--) | Hämta en systemdefinierad färg. |
+| [getViolet()](#getViolet--) | Hämta en systemdefinierad färg. |
+| [getWheat()](#getWheat--) | Hämta en systemdefinierad färg. |
+| [getWhite()](#getWhite--) | Hämta en systemdefinierad färg. |
+| [getWhiteSmoke()](#getWhiteSmoke--) | Hämta en systemdefinierad färg. |
+| [getYellow()](#getYellow--) | Hämta en systemdefinierad färg. |
+| [getYellowGreen()](#getYellowGreen--) | Hämta en systemdefinierad färg. |
+| [hashCode()](#hashCode--) | Returnerar en hashkod för detta Color-objekt. |
+| [isEmpty()](#isEmpty--) | Anger om detta Color-objekt är oinitierat. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toArgb()](#toArgb--) | Hämtar det 32-bitars ARGB-värdet för detta Color-objekt. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Color() {#Color--}
+```
+public Color()
+```
+
+
+konstruktionsfunktion
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Testar om det angivna objektet är ett Color-objekt och är ekvivalent med detta objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object | Objektet att testa. |
+
+**Returns:**
+boolean - sant om obj är ett Color-objekt och ekvivalent med detta Color-objekt; annars falskt.
+### fromArgb(int argb) {#fromArgb-int-}
+```
+public static Color fromArgb(int argb)
+```
+
+
+Skapar ett Color-objekt från ett 32-bitars ARGB-värde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| argb | int | Ett värde som specificerar det 32-bitars ARGB-värdet. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int red, int green, int blue) {#fromArgb-int-int-int-}
+```
+public static Color fromArgb(int red, int green, int blue)
+```
+
+
+Skapar ett Color-objekt från de angivna 8-bitars färgvärdena (röd, grön och blå). Alfa‑värdet är implicit 255 (fullt ogenomskinligt). Även om denna metod tillåter att ett 32-bitars värde skickas för varje färgkomponent, är värdet för varje komponent begränsat till 8 bitar.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| röd | int | Röd‑komponentens värde för det nya Color-objektet. Giltiga värden är 0 till 255. |
+| grön | int | Det gröna komponentvärdet för det nya Color‑objektet. Giltiga värden är 0 till 255. |
+| blå | int | Det blå komponentvärdet för det nya Color‑objektet. Giltiga värden är 0 till 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### fromArgb(int alpha, int red, int green, int blue) {#fromArgb-int-int-int-int-}
+```
+public static Color fromArgb(int alpha, int red, int green, int blue)
+```
+
+
+Skapar ett Color‑objekt från de fyra ARGB‑komponenterna (alpha, röd, grön och blå) värden. Även om den här metoden tillåter ett 32‑bitars värde att skickas för varje komponent, är värdet för varje komponent begränsat till 8 bitar.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| alpha | int | Alfakomponenten. Giltiga värden är 0 till 255. |
+| röd | int | Den röda komponenten. Giltiga värden är 0 till 255. |
+| grön | int | Den gröna komponenten. Giltiga värden är 0 till 255. |
+| blå | int | Den blå komponenten. Giltiga värden är 0 till 255. |
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - The Color object that this method creates.
+### getA() {#getA--}
+```
+public byte getA()
+```
+
+
+Hämtar alfa-komponentens värde för detta Color-objekt.
+
+**Returns:**
+byte - Alfakomponentvärdet för detta Color‑objekt.
+### getAliceBlue() {#getAliceBlue--}
+```
+public static Color getAliceBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAntiqueWhite() {#getAntiqueWhite--}
+```
+public static Color getAntiqueWhite()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAqua() {#getAqua--}
+```
+public static Color getAqua()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAquamarine() {#getAquamarine--}
+```
+public static Color getAquamarine()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getAzure() {#getAzure--}
+```
+public static Color getAzure()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getB() {#getB--}
+```
+public byte getB()
+```
+
+
+Hämtar blå-komponentens värde för detta Color-objekt.
+
+**Returns:**
+byte - Blåkomponentvärdet för detta Color‑objekt.
+### getBeige() {#getBeige--}
+```
+public static Color getBeige()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBisque() {#getBisque--}
+```
+public static Color getBisque()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlack() {#getBlack--}
+```
+public static Color getBlack()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlanchedAlmond() {#getBlanchedAlmond--}
+```
+public static Color getBlanchedAlmond()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlue() {#getBlue--}
+```
+public static Color getBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBlueViolet() {#getBlueViolet--}
+```
+public static Color getBlueViolet()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBrown() {#getBrown--}
+```
+public static Color getBrown()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getBurlyWood() {#getBurlyWood--}
+```
+public static Color getBurlyWood()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCadetBlue() {#getCadetBlue--}
+```
+public static Color getCadetBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChartreuse() {#getChartreuse--}
+```
+public static Color getChartreuse()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getChocolate() {#getChocolate--}
+```
+public static Color getChocolate()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoral() {#getCoral--}
+```
+public static Color getCoral()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornflowerBlue() {#getCornflowerBlue--}
+```
+public static Color getCornflowerBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCornsilk() {#getCornsilk--}
+```
+public static Color getCornsilk()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCrimson() {#getCrimson--}
+```
+public static Color getCrimson()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getCyan() {#getCyan--}
+```
+public static Color getCyan()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkBlue() {#getDarkBlue--}
+```
+public static Color getDarkBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkCyan() {#getDarkCyan--}
+```
+public static Color getDarkCyan()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGoldenrod() {#getDarkGoldenrod--}
+```
+public static Color getDarkGoldenrod()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGray() {#getDarkGray--}
+```
+public static Color getDarkGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkGreen() {#getDarkGreen--}
+```
+public static Color getDarkGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkKhaki() {#getDarkKhaki--}
+```
+public static Color getDarkKhaki()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkMagenta() {#getDarkMagenta--}
+```
+public static Color getDarkMagenta()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOliveGreen() {#getDarkOliveGreen--}
+```
+public static Color getDarkOliveGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrange() {#getDarkOrange--}
+```
+public static Color getDarkOrange()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkOrchid() {#getDarkOrchid--}
+```
+public static Color getDarkOrchid()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkRed() {#getDarkRed--}
+```
+public static Color getDarkRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSalmon() {#getDarkSalmon--}
+```
+public static Color getDarkSalmon()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSeaGreen() {#getDarkSeaGreen--}
+```
+public static Color getDarkSeaGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateBlue() {#getDarkSlateBlue--}
+```
+public static Color getDarkSlateBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkSlateGray() {#getDarkSlateGray--}
+```
+public static Color getDarkSlateGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkTurquoise() {#getDarkTurquoise--}
+```
+public static Color getDarkTurquoise()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDarkViolet() {#getDarkViolet--}
+```
+public static Color getDarkViolet()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepPink() {#getDeepPink--}
+```
+public static Color getDeepPink()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDeepSkyBlue() {#getDeepSkyBlue--}
+```
+public static Color getDeepSkyBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDimGray() {#getDimGray--}
+```
+public static Color getDimGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getDodgerBlue() {#getDodgerBlue--}
+```
+public static Color getDodgerBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getEmpty() {#getEmpty--}
+```
+public static Color getEmpty()
+```
+
+
+Hämta en systemdefinierad tom färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFirebrick() {#getFirebrick--}
+```
+public static Color getFirebrick()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFloralWhite() {#getFloralWhite--}
+```
+public static Color getFloralWhite()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getForestGreen() {#getForestGreen--}
+```
+public static Color getForestGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getFuchsia() {#getFuchsia--}
+```
+public static Color getFuchsia()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getG() {#getG--}
+```
+public byte getG()
+```
+
+
+Hämtar grön-komponentens värde för detta Color-objekt.
+
+**Returns:**
+byte - Grönkomponentvärdet för detta Color‑objekt.
+### getGainsboro() {#getGainsboro--}
+```
+public static Color getGainsboro()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGhostWhite() {#getGhostWhite--}
+```
+public static Color getGhostWhite()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGold() {#getGold--}
+```
+public static Color getGold()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGoldenrod() {#getGoldenrod--}
+```
+public static Color getGoldenrod()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGray() {#getGray--}
+```
+public static Color getGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreen() {#getGreen--}
+```
+public static Color getGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getGreenYellow() {#getGreenYellow--}
+```
+public static Color getGreenYellow()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHoneydew() {#getHoneydew--}
+```
+public static Color getHoneydew()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getHotPink() {#getHotPink--}
+```
+public static Color getHotPink()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndianRed() {#getIndianRed--}
+```
+public static Color getIndianRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIndigo() {#getIndigo--}
+```
+public static Color getIndigo()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getIvory() {#getIvory--}
+```
+public static Color getIvory()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getKhaki() {#getKhaki--}
+```
+public static Color getKhaki()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavender() {#getLavender--}
+```
+public static Color getLavender()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLavenderBlush() {#getLavenderBlush--}
+```
+public static Color getLavenderBlush()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLawnGreen() {#getLawnGreen--}
+```
+public static Color getLawnGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLemonChiffon() {#getLemonChiffon--}
+```
+public static Color getLemonChiffon()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightBlue() {#getLightBlue--}
+```
+public static Color getLightBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCoral() {#getLightCoral--}
+```
+public static Color getLightCoral()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightCyan() {#getLightCyan--}
+```
+public static Color getLightCyan()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGoldenrodYellow() {#getLightGoldenrodYellow--}
+```
+public static Color getLightGoldenrodYellow()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGray() {#getLightGray--}
+```
+public static Color getLightGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightGreen() {#getLightGreen--}
+```
+public static Color getLightGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightPink() {#getLightPink--}
+```
+public static Color getLightPink()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSalmon() {#getLightSalmon--}
+```
+public static Color getLightSalmon()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSeaGreen() {#getLightSeaGreen--}
+```
+public static Color getLightSeaGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSkyBlue() {#getLightSkyBlue--}
+```
+public static Color getLightSkyBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSlateGray() {#getLightSlateGray--}
+```
+public static Color getLightSlateGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightSteelBlue() {#getLightSteelBlue--}
+```
+public static Color getLightSteelBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLightYellow() {#getLightYellow--}
+```
+public static Color getLightYellow()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLime() {#getLime--}
+```
+public static Color getLime()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLimeGreen() {#getLimeGreen--}
+```
+public static Color getLimeGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getLinen() {#getLinen--}
+```
+public static Color getLinen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMagenta() {#getMagenta--}
+```
+public static Color getMagenta()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMaroon() {#getMaroon--}
+```
+public static Color getMaroon()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumAquamarine() {#getMediumAquamarine--}
+```
+public static Color getMediumAquamarine()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumBlue() {#getMediumBlue--}
+```
+public static Color getMediumBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumOrchid() {#getMediumOrchid--}
+```
+public static Color getMediumOrchid()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumPurple() {#getMediumPurple--}
+```
+public static Color getMediumPurple()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSeaGreen() {#getMediumSeaGreen--}
+```
+public static Color getMediumSeaGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSlateBlue() {#getMediumSlateBlue--}
+```
+public static Color getMediumSlateBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumSpringGreen() {#getMediumSpringGreen--}
+```
+public static Color getMediumSpringGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumTurquoise() {#getMediumTurquoise--}
+```
+public static Color getMediumTurquoise()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMediumVioletRed() {#getMediumVioletRed--}
+```
+public static Color getMediumVioletRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMidnightBlue() {#getMidnightBlue--}
+```
+public static Color getMidnightBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMintCream() {#getMintCream--}
+```
+public static Color getMintCream()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMistyRose() {#getMistyRose--}
+```
+public static Color getMistyRose()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getMoccasin() {#getMoccasin--}
+```
+public static Color getMoccasin()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavajoWhite() {#getNavajoWhite--}
+```
+public static Color getNavajoWhite()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getNavy() {#getNavy--}
+```
+public static Color getNavy()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOldLace() {#getOldLace--}
+```
+public static Color getOldLace()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOlive() {#getOlive--}
+```
+public static Color getOlive()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOliveDrab() {#getOliveDrab--}
+```
+public static Color getOliveDrab()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrange() {#getOrange--}
+```
+public static Color getOrange()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrangeRed() {#getOrangeRed--}
+```
+public static Color getOrangeRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getOrchid() {#getOrchid--}
+```
+public static Color getOrchid()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGoldenrod() {#getPaleGoldenrod--}
+```
+public static Color getPaleGoldenrod()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleGreen() {#getPaleGreen--}
+```
+public static Color getPaleGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleTurquoise() {#getPaleTurquoise--}
+```
+public static Color getPaleTurquoise()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPaleVioletRed() {#getPaleVioletRed--}
+```
+public static Color getPaleVioletRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPapayaWhip() {#getPapayaWhip--}
+```
+public static Color getPapayaWhip()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeachPuff() {#getPeachPuff--}
+```
+public static Color getPeachPuff()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPeru() {#getPeru--}
+```
+public static Color getPeru()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPink() {#getPink--}
+```
+public static Color getPink()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPlum() {#getPlum--}
+```
+public static Color getPlum()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPowderBlue() {#getPowderBlue--}
+```
+public static Color getPowderBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getPurple() {#getPurple--}
+```
+public static Color getPurple()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getR() {#getR--}
+```
+public byte getR()
+```
+
+
+Hämtar röd-komponentens värde för detta Color-objekt.
+
+**Returns:**
+byte - Rödkomponentvärdet för detta Color‑objekt.
+### getRed() {#getRed--}
+```
+public static Color getRed()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRosyBrown() {#getRosyBrown--}
+```
+public static Color getRosyBrown()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getRoyalBlue() {#getRoyalBlue--}
+```
+public static Color getRoyalBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSaddleBrown() {#getSaddleBrown--}
+```
+public static Color getSaddleBrown()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSalmon() {#getSalmon--}
+```
+public static Color getSalmon()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSandyBrown() {#getSandyBrown--}
+```
+public static Color getSandyBrown()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaGreen() {#getSeaGreen--}
+```
+public static Color getSeaGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSeaShell() {#getSeaShell--}
+```
+public static Color getSeaShell()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSienna() {#getSienna--}
+```
+public static Color getSienna()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSilver() {#getSilver--}
+```
+public static Color getSilver()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSkyBlue() {#getSkyBlue--}
+```
+public static Color getSkyBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateBlue() {#getSlateBlue--}
+```
+public static Color getSlateBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSlateGray() {#getSlateGray--}
+```
+public static Color getSlateGray()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSnow() {#getSnow--}
+```
+public static Color getSnow()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSpringGreen() {#getSpringGreen--}
+```
+public static Color getSpringGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getSteelBlue() {#getSteelBlue--}
+```
+public static Color getSteelBlue()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTan() {#getTan--}
+```
+public static Color getTan()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTeal() {#getTeal--}
+```
+public static Color getTeal()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getThistle() {#getThistle--}
+```
+public static Color getThistle()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTomato() {#getTomato--}
+```
+public static Color getTomato()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTransparent() {#getTransparent--}
+```
+public static Color getTransparent()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getTurquoise() {#getTurquoise--}
+```
+public static Color getTurquoise()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getViolet() {#getViolet--}
+```
+public static Color getViolet()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWheat() {#getWheat--}
+```
+public static Color getWheat()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhite() {#getWhite--}
+```
+public static Color getWhite()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getWhiteSmoke() {#getWhiteSmoke--}
+```
+public static Color getWhiteSmoke()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellow() {#getYellow--}
+```
+public static Color getYellow()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### getYellowGreen() {#getYellowGreen--}
+```
+public static Color getYellowGreen()
+```
+
+
+Hämta en systemdefinierad färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color) - A Color object representing a system-defined color.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Returnerar en hashkod för detta Color-objekt.
+
+**Returns:**
+int - Ett heltalsvärde som specificerar hash‑koden för detta Color‑objekt.
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+Anger om detta Color-objekt är oinitierat.
+
+**Returns:**
+boolean - Denna egenskap returnerar true om denna färg är oinitierad; annars false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toArgb() {#toArgb--}
+```
+public int toArgb()
+```
+
+
+Hämtar det 32-bitars ARGB-värdet för detta Color-objekt.
+
+**Returns:**
+int - 32‑bitars ARGB‑värdet för detta Color‑objekt.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/colorentry/_index.md
+++ b/swedish/java/com.aspose.diagram/colorentry/_index.md
@@ -1,0 +1,188 @@
+---
+title: ColorEntry
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller ett färgtabellpost.
+type: docs
+weight: 52
+url: /sv/java/com.aspose.diagram/colorentry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorEntry
+```
+
+Innehåller en färgtabellpost. Varje färgtabellpost specificerar en standardfärg som är tillgänglig för tillämpning på objekt såsom former, text och lager i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ColorEntry()](#ColorEntry--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Representerar en ARGB-färg. |
+| [getIX()](#getIX--) | Obligatorisk int. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(Color value)](#setColor-com.aspose.diagram.Color-) | För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/colorentry\#getColor--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/colorentry\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorEntry() {#ColorEntry--}
+```
+public ColorEntry()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public Color getColor()
+```
+
+
+Representerar en ARGB-färg.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Obligatorisk int. Det nollbaserade indexet för elementet inom dess förälderelement.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(Color value) {#setColor-com.aspose.diagram.Color-}
+```
+public void setColor(Color value)
+```
+
+
+För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/colorentry\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/colorentry\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/colorentrycollection/_index.md
+++ b/swedish/java/com.aspose.diagram/colorentrycollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ColorEntryCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller dokumentets färgtabell.
+type: docs
+weight: 53
+url: /sv/java/com.aspose.diagram/colorentrycollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ColorEntryCollection extends Collection
+```
+
+Innehåller dokumentets färgtabell. Varje dokument innehåller en enda färgtabell, som listar de 24 standardfärgerna som är tillgängliga för tillämpning på objekt såsom former, text och lager i dokumentet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(ColorEntry color)](#add-com.aspose.diagram.ColorEntry-) | Lägg till Color‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ColorEntry color)](#remove-com.aspose.diagram.ColorEntry-) | Ta bort Color‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ColorEntry color) {#add-com.aspose.diagram.ColorEntry-}
+```
+public int add(ColorEntry color)
+```
+
+
+Lägg till Color‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ColorEntry get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[ColorEntry](../../com.aspose.diagram/colorentry) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ColorEntry color) {#remove-com.aspose.diagram.ColorEntry-}
+```
+public void remove(ColorEntry color)
+```
+
+
+Ta bort Color‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| color | [ColorEntry](../../com.aspose.diagram/colorentry) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/colorvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/colorvalue/_index.md
@@ -1,0 +1,205 @@
+---
+title: ColorValue
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar färgvärde
+type: docs
+weight: 54
+url: /sv/java/com.aspose.diagram/colorvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ColorValue
+```
+
+Representerar färgvärde
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ColorValue(String value, int unit)](#ColorValue-java.lang.String-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Färgvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/colorvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ColorValue(String value, int unit) {#ColorValue-java.lang.String-int-}
+```
+public ColorValue(String value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+| enhet | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Färgvärde. För att ange färgen, ange ett tal från 0 till 23 eller RGB‑värdet i hexadecimal notation.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/colorvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/colorvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/comboboxactivexcontrol/_index.md
@@ -1,0 +1,972 @@
+---
+title: ComboBoxActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en ComboBox ActiveX-kontroll.
+type: docs
+weight: 55
+url: /sv/java/com.aspose.diagram/comboboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ComboBoxActiveXControl extends ActiveXControl
+```
+
+Representerar en ComboBox ActiveX-kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderOleColor()](#getBorderOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderStyle()](#getBorderStyle--) | typen av ram som används av kontrollen. |
+| [getBoundColumn()](#getBoundColumn--) | Representerar hur Value‑egenskapen bestäms för en ComboBox eller ListBox när MultiSelect‑egenskapens värde (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Representerar antalet kolumner som ska visas i en ComboBox eller ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | bredden på kolumnen. |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Anger symbolen som visas på nedrullningsknappen |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Anger urvalsbeteende när kontrollen aktiveras. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getHideSelection()](#getHideSelection--) | Indikerar om markerad text i kontrollen visas markerad när kontrollen inte har fokus. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getListRows()](#getListRows--) | Representerar det maximala antalet rader som ska visas i listan. |
+| [getListStyle()](#getListStyle--) | det visuella utseendet. |
+| [getListWidth()](#getListWidth--) | bredden i enheten punkter. |
+| [getMatchEntry()](#getMatchEntry--) | Indikerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver. |
+| [getMaxLength()](#getMaxLength--) | det maximala antalet tecken |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getSelectionMargin()](#getSelectionMargin--) | Indikerar om användaren kan markera en textrad genom att klicka i området till vänster om texten. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indikerar om kolumnrubriker visas. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Anger symbolen som visas på nedrullningsknappen |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getTextColumn()](#getTextColumn--) | Representerar kolumnen i en ComboBox eller ListBox som ska visas för användaren. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getValue()](#getValue--) | värdet för kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Anger den grundläggande enheten som används för att utöka en markering. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indikerar om dra‑och‑släpp är aktiverat för kontrollen. |
+| [isEditable()](#isEditable--) | Indikerar om användaren kan skriva i kontrollen. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | För beskrivningen av denna egenskap, se [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | För beskrivningen av denna egenskap, se [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | För beskrivningen av den här egenskapen, se [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | För beskrivningen av den här egenskapen, se [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | För beskrivningen av den här egenskapen, se [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | För beskrivningen av den här egenskapen, se [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | För beskrivningen av den här egenskapen, se [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | För beskrivningen av den här egenskapen, se [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | För beskrivningen av den här egenskapen, se [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setListRows(int value)](#setListRows-int-) | För beskrivningen av den här egenskapen, se [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--) |
+| [setListStyle(int value)](#setListStyle-int-) | För beskrivningen av den här egenskapen, se [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | För beskrivningen av den här egenskapen, se [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | För beskrivningen av den här egenskapen, se [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | För beskrivningen av den här egenskapen, se [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setSelectionMargin(boolean value)](#setSelectionMargin-boolean-) | För beskrivningen av den här egenskapen, se [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | För beskrivningen av den här egenskapen, se [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | För beskrivningen av den här egenskapen, se [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | För beskrivningen av den här egenskapen, se [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+typen av ram som används av kontrollen.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Representerar hur Value‑egenskapen bestäms för en ComboBox eller ListBox när MultiSelect‑egenskapens värde (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Representerar antalet kolumner som ska visas i en ComboBox eller ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+bredden på kolumnen.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Anger symbolen som visas på nedrullningsknappen
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Anger markeringsbeteende när kontrollen aktiveras. True anger att markeringen förblir oförändrad sedan senaste gången kontrollen var aktiv. False anger att all text i kontrollen kommer att markeras när kontrollen aktiveras.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indikerar om markerad text i kontrollen visas markerad när kontrollen inte har fokus.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getListRows() {#getListRows--}
+```
+public int getListRows()
+```
+
+
+Representerar det maximala antalet rader som ska visas i listan.
+
+**Returns:**
+int
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+det visuella utseendet.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+bredden i enheten punkter.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indikerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver.
+
+**Returns:**
+int
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+det maximala antalet tecken
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getSelectionMargin() {#getSelectionMargin--}
+```
+public boolean getSelectionMargin()
+```
+
+
+Indikerar om användaren kan markera en textrad genom att klicka i området till vänster om texten.
+
+**Returns:**
+boolean
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indikerar om kolumnrubriker visas.
+
+**Returns:**
+boolean
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Anger symbolen som visas på nedrullningsknappen
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Representerar kolumnen i en ComboBox eller ListBox som ska visas för användaren.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+värdet för kontrollen.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Anger den grundläggande enheten som används för att utöka en markering. True anger att den grundläggande enheten är ett enskilt tecken. false anger att den grundläggande enheten är ett helt ord.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indikerar om dra‑och‑släpp är aktiverat för kontrollen.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indikerar om användaren kan skriva i kontrollen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoWordSelected()](../../com.aspose.diagram/comboboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBorderOleColor()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBoundColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getColumnCount()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getColumnWidths()](../../com.aspose.diagram/comboboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isDragBehaviorEnabled()](../../com.aspose.diagram/comboboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDropButtonStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEditable()](../../com.aspose.diagram/comboboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnterFieldBehavior()](../../com.aspose.diagram/comboboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHideSelection()](../../com.aspose.diagram/comboboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setListRows(int value) {#setListRows-int-}
+```
+public void setListRows(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getListRows()](../../com.aspose.diagram/comboboxactivexcontrol\#getListRows--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getListStyle()](../../com.aspose.diagram/comboboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getListWidth()](../../com.aspose.diagram/comboboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMatchEntry()](../../com.aspose.diagram/comboboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMaxLength()](../../com.aspose.diagram/comboboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSelectionMargin(boolean value) {#setSelectionMargin-boolean-}
+```
+public void setSelectionMargin(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSelectionMargin()](../../com.aspose.diagram/comboboxactivexcontrol\#getSelectionMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowColumnHeads()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowDropButtonTypeWhen()](../../com.aspose.diagram/comboboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/comboboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTextColumn()](../../com.aspose.diagram/comboboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/comboboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/commandbuttonactivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: CommandButtonActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en kommandoknapp.
+type: docs
+weight: 56
+url: /sv/java/com.aspose.diagram/commandbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class CommandButtonActiveXControl extends ActiveXControl
+```
+
+Representerar en kommandoknapp.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Acceleratortangenten för kontrollen. |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getCaption()](#getCaption--) | Den beskrivande texten som visas på en kontroll. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPicturePosition()](#getPicturePosition--) | platsen för kontrollens bild relativt dess rubrik. |
+| [getTakeFocusOnClick()](#getTakeFocusOnClick--) | Indikerar om kontrollen får fokus när den klickas. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isWordWrapped()](#isWordWrapped--) | Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--) |
+| [setTakeFocusOnClick(boolean value)](#setTakeFocusOnClick-boolean-) | För beskrivningen av denna egenskap, se [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Acceleratortangenten för kontrollen.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Den beskrivande texten som visas på en kontroll.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+platsen för kontrollens bild relativt dess rubrik.
+
+**Returns:**
+int
+### getTakeFocusOnClick() {#getTakeFocusOnClick--}
+```
+public boolean getTakeFocusOnClick()
+```
+
+
+Indikerar om kontrollen får fokus när den klickas.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTakeFocusOnClick(boolean value) {#setTakeFocusOnClick-boolean-}
+```
+public void setTakeFocusOnClick(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTakeFocusOnClick()](../../com.aspose.diagram/commandbuttonactivexcontrol\#getTakeFocusOnClick--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/commandbuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/compositingquality/_index.md
+++ b/swedish/java/com.aspose.diagram/compositingquality/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompositingQuality
+second_title: Aspose.Diagram för Java API-referens
+description: Anger kvalitetsnivån som ska användas vid sammansättning.
+type: docs
+weight: 57
+url: /sv/java/com.aspose.diagram/compositingquality/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompositingQuality
+```
+
+Anger kvalitetsnivån som ska användas vid sammansättning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ASSUME_LINEAR](#ASSUME-LINEAR) | Anta linjära värden. |
+| [DEFAULT](#DEFAULT) | Standardkvalitet. |
+| [GAMMA_CORRECTED](#GAMMA-CORRECTED) | Gamma-korrigering används. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Hög kvalitet, låg hastighet vid sammansättning. |
+| [HIGH_SPEED](#HIGH-SPEED) | Hög hastighet, låg kvalitet. |
+| [INVALID](#INVALID) | Ogiltig kvalitet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ASSUME_LINEAR {#ASSUME-LINEAR}
+```
+public static final int ASSUME_LINEAR
+```
+
+
+Anta linjära värden.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standardkvalitet.
+
+### GAMMA_CORRECTED {#GAMMA-CORRECTED}
+```
+public static final int GAMMA_CORRECTED
+```
+
+
+Gamma-korrigering används.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Hög kvalitet, låg hastighet vid sammansättning.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Hög hastighet, låg kvalitet.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Ogiltig kvalitet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/compoundtype/_index.md
+++ b/swedish/java/com.aspose.diagram/compoundtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: CompoundType
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar storleken på linjens pilspets.
+type: docs
+weight: 58
+url: /sv/java/com.aspose.diagram/compoundtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CompoundType
+```
+
+Specificerar storleken på linjens pilspets.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CompoundType(int value)](#CompoundType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar storleken på linjens pilspets. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/compoundtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompoundType(int value) {#CompoundType-int-}
+```
+public CompoundType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar storleken på linjens pilspets.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/compoundtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/compoundtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/compoundtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompoundTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar stil för ritade linjer.
+type: docs
+weight: 59
+url: /sv/java/com.aspose.diagram/compoundtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompoundTypeValue
+```
+
+Representerar stil för ritade linjer.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [SINGLE](#SINGLE) | Enkel linje (med bredd lineWidth) |
+| [THICK_BETWEEN_THIN](#THICK-BETWEEN-THIN) | Tre linjer, tunn, tjock, tunn |
+| [THICK_THIN](#THICK-THIN) | Dubbla linjer, en tjock, en tunn |
+| [THIN_THICK](#THIN-THICK) | Dubbla linjer, en tunn, en tjock |
+| [THIN_THIN](#THIN-THIN) | Dubbla linjer med lika bredd |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Enkel linje (med bredd lineWidth)
+
+### THICK_BETWEEN_THIN {#THICK-BETWEEN-THIN}
+```
+public static final int THICK_BETWEEN_THIN
+```
+
+
+Tre linjer, tunn, tjock, tunn
+
+### THICK_THIN {#THICK-THIN}
+```
+public static final int THICK_THIN
+```
+
+
+Dubbla linjer, en tjock, en tunn
+
+### THIN_THICK {#THIN-THICK}
+```
+public static final int THIN_THICK
+```
+
+
+Dubbla linjer, en tunn, en tjock
+
+### THIN_THIN {#THIN-THIN}
+```
+public static final int THIN_THIN
+```
+
+
+Dubbla linjer med lika bredd
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/compressiontype/_index.md
+++ b/swedish/java/com.aspose.diagram/compressiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: CompressionType
+second_title: Aspose.Diagram för Java API-referens
+description: Detta attribut är endast meningsfullt om den externa datan är ett rasterbaserat främmande objekt såsom en DIB JPG PNG TIFF eller GIF-fil.
+type: docs
+weight: 60
+url: /sv/java/com.aspose.diagram/compressiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CompressionType
+```
+
+Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. Värdet anger typen av kompression som tillämpas på filen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [GIF](#GIF) | GIF-komprimering. |
+| [JPEG](#JPEG) | JPEG-komprimering. |
+| [NO](#NO) | Ingen komprimering (standard). |
+| [PNG](#PNG) | PNG-komprimering. |
+| [TIFF](#TIFF) | TIFF-komprimering. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+GIF-komprimering.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+JPEG-komprimering.
+
+### NO {#NO}
+```
+public static final int NO
+```
+
+
+Ingen komprimering (standard).
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+PNG-komprimering.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+TIFF-komprimering.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/confixedcode/_index.md
+++ b/swedish/java/com.aspose.diagram/confixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConFixedCode
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer när en anslutning omdirigeras.
+type: docs
+weight: 61
+url: /sv/java/com.aspose.diagram/confixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConFixedCode
+```
+
+Bestämmer när en anslutning omdirigeras.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConFixedCode(int value)](#ConFixedCode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer när en anslutning omdirigeras. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/confixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConFixedCode(int value) {#ConFixedCode-int-}
+```
+public ConFixedCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer när en anslutning omdirigeras.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/confixedcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/confixedcodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/confixedcodevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ConFixedCodeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer när en anslutning omdirigeras.
+type: docs
+weight: 62
+url: /sv/java/com.aspose.diagram/confixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConFixedCodeValue
+```
+
+Bestämmer när en anslutning omdirigeras.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NEVER_REROUTE](#NEVER-REROUTE) | Aldrig omdirigera. |
+| [REROUTE_FREELY](#REROUTE-FREELY) | Omdirigera fritt. |
+| [REROUTE_NEEDED](#REROUTE-NEEDED) | Omdirigera vid behov. |
+| [REROUTE_ON_CROSSOVER](#REROUTE-ON-CROSSOVER) | Omdirigera vid korsning. |
+| [RESERVED_1](#RESERVED-1) | Endast reserverad för internt bruk. |
+| [RESERVED_2](#RESERVED-2) | Endast reserverad för internt bruk. |
+| [RESERVED_3](#RESERVED-3) | Endast reserverad för internt bruk. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NEVER_REROUTE {#NEVER-REROUTE}
+```
+public static final int NEVER_REROUTE
+```
+
+
+Aldrig omdirigera.
+
+### REROUTE_FREELY {#REROUTE-FREELY}
+```
+public static final int REROUTE_FREELY
+```
+
+
+Omdirigera fritt.
+
+### REROUTE_NEEDED {#REROUTE-NEEDED}
+```
+public static final int REROUTE_NEEDED
+```
+
+
+Omdirigera vid behov.
+
+### REROUTE_ON_CROSSOVER {#REROUTE-ON-CROSSOVER}
+```
+public static final int REROUTE_ON_CROSSOVER
+```
+
+
+Omdirigera vid korsning.
+
+### RESERVED_1 {#RESERVED-1}
+```
+public static final int RESERVED_1
+```
+
+
+Endast reserverad för internt bruk.
+
+### RESERVED_2 {#RESERVED-2}
+```
+public static final int RESERVED_2
+```
+
+
+Endast reserverad för internt bruk.
+
+### RESERVED_3 {#RESERVED-3}
+```
+public static final int RESERVED_3
+```
+
+
+Endast reserverad för internt bruk.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpcode/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpCode
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om en anslutning hoppar när två anslutningar korsar varandra.
+type: docs
+weight: 63
+url: /sv/java/com.aspose.diagram/conlinejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpCode
+```
+
+Bestämmer om en anslutning hoppar när två anslutningar korsar varandra.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConLineJumpCode(int value)](#ConLineJumpCode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer om en anslutning hoppar när två anslutningar korsar varandra. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpCode(int value) {#ConLineJumpCode-int-}
+```
+public ConLineJumpCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer om en anslutning hoppar när två anslutningar korsar varandra.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/conlinejumpcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpcodevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ConLineJumpCodeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om en anslutning hoppar när två anslutningar korsar varandra.
+type: docs
+weight: 64
+url: /sv/java/com.aspose.diagram/conlinejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpCodeValue
+```
+
+Bestämmer om en anslutning hoppar när två anslutningar korsar varandra.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Alltid |
+| [NEITHER_CONNECTOR_JUMPS](#NEITHER-CONNECTOR-JUMPS) | Varken anslutningshopp. |
+| [NEVER](#NEVER) | Aldrig. |
+| [OTHER_CONNECTOR_JUMPS](#OTHER-CONNECTOR-JUMPS) | Andra anslutningshopp. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Alltid
+
+### NEITHER_CONNECTOR_JUMPS {#NEITHER-CONNECTOR-JUMPS}
+```
+public static final int NEITHER_CONNECTOR_JUMPS
+```
+
+
+Varken anslutningshopp.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Aldrig.
+
+### OTHER_CONNECTOR_JUMPS {#OTHER-CONNECTOR-JUMPS}
+```
+public static final int OTHER_CONNECTOR_JUMPS
+```
+
+
+Andra anslutningshopp.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpdirx/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirX
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+type: docs
+weight: 65
+url: /sv/java/com.aspose.diagram/conlinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirX
+```
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConLineJumpDirX(int value)](#ConLineJumpDirX-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirX(int value) {#ConLineJumpDirX-int-}
+```
+public ConLineJumpDirX(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirXValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+type: docs
+weight: 66
+url: /sv/java/com.aspose.diagram/conlinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirXValue
+```
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DOWN](#DOWN) | Ned. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [UP](#UP) | Upp. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Ned.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Upp.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpdiry/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpDirY
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+type: docs
+weight: 67
+url: /sv/java/com.aspose.diagram/conlinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpDirY
+```
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConLineJumpDirY(int value)](#ConLineJumpDirY-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpDirY(int value) {#ConLineJumpDirY-int-}
+```
+public ConLineJumpDirY(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineJumpDirYValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+type: docs
+weight: 68
+url: /sv/java/com.aspose.diagram/conlinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpDirYValue
+```
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [LEFT](#LEFT) | Vänster. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [RIGHT](#RIGHT) | Höger. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Vänster.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Höger.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpstyle/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineJumpStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+type: docs
+weight: 69
+url: /sv/java/com.aspose.diagram/conlinejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineJumpStyle
+```
+
+Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConLineJumpStyle(int value)](#ConLineJumpStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineJumpStyle(int value) {#ConLineJumpStyle-int-}
+```
+public ConLineJumpStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/conlinejumpstyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConLineJumpStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+type: docs
+weight: 70
+url: /sv/java/com.aspose.diagram/conlinejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineJumpStyleValue
+```
+
+Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ARC](#ARC) | Båge. |
+| [GAP](#GAP) | Mellanrum. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [SIDES_2](#SIDES-2) | Sides2. |
+| [SIDES_3](#SIDES-3) | Sides3. |
+| [SIDES_4](#SIDES-4) | Sides4. |
+| [SIDES_5](#SIDES-5) | Sides5. |
+| [SIDES_6](#SIDES-6) | Sides6. |
+| [SIDES_7](#SIDES-7) | Sides7 |
+| [SQUARE](#SQUARE) | Fyrkant. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Båge.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Mellanrum.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+Sides2.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+Sides3.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+Sides4.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+Sides5.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+Sides6.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+Sides7
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Fyrkant.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinerouteext/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: ConLineRouteExt
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer utseendet på en anslutning.
+type: docs
+weight: 71
+url: /sv/java/com.aspose.diagram/conlinerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConLineRouteExt
+```
+
+Bestämmer utseendet på en anslutning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConLineRouteExt(int value)](#ConLineRouteExt-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer utseendet på en anslutning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConLineRouteExt(int value) {#ConLineRouteExt-int-}
+```
+public ConLineRouteExt(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer utseendet på en anslutning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/conlinerouteext\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/conlinerouteextvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/conlinerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConLineRouteExtValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer utseendet på en anslutning.
+type: docs
+weight: 72
+url: /sv/java/com.aspose.diagram/conlinerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConLineRouteExtValue
+```
+
+Bestämmer utseendet på en anslutning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CURVED](#CURVED) | Kurvig. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [STRAIGHT](#STRAIGHT) | Rak. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Kurvig.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Rak.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connect/_index.md
+++ b/swedish/java/com.aspose.diagram/connect/_index.md
@@ -1,0 +1,299 @@
+---
+title: Connect
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en anslutning mellan två former i en ritning, såsom en linje och en ruta i ett organisationsdiagram.
+type: docs
+weight: 75
+url: /sv/java/com.aspose.diagram/connect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connect
+```
+
+Representerar en anslutning mellan två former i en ritning, såsom en linje och en ruta i ett organisationsdiagram.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Connect()](#Connect--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFromCell()](#getFromCell--) | Cellen från vilken en anslutning görs. |
+| [getFromPart()](#getFromPart--) | Cellen från vilken en anslutning har sitt ursprung. |
+| [getFromSheet()](#getFromSheet--) | ID för formen från vilken en anslutning eller flera anslutningar har sitt ursprung. |
+| [getToCell()](#getToCell--) | Cellen till vilken en anslutning görs. |
+| [getToPart()](#getToPart--) | Den del av en figur som en anslutning görs till. |
+| [getToSheet()](#getToSheet--) | ID för formen till vilken en eller flera anslutningar görs |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFromCell(String value)](#setFromCell-java.lang.String-) | För beskrivningen av den här egenskapen, se [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--) |
+| [setFromPart(int value)](#setFromPart-int-) | För beskrivningen av den här egenskapen, se [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--) |
+| [setFromSheet(long value)](#setFromSheet-long-) | För beskrivningen av den här egenskapen, se [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--) |
+| [setToCell(String value)](#setToCell-java.lang.String-) | För beskrivningen av den här egenskapen, se [getToCell()](../../com.aspose.diagram/connect\#getToCell--) |
+| [setToPart(int value)](#setToPart-int-) | För beskrivningen av den här egenskapen, se [getToPart()](../../com.aspose.diagram/connect\#getToPart--) |
+| [setToSheet(long value)](#setToSheet-long-) | För beskrivningen av den här egenskapen, se [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connect() {#Connect--}
+```
+public Connect()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFromCell() {#getFromCell--}
+```
+public String getFromCell()
+```
+
+
+Cellen från vilken en anslutning görs.
+
+**Returns:**
+java.lang.String
+### getFromPart() {#getFromPart--}
+```
+public int getFromPart()
+```
+
+
+Cellen från vilken en anslutning har sitt ursprung.
+
+**Returns:**
+int
+### getFromSheet() {#getFromSheet--}
+```
+public long getFromSheet()
+```
+
+
+ID för formen från vilken en anslutning eller flera anslutningar har sitt ursprung.
+
+**Returns:**
+long
+### getToCell() {#getToCell--}
+```
+public String getToCell()
+```
+
+
+Cellen till vilken en anslutning görs.
+
+**Returns:**
+java.lang.String
+### getToPart() {#getToPart--}
+```
+public int getToPart()
+```
+
+
+Den del av en figur som en anslutning görs till.
+
+**Returns:**
+int
+### getToSheet() {#getToSheet--}
+```
+public long getToSheet()
+```
+
+
+ID för formen till vilken en eller flera anslutningar görs
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFromCell(String value) {#setFromCell-java.lang.String-}
+```
+public void setFromCell(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFromCell()](../../com.aspose.diagram/connect\#getFromCell--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFromPart(int value) {#setFromPart-int-}
+```
+public void setFromPart(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFromPart()](../../com.aspose.diagram/connect\#getFromPart--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setFromSheet(long value) {#setFromSheet-long-}
+```
+public void setFromSheet(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFromSheet()](../../com.aspose.diagram/connect\#getFromSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setToCell(String value) {#setToCell-java.lang.String-}
+```
+public void setToCell(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getToCell()](../../com.aspose.diagram/connect\#getToCell--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setToPart(int value) {#setToPart-int-}
+```
+public void setToPart(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getToPart()](../../com.aspose.diagram/connect\#getToPart--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setToSheet(long value) {#setToSheet-long-}
+```
+public void setToSheet(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getToSheet()](../../com.aspose.diagram/connect\#getToSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/connectcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Anslut samling.
+type: docs
+weight: 76
+url: /sv/java/com.aspose.diagram/connectcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectCollection extends Collection
+```
+
+Anslut samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Connect connect)](#add-com.aspose.diagram.Connect-) | Lägg till anslutningen i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connect connect)](#remove-com.aspose.diagram.Connect-) | Ta bort anslutningen från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connect connect) {#add-com.aspose.diagram.Connect-}
+```
+public int add(Connect connect)
+```
+
+
+Lägg till anslutningen i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connect get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Connect](../../com.aspose.diagram/connect) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connect connect) {#remove-com.aspose.diagram.Connect-}
+```
+public void remove(Connect connect)
+```
+
+
+Ta bort anslutningen från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| connect | [Connect](../../com.aspose.diagram/connect) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectedshapesflags/_index.md
+++ b/swedish/java/com.aspose.diagram/connectedshapesflags/_index.md
@@ -1,0 +1,156 @@
+---
+title: ConnectedShapesFlags
+second_title: Aspose.Diagram för Java API-referens
+description: Filtrerar arrayen med returnerade form-ID:n efter anslutningarnas riktning.
+type: docs
+weight: 77
+url: /sv/java/com.aspose.diagram/connectedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectedShapesFlags
+```
+
+Filtrerar arrayen med returnerade form-ID:n efter anslutningarnas riktning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CONNECTED_SHAPES_ALL_NODES](#CONNECTED-SHAPES-ALL-NODES) | Returnerar ID:n för former som är associerade med både inkommande och utgående anslutningar. |
+| [CONNECTED_SHAPES_INCOMING_NODES](#CONNECTED-SHAPES-INCOMING-NODES) | Returnerar ID:n för former som är associerade med inkommande anslutningar. |
+| [CONNECTED_SHAPES_OUTGOING_NODES](#CONNECTED-SHAPES-OUTGOING-NODES) | Returnerar ID:n för former som är associerade med utgående anslutningar. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTED_SHAPES_ALL_NODES {#CONNECTED-SHAPES-ALL-NODES}
+```
+public static final int CONNECTED_SHAPES_ALL_NODES
+```
+
+
+Returnerar ID:n för former som är associerade med både inkommande och utgående anslutningar.
+
+### CONNECTED_SHAPES_INCOMING_NODES {#CONNECTED-SHAPES-INCOMING-NODES}
+```
+public static final int CONNECTED_SHAPES_INCOMING_NODES
+```
+
+
+Returnerar ID:n för former som är associerade med inkommande anslutningar.
+
+### CONNECTED_SHAPES_OUTGOING_NODES {#CONNECTED-SHAPES-OUTGOING-NODES}
+```
+public static final int CONNECTED_SHAPES_OUTGOING_NODES
+```
+
+
+Returnerar ID:n för former som är associerade med utgående anslutningar.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connection/_index.md
+++ b/swedish/java/com.aspose.diagram/connection/_index.md
@@ -1,0 +1,351 @@
+---
+title: Anslutning
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element för en anslutningspunkt som definierats för formen.
+type: docs
+weight: 78
+url: /sv/java/com.aspose.diagram/connection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Connection
+```
+
+Innehåller element för en anslutningspunkt som definierats för formen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Connection()](#Connection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoGen()](#getAutoGen--) | Anger om anslutningspunkten genereras automatiskt. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDirX()](#getDirX--) | Anger x-komponenten för den erforderliga justeringsvektorn för en matchande anslutningspunkt. |
+| [getDirY()](#getDirY--) | Anger y-komponenten för den erforderliga justeringsvektorn för en matchande anslutningspunkt. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPrompt()](#getPrompt--) | Innehåller varierande promptinformation, baserat på elementet där den finns. |
+| [getType()](#getType--) | Anger olika typer, baserat på elementet som den finns i. |
+| [getX()](#getX--) | Anger en x‑koordinat på en form i lokala koordinater. |
+| [getY()](#getY--) | Anger en y‑koordinat på en form i lokala koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/connection\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/connection\#getID--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/connection\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/connection\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/connection\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Connection() {#Connection--}
+```
+public Connection()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoGen() {#getAutoGen--}
+```
+public BoolValue getAutoGen()
+```
+
+
+Anger om anslutningspunkten genereras automatiskt. Ett värde på 1 indikerar att anslutningspunkten genereras automatiskt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDirX() {#getDirX--}
+```
+public DoubleValue getDirX()
+```
+
+
+Anger x-komponenten för den erforderliga justeringsvektorn för en matchande anslutningspunkt. DirX-elementet används också för att orientera den fästa benet på en dynamisk anslutning.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDirY() {#getDirY--}
+```
+public DoubleValue getDirY()
+```
+
+
+Anger y-komponenten för den erforderliga justeringsvektorn för en matchande anslutningspunkt. DirY-elementet används också för att orientera den fästa benet på en dynamisk anslutning.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Innehåller varierande promptinformation, baserat på elementet där den finns.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeConnection getType()
+```
+
+
+Anger olika typer, baserat på elementet som den finns i.
+
+**Returns:**
+[TypeConnection](../../com.aspose.diagram/typeconnection)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Anger en x‑koordinat på en form i lokala koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Anger en y-koordinat på en form i lokala koordinater. Lokala koordinater är de vars referensram är formen, istället för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/connection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/connection\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/connection\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/connection\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/connection\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectionabcd/_index.md
+++ b/swedish/java/com.aspose.diagram/connectionabcd/_index.md
@@ -1,0 +1,340 @@
+---
+title: ConnectionABCD
+second_title: Aspose.Diagram för Java API-referens
+description: Elementet ConnectionABCD är en föråldrad version av Connection-elementet och finns endast för bakåtkompatibilitet.
+type: docs
+weight: 79
+url: /sv/java/com.aspose.diagram/connectionabcd/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectionABCD
+```
+
+Elementet ConnectionABCD är en föråldrad version av Connection-elementet och finns endast för bakåtkompatibilitet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConnectionABCD()](#ConnectionABCD--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Representerar olika information beroende på dess överordnade element. |
+| [getB()](#getB--) | Representerar olika information beroende på dess överordnade element. |
+| [getC()](#getC--) | Representerar olika information baserat på dess överordnade element. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Representerar olika information baserat på dess överordnade element. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getX()](#getX--) | Anger en x‑koordinat på en form i lokala koordinater. |
+| [getY()](#getY--) | Anger en y‑koordinat på en form i lokala koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/connectionabcd\#getID--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/connectionabcd\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConnectionABCD() {#ConnectionABCD--}
+```
+public ConnectionABCD()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Representerar olika information beroende på dess överordnade element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Representerar olika information beroende på dess överordnade element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Representerar olika information baserat på dess överordnade element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Representerar olika information baserat på dess överordnade element.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Anger en x-koordinat på en form i lokala koordinater. Följande tabell beskriver X‑elementet baserat på det element som innehåller det.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Anger en y-koordinat på en form i lokala koordinater. Lokala koordinater är de vars referensram är formen, istället för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/connectionabcd\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/connectionabcd\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/connectionabcd\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/connectionabcd\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/connectionabcd\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectionabcdcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/connectionabcdcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionABCDCollection
+second_title: Aspose.Diagram för Java API-referens
+description: ConnectionABCD-samling.
+type: docs
+weight: 80
+url: /sv/java/com.aspose.diagram/connectionabcdcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionABCDCollection extends Collection
+```
+
+ConnectionABCD-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(ConnectionABCD item)](#add-com.aspose.diagram.ConnectionABCD-) | Lägg till ConnectionABCD‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ConnectionABCD item)](#remove-com.aspose.diagram.ConnectionABCD-) | Ta bort ConnectionABCD‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ConnectionABCD item) {#add-com.aspose.diagram.ConnectionABCD-}
+```
+public int add(ConnectionABCD item)
+```
+
+
+Lägg till ConnectionABCD‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public ConnectionABCD get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[ConnectionABCD](../../com.aspose.diagram/connectionabcd) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ConnectionABCD item) {#remove-com.aspose.diagram.ConnectionABCD-}
+```
+public void remove(ConnectionABCD item)
+```
+
+
+Ta bort ConnectionABCD‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [ConnectionABCD](../../com.aspose.diagram/connectionabcd) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectioncollection/_index.md
+++ b/swedish/java/com.aspose.diagram/connectioncollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ConnectionCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Connection-samling.
+type: docs
+weight: 81
+url: /sv/java/com.aspose.diagram/connectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ConnectionCollection extends Collection
+```
+
+Connection-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Connection item)](#add-com.aspose.diagram.Connection-) | Lägg till Connection‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Connection item)](#remove-com.aspose.diagram.Connection-) | Ta bort Connection‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Connection item) {#add-com.aspose.diagram.Connection-}
+```
+public int add(Connection item)
+```
+
+
+Lägg till Connection‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Connection get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Connection item) {#remove-com.aspose.diagram.Connection-}
+```
+public void remove(Connection item)
+```
+
+
+Ta bort Connection‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Connection](../../com.aspose.diagram/connection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectionpointplace/_index.md
+++ b/swedish/java/com.aspose.diagram/connectionpointplace/_index.md
@@ -1,0 +1,174 @@
+---
+title: ConnectionPointPlace
+second_title: Aspose.Diagram för Java API-referens
+description: Anger platsen på formen där anslutningen kommer att anslutas.
+type: docs
+weight: 82
+url: /sv/java/com.aspose.diagram/connectionpointplace/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectionPointPlace
+```
+
+Anger platsen på formen där anslutningen kommer att anslutas.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Formens botten. |
+| [CENTER](#CENTER) | Formens centrum. |
+| [LEFT](#LEFT) | Formens vänstra sida. |
+| [RIGHT](#RIGHT) | Formens högra sida. |
+| [TOP](#TOP) | Formens topp. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Formens botten.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Formens centrum.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Formens vänstra sida.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Formens högra sida.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Formens topp.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectorrule/_index.md
+++ b/swedish/java/com.aspose.diagram/connectorrule/_index.md
@@ -1,0 +1,169 @@
+---
+title: ConnectorRule
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar anslutningsregel mellan två former med en connectorIncluding som anger vilken anslutningspunkt på vilken form den startar från slutformen och dess anslutningspunkt.
+type: docs
+weight: 83
+url: /sv/java/com.aspose.diagram/connectorrule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConnectorRule
+```
+
+Representerar anslutningsregel mellan två former med en anslutning, inklusive vilken anslutningspunkt på vilken form den startar från, slutformen och dess anslutningspunkt.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEndShapeConnection()](#getEndShapeConnection--) | Formens anslutning till vilken en anslutning görs. |
+| [getEndShapeId()](#getEndShapeId--) | Formen som en anslutning görs till. |
+| [getStartShapeConnection()](#getStartShapeConnection--) | Formens anslutning från vilken en anslutning görs. |
+| [getStartShapeId()](#getStartShapeId--) | Formen som en anslutning görs från. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEndShapeConnection() {#getEndShapeConnection--}
+```
+public Connection getEndShapeConnection()
+```
+
+
+Formens anslutning till vilken en anslutning görs.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getEndShapeId() {#getEndShapeId--}
+```
+public long getEndShapeId()
+```
+
+
+Formen som en anslutning görs till.
+
+**Returns:**
+long
+### getStartShapeConnection() {#getStartShapeConnection--}
+```
+public Connection getStartShapeConnection()
+```
+
+
+Formens anslutning från vilken en anslutning görs.
+
+**Returns:**
+[Connection](../../com.aspose.diagram/connection)
+### getStartShapeId() {#getStartShapeId--}
+```
+public long getStartShapeId()
+```
+
+
+Formen som en anslutning görs från.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/connectorstypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/connectorstypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ConnectorsTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Kan vara ett av följande värden RightAngle StraightLines eller CurvedLines.
+type: docs
+weight: 84
+url: /sv/java/com.aspose.diagram/connectorstypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConnectorsTypeValue
+```
+
+Kan vara ett av följande värden: RightAngle, StraightLines eller CurvedLines. Endast relevant när WindowType är angivet som Drawing eller Sheet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CURVED_LINES](#CURVED-LINES) | CurvedLines. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | RightAngle. |
+| [STRAIGHT_LINES](#STRAIGHT-LINES) | StraightLines. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED_LINES {#CURVED-LINES}
+```
+public static final int CURVED_LINES
+```
+
+
+CurvedLines.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+RightAngle.
+
+### STRAIGHT_LINES {#STRAIGHT-LINES}
+```
+public static final int STRAIGHT_LINES
+```
+
+
+StraightLines.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/containertypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/containertypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ContainerTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Kan vara ett av följande värden Dokument, Sida eller Master.
+type: docs
+weight: 85
+url: /sv/java/com.aspose.diagram/containertypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContainerTypeValue
+```
+
+Kan vara ett av följande värden: Dokument, Sida eller Master. Endast relevant när WindowType anges som Drawing eller Sheet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DOCUMENT](#DOCUMENT) | Dokument. |
+| [MASTER](#MASTER) | Master. |
+| [PAGE](#PAGE) | Sida. |
+| [STYLE](#STYLE) | Master. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Dokument.
+
+### MASTER {#MASTER}
+```
+public static final int MASTER
+```
+
+
+Master.
+
+### PAGE {#PAGE}
+```
+public static final int PAGE
+```
+
+
+Sida.
+
+### STYLE {#STYLE}
+```
+public static final int STYLE
+```
+
+
+Master.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/contexttypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/contexttypevalue/_index.md
@@ -1,0 +1,255 @@
+---
+title: ContextTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger egenskaper för gruppen eller formen som ska användas för jämförelsen.
+type: docs
+weight: 86
+url: /sv/java/com.aspose.diagram/contexttypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ContextTypeValue
+```
+
+Anger egenskaper för gruppen eller formen som ska användas för jämförelsen. Möjliga värden visas i följande tabell.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DATA_1](#DATA-1) | Data1. |
+| [DATA_2](#DATA-2) | Data2. |
+| [DATA_3](#DATA-3) | Data3. |
+| [GEOMETRY_ANGLE](#GEOMETRY-ANGLE) | Geometri vinkel. |
+| [GEOMETRY_HEIGHT](#GEOMETRY-HEIGHT) | Geometri höjd. |
+| [GEOMETRY_WIDTH](#GEOMETRY-WIDTH) | Geometri bredd. |
+| [MASTER_NAME](#MASTER-NAME) | Masternamn. |
+| [SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL](#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL) | Shape-data-item (anpassad egenskap) etikett. |
+| [SHAPE_ID](#SHAPE-ID) | Form-ID. |
+| [SHAPE_LOCAL_NAME](#SHAPE-LOCAL-NAME) | Formens lokala namn. |
+| [SHAPE_TEXT](#SHAPE-TEXT) | Formtext. |
+| [SHAPE_TYPE](#SHAPE-TYPE) | Formtyp. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [USER_CELL_LOCAL_ROW_NAME](#USER-CELL-LOCAL-ROW-NAME) | Användarcellens lokala radnamn. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_1 {#DATA-1}
+```
+public static final int DATA_1
+```
+
+
+Data1.
+
+### DATA_2 {#DATA-2}
+```
+public static final int DATA_2
+```
+
+
+Data2.
+
+### DATA_3 {#DATA-3}
+```
+public static final int DATA_3
+```
+
+
+Data3.
+
+### GEOMETRY_ANGLE {#GEOMETRY-ANGLE}
+```
+public static final int GEOMETRY_ANGLE
+```
+
+
+Geometri vinkel.
+
+### GEOMETRY_HEIGHT {#GEOMETRY-HEIGHT}
+```
+public static final int GEOMETRY_HEIGHT
+```
+
+
+Geometri höjd.
+
+### GEOMETRY_WIDTH {#GEOMETRY-WIDTH}
+```
+public static final int GEOMETRY_WIDTH
+```
+
+
+Geometri bredd.
+
+### MASTER_NAME {#MASTER-NAME}
+```
+public static final int MASTER_NAME
+```
+
+
+Masternamn.
+
+### SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL {#SHAPE-DATA-ITEM-CUSTOM-PROPERTY-LABEL}
+```
+public static final int SHAPE_DATA_ITEM_CUSTOM_PROPERTY_LABEL
+```
+
+
+Shape-data-item (anpassad egenskap) etikett.
+
+### SHAPE_ID {#SHAPE-ID}
+```
+public static final int SHAPE_ID
+```
+
+
+Form-ID.
+
+### SHAPE_LOCAL_NAME {#SHAPE-LOCAL-NAME}
+```
+public static final int SHAPE_LOCAL_NAME
+```
+
+
+Formens lokala namn.
+
+### SHAPE_TEXT {#SHAPE-TEXT}
+```
+public static final int SHAPE_TEXT
+```
+
+
+Formtext.
+
+### SHAPE_TYPE {#SHAPE-TYPE}
+```
+public static final int SHAPE_TYPE
+```
+
+
+Formtyp.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### USER_CELL_LOCAL_ROW_NAME {#USER-CELL-LOCAL-ROW-NAME}
+```
+public static final int USER_CELL_LOCAL_ROW_NAME
+```
+
+
+Användarcellens lokala radnamn.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/control/_index.md
+++ b/swedish/java/com.aspose.diagram/control/_index.md
@@ -1,0 +1,474 @@
+---
+title: Kontroll
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element för x- och y-koordinaterna för varje kontrollhandtag som definierats för en form samt element som specificerar hur kontrollhandtaget ska bete sig.
+type: docs
+weight: 87
+url: /sv/java/com.aspose.diagram/control/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Control
+```
+
+Innehåller element för x- och y-koordinaterna för varje kontrollhandtag som definierats för en form, samt element som anger hur kontrollhandtaget ska bete sig.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Control()](#Control--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [canGlue()](#canGlue--) | Bestämmer om ett kontrollhandtag kan fästas på andra former. |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPrompt()](#getPrompt--) | Prompt-elementet specificerar beskrivande text som visas som verktygstips när muspekaren hålls över ett formes kontrollhandtag. |
+| [getX()](#getX--) | X-koordinaten som anger placeringen för ett formes kontrollhandtag. |
+| [getXCon()](#getXCon--) | Specificerar typen av beteende som x-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats. |
+| [getXDyn()](#getXDyn--) | Specificerar x-koordinaten för ett kontrollhandtags ankarnpunkt i lokala koordinater. |
+| [getY()](#getY--) | Y-koordinaten som anger placeringen för ett formes kontrollhandtag. |
+| [getYCon()](#getYCon--) | Specificerar typen av beteende som x-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats. |
+| [getYDyn()](#getYDyn--) | Specificerar y-koordinaten för ett kontrollhandtags ankarnpunkt i lokala koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCanGlue(BoolValue value)](#setCanGlue-com.aspose.diagram.BoolValue-) | För beskrivningen av denna egenskap, se [canGlue()](../../com.aspose.diagram/control\#canGlue--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/control\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/control\#getID--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/control\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/control\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/control\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/control\#getPrompt--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/control\#getX--) |
+| [setXCon(ConType value)](#setXCon-com.aspose.diagram.ConType-) | För beskrivningen av denna egenskap, se [getXCon()](../../com.aspose.diagram/control\#getXCon--) |
+| [setXDyn(DoubleValue value)](#setXDyn-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getXDyn()](../../com.aspose.diagram/control\#getXDyn--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/control\#getY--) |
+| [setYCon(ConType value)](#setYCon-com.aspose.diagram.ConType-) | För beskrivningen av denna egenskap, se [getYCon()](../../com.aspose.diagram/control\#getYCon--) |
+| [setYDyn(DoubleValue value)](#setYDyn-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getYDyn()](../../com.aspose.diagram/control\#getYDyn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Control() {#Control--}
+```
+public Control()
+```
+
+
+Konstruktor.
+
+### canGlue() {#canGlue--}
+```
+public BoolValue canGlue()
+```
+
+
+Bestämmer om ett kontrollhandtag kan fästas på andra former.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Prompt-elementet specificerar beskrivande text som visas som verktygstips när muspekaren hålls över ett formes kontrollhandtag.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten som anger placeringen för ett formes kontrollhandtag.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXCon() {#getXCon--}
+```
+public ConType getXCon()
+```
+
+
+Specificerar typen av beteende som x-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getXDyn() {#getXDyn--}
+```
+public DoubleValue getXDyn()
+```
+
+
+Anger x-koordinaten för ett kontrollhandtags ankarnpunkt i lokala koordinater. Ankarnpunkten används för elastisk bandning under dynamik.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten som anger placeringen för ett formes kontrollhandtag.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYCon() {#getYCon--}
+```
+public ConType getYCon()
+```
+
+
+Specificerar typen av beteende som x-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+
+**Returns:**
+[ConType](../../com.aspose.diagram/contype)
+### getYDyn() {#getYDyn--}
+```
+public DoubleValue getYDyn()
+```
+
+
+Anger y-koordinaten för ett kontrollhandtags ankarnpunkt i lokala koordinater. Ankarnpunkten används för elastisk bandning under dynamik.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCanGlue(BoolValue value) {#setCanGlue-com.aspose.diagram.BoolValue-}
+```
+public void setCanGlue(BoolValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [canGlue()](../../com.aspose.diagram/control\#canGlue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/control\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/control\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/control\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/control\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/control\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/control\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/control\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setXCon(ConType value) {#setXCon-com.aspose.diagram.ConType-}
+```
+public void setXCon(ConType value)
+```
+
+
+För beskrivningen av denna egenskap, se [getXCon()](../../com.aspose.diagram/control\#getXCon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setXDyn(DoubleValue value) {#setXDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setXDyn(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getXDyn()](../../com.aspose.diagram/control\#getXDyn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/control\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setYCon(ConType value) {#setYCon-com.aspose.diagram.ConType-}
+```
+public void setYCon(ConType value)
+```
+
+
+För beskrivningen av denna egenskap, se [getYCon()](../../com.aspose.diagram/control\#getYCon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ConType](../../com.aspose.diagram/contype) |  |
+
+### setYDyn(DoubleValue value) {#setYDyn-com.aspose.diagram.DoubleValue-}
+```
+public void setYDyn(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getYDyn()](../../com.aspose.diagram/control\#getYDyn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlbordertype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlbordertype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlBorderType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar kanttypen för ActiveX-kontrollen.
+type: docs
+weight: 88
+url: /sv/java/com.aspose.diagram/controlbordertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlBorderType
+```
+
+Representerar kanttypen för ActiveX-kontrollen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NONE](#NONE) | Ingen kant. |
+| [SINGLE](#SINGLE) | Den enkla linjen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen kant.
+
+### SINGLE {#SINGLE}
+```
+public static final int SINGLE
+```
+
+
+Den enkla linjen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlcaptionalignmenttype/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlCaptionAlignmentType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar positionen för bildtexten relativt kontrollen.
+type: docs
+weight: 89
+url: /sv/java/com.aspose.diagram/controlcaptionalignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlCaptionAlignmentType
+```
+
+Representerar positionen för bildtexten relativt kontrollen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [LEFT](#LEFT) | Kontrollens vänstra sida. |
+| [RIGHT](#RIGHT) | Kontrollens högra sida. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Kontrollens vänstra sida.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Kontrollens högra sida.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/controlcollection/_index.md
@@ -1,0 +1,266 @@
+---
+title: ControlCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Kontroll-samling.
+type: docs
+weight: 90
+url: /sv/java/com.aspose.diagram/controlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ControlCollection extends Collection
+```
+
+Kontroll-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Control item)](#add-com.aspose.diagram.Control-) | Lägg till Control‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getControl(int IX)](#getControl-int-) | Hämtar elementet på det angivna indexet IX. |
+| [getControlFromId(int ID)](#getControlFromId-int-) | Hämtar elementet med angivet ID. |
+| [getControlFromName(String name)](#getControlFromName-java.lang.String-) | Hämtar elementet med angivet namn. |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Control item)](#remove-com.aspose.diagram.Control-) | Ta bort Control‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Control item) {#add-com.aspose.diagram.Control-}
+```
+public int add(Control item)
+```
+
+
+Lägg till Control‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Control get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getControl(int IX) {#getControl-int-}
+```
+public Control getControl(int IX)
+```
+
+
+Hämtar elementet på det angivna indexet IX.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromId(int ID) {#getControlFromId-int-}
+```
+public Control getControlFromId(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getControlFromName(String name) {#getControlFromName-java.lang.String-}
+```
+public Control getControlFromName(String name)
+```
+
+
+Hämtar elementet med angivet namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Control](../../com.aspose.diagram/control) - 
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Control item) {#remove-com.aspose.diagram.Control-}
+```
+public void remove(Control item)
+```
+
+
+Ta bort Control‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Control](../../com.aspose.diagram/control) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlliststyle/_index.md
+++ b/swedish/java/com.aspose.diagram/controlliststyle/_index.md
@@ -1,0 +1,147 @@
+---
+title: ControlListStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar den visuella utformningen av listan i en ListBox eller ComboBox.
+type: docs
+weight: 91
+url: /sv/java/com.aspose.diagram/controlliststyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlListStyle
+```
+
+Representerar den visuella utformningen av listan i en ListBox eller ComboBox.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [OPTION](#OPTION) | Visar en lista där en alternativknapp eller en kryssruta bredvid varje post visar urvalstillståndet för det objektet. |
+| [PLAIN](#PLAIN) | Visar en lista där bakgrunden på ett objekt markeras när det är valt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OPTION {#OPTION}
+```
+public static final int OPTION
+```
+
+
+Visar en lista där en alternativknapp eller en kryssruta bredvid varje post visar urvalstillståndet för det objektet.
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Visar en lista där bakgrunden på ett objekt markeras när det är valt.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlmatchentrytype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlmatchentrytype/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlMatchEntryType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver.
+type: docs
+weight: 92
+url: /sv/java/com.aspose.diagram/controlmatchentrytype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMatchEntryType
+```
+
+Representerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [COMPLETE](#COMPLETE) | När varje tecken skrivs in söker kontrollen efter en post som matchar alla inmatade tecken. |
+| [FIRST_LETTER](#FIRST-LETTER) | Kontrollen söker efter nästa post som börjar med det inmatade tecknet. |
+| [NONE](#NONE) | Listan kommer inte att sökas när tecken skrivs in. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COMPLETE {#COMPLETE}
+```
+public static final int COMPLETE
+```
+
+
+När varje tecken skrivs in söker kontrollen efter en post som matchar alla inmatade tecken.
+
+### FIRST_LETTER {#FIRST-LETTER}
+```
+public static final int FIRST_LETTER
+```
+
+
+Kontrollen söker efter nästa post som börjar med det inmatade tecknet. Att upprepade gånger skriva samma bokstav cyklar igenom alla poster som börjar med den bokstaven.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Listan kommer inte att sökas när tecken skrivs in.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlmousepointertype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlmousepointertype/_index.md
@@ -1,0 +1,264 @@
+---
+title: ControlMousePointerType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av ikon som visas som muspekaren för kontrollen.
+type: docs
+weight: 93
+url: /sv/java/com.aspose.diagram/controlmousepointertype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlMousePointerType
+```
+
+Representerar typen av ikon som visas som muspekaren för kontrollen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [APP_STARTING](#APP-STARTING) | Pil med en timglas. |
+| [ARROW](#ARROW) | Pil. |
+| [CROSS](#CROSS) | Korshårspointer. |
+| [CUSTOM](#CUSTOM) | Använder ikonen som anges av egenskapen MouseIcon. |
+| [DEFAULT](#DEFAULT) | Standardpekare. |
+| [HELP](#HELP) | Pil med ett frågetecken. |
+| [HOUR_GLASS](#HOUR-GLASS) | Timglas. |
+| [I_BEAM](#I-BEAM) | I-balk. |
+| [NO_DROP](#NO-DROP) | \\u9225\\u6de3ot\\u9225? |
+| [SIZE_ALL](#SIZE-ALL) | \\u9225\\u6deaize-all\\u9225? |
+| [SIZE_NESW](#SIZE-NESW) | Dubbel pil som pekar nordost och sydväst. |
+| [SIZE_NS](#SIZE-NS) | Dubbel pil som pekar norr och söder. |
+| [SIZE_NWSE](#SIZE-NWSE) | Dubbel pil som pekar nordväst och sydost. |
+| [SIZE_WE](#SIZE-WE) | Dubbel pil som pekar väst och öst. |
+| [UP_ARROW](#UP-ARROW) | Uppåtpil. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### APP_STARTING {#APP-STARTING}
+```
+public static final int APP_STARTING
+```
+
+
+Pil med en timglas.
+
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Pil.
+
+### CROSS {#CROSS}
+```
+public static final int CROSS
+```
+
+
+Korshårspointer.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Använder ikonen som anges av egenskapen MouseIcon.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standardpekare.
+
+### HELP {#HELP}
+```
+public static final int HELP
+```
+
+
+Pil med ett frågetecken.
+
+### HOUR_GLASS {#HOUR-GLASS}
+```
+public static final int HOUR_GLASS
+```
+
+
+Timglas.
+
+### I_BEAM {#I-BEAM}
+```
+public static final int I_BEAM
+```
+
+
+I-balk.
+
+### NO_DROP {#NO-DROP}
+```
+public static final int NO_DROP
+```
+
+
+\\u9225\\u6de3ot\\u9225?symbol (cirkel med en diagonal linje) ovanpå objektet som dras.
+
+### SIZE_ALL {#SIZE-ALL}
+```
+public static final int SIZE_ALL
+```
+
+
+\\u9225\\u6deaize-all\\u9225?cursor (pilar som pekar norr, söder, öst och väst).
+
+### SIZE_NESW {#SIZE-NESW}
+```
+public static final int SIZE_NESW
+```
+
+
+Dubbel pil som pekar nordost och sydväst.
+
+### SIZE_NS {#SIZE-NS}
+```
+public static final int SIZE_NS
+```
+
+
+Dubbel pil som pekar norr och söder.
+
+### SIZE_NWSE {#SIZE-NWSE}
+```
+public static final int SIZE_NWSE
+```
+
+
+Dubbel pil som pekar nordväst och sydost.
+
+### SIZE_WE {#SIZE-WE}
+```
+public static final int SIZE_WE
+```
+
+
+Dubbel pil som pekar väst och öst.
+
+### UP_ARROW {#UP-ARROW}
+```
+public static final int UP_ARROW
+```
+
+
+Uppåtpil.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlpicturealignmenttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlPictureAlignmentType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar bildens justering i formuläret eller bilden.
+type: docs
+weight: 94
+url: /sv/java/com.aspose.diagram/controlpicturealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureAlignmentType
+```
+
+Representerar bildens justering i formuläret eller bilden.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Det nedre vänstra hörnet. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Det nedre högra hörnet. |
+| [CENTER](#CENTER) | Centrum. |
+| [TOP_LEFT](#TOP-LEFT) | Det övre vänstra hörnet. |
+| [TOP_RIGHT](#TOP-RIGHT) | Det övre högra hörnet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Det nedre vänstra hörnet.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Det nedre högra hörnet.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centrum.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Det övre vänstra hörnet.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Det övre högra hörnet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlpicturepositiontype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlpicturepositiontype/_index.md
@@ -1,0 +1,246 @@
+---
+title: ControlPicturePositionType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar placeringen av kontrollens bild i förhållande till dess rubrik.
+type: docs
+weight: 95
+url: /sv/java/com.aspose.diagram/controlpicturepositiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPicturePositionType
+```
+
+Representerar kontrollens bilds placering relativt dess rubrik.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ABOVE_CENTER](#ABOVE-CENTER) | Bilden visas ovanför rubriken. |
+| [ABOVE_LEFT](#ABOVE-LEFT) | Bilden visas ovanför rubriken. |
+| [ABOVE_RIGHT](#ABOVE-RIGHT) | Bilden visas ovanför rubriken. |
+| [BELOW_CENTER](#BELOW-CENTER) | Bilden visas under rubriken. |
+| [BELOW_LEFT](#BELOW-LEFT) | Bilden visas under rubriken. |
+| [BELOW_RIGHT](#BELOW-RIGHT) | Bilden visas under rubriken. |
+| [CENTER](#CENTER) | Bilden visas i mitten av kontrollen. |
+| [LEFT_BOTTOM](#LEFT-BOTTOM) | Bilden visas till vänster om rubriken. |
+| [LEFT_CENTER](#LEFT-CENTER) | Bilden visas till vänster om rubriken. |
+| [LEFT_TOP](#LEFT-TOP) | Bilden visas till vänster om rubriken. |
+| [RIGHT_BOTTOM](#RIGHT-BOTTOM) | Bilden visas till höger om rubriken. |
+| [RIGHT_CENTER](#RIGHT-CENTER) | Bilden visas till höger om rubriken. |
+| [RIGHT_TOP](#RIGHT-TOP) | Bilden visas till höger om rubriken. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ABOVE_CENTER {#ABOVE-CENTER}
+```
+public static final int ABOVE_CENTER
+```
+
+
+Bilden visas ovanför rubriken. Rubriken är centrerad under bilden.
+
+### ABOVE_LEFT {#ABOVE-LEFT}
+```
+public static final int ABOVE_LEFT
+```
+
+
+Bilden visas ovanför rubriken. Rubriken är justerad med bildens vänstra kant.
+
+### ABOVE_RIGHT {#ABOVE-RIGHT}
+```
+public static final int ABOVE_RIGHT
+```
+
+
+Bilden visas ovanför rubriken. Rubriken är justerad med bildens högra kant.
+
+### BELOW_CENTER {#BELOW-CENTER}
+```
+public static final int BELOW_CENTER
+```
+
+
+Bilden visas under rubriken. Rubriken är centrerad ovanför bilden.
+
+### BELOW_LEFT {#BELOW-LEFT}
+```
+public static final int BELOW_LEFT
+```
+
+
+Bilden visas under rubriken. Rubriken är justerad med bildens vänstra kant.
+
+### BELOW_RIGHT {#BELOW-RIGHT}
+```
+public static final int BELOW_RIGHT
+```
+
+
+Bilden visas under rubriken. Rubriken är justerad med bildens högra kant.
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Bilden visas i mitten av kontrollen. Rubriken är centrerad horisontellt och vertikalt ovanpå bilden.
+
+### LEFT_BOTTOM {#LEFT-BOTTOM}
+```
+public static final int LEFT_BOTTOM
+```
+
+
+Bilden visas till vänster om rubriken. Rubriken är justerad med bildens nederkant.
+
+### LEFT_CENTER {#LEFT-CENTER}
+```
+public static final int LEFT_CENTER
+```
+
+
+Bilden visas till vänster om rubriken. Rubriken är centrerad i förhållande till bilden.
+
+### LEFT_TOP {#LEFT-TOP}
+```
+public static final int LEFT_TOP
+```
+
+
+Bilden visas till vänster om rubriken. Rubriken är justerad med bildens överkant.
+
+### RIGHT_BOTTOM {#RIGHT-BOTTOM}
+```
+public static final int RIGHT_BOTTOM
+```
+
+
+Bilden visas till höger om rubriken. Rubriken är justerad med bildens nederkant.
+
+### RIGHT_CENTER {#RIGHT-CENTER}
+```
+public static final int RIGHT_CENTER
+```
+
+
+Bilden visas till höger om rubriken. Rubriken är centrerad i förhållande till bilden.
+
+### RIGHT_TOP {#RIGHT-TOP}
+```
+public static final int RIGHT_TOP
+```
+
+
+Bilden visas till höger om rubriken. Rubriken är justerad med bildens överkant.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlpicturesizemode/_index.md
+++ b/swedish/java/com.aspose.diagram/controlpicturesizemode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlPictureSizeMode
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar hur bilden ska visas.
+type: docs
+weight: 96
+url: /sv/java/com.aspose.diagram/controlpicturesizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlPictureSizeMode
+```
+
+Representerar hur bilden ska visas.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CLIP](#CLIP) | Beskär alla delar av bilden som är större än kontrollens gränser. |
+| [STRETCH](#STRETCH) | Sträcker bilden för att fylla kontrollens område. |
+| [ZOOM](#ZOOM) | Förstorar bilden, men förvränger inte bilden varken horisontellt eller vertikalt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLIP {#CLIP}
+```
+public static final int CLIP
+```
+
+
+Beskär alla delar av bilden som är större än kontrollens gränser.
+
+### STRETCH {#STRETCH}
+```
+public static final int STRETCH
+```
+
+
+Sträcker bilden för att fylla kontrollens område. Denna inställning förvränger bilden antingen horisontellt eller vertikalt.
+
+### ZOOM {#ZOOM}
+```
+public static final int ZOOM
+```
+
+
+Förstorar bilden, men förvränger inte bilden varken horisontellt eller vertikalt.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlscrollbartype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlscrollbartype/_index.md
@@ -1,0 +1,165 @@
+---
+title: ControlScrollBarType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av rullningslist.
+type: docs
+weight: 97
+url: /sv/java/com.aspose.diagram/controlscrollbartype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollBarType
+```
+
+Representerar typen av rullningslist.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BARS_BOTH](#BARS-BOTH) | Visar både en horisontell och en vertikal rullningslist. |
+| [BARS_VERTICAL](#BARS-VERTICAL) | Visar en vertikal rullningslist. |
+| [HORIZONTAL](#HORIZONTAL) | Visar en horisontell rullningslist. |
+| [NONE](#NONE) | Visar inga rullningslistor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BARS_BOTH {#BARS-BOTH}
+```
+public static final int BARS_BOTH
+```
+
+
+Visar både en horisontell och en vertikal rullningslist.
+
+### BARS_VERTICAL {#BARS-VERTICAL}
+```
+public static final int BARS_VERTICAL
+```
+
+
+Visar en vertikal rullningslist.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Visar en horisontell rullningslist.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Visar inga rullningslistor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlscrollorientation/_index.md
+++ b/swedish/java/com.aspose.diagram/controlscrollorientation/_index.md
@@ -1,0 +1,156 @@
+---
+title: ControlScrollOrientation
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typ av rullningsorientering
+type: docs
+weight: 98
+url: /sv/java/com.aspose.diagram/controlscrollorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlScrollOrientation
+```
+
+Representerar typ av rullningsorientering
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [AUTO](#AUTO) | Kontrollen renderas horisontellt när kontrollens bredd är större än dess höjd. |
+| [HORIZONTAL](#HORIZONTAL) | Kontrollen renderas horisontellt. |
+| [VERTICAL](#VERTICAL) | Kontrollen renderas vertikalt. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTO {#AUTO}
+```
+public static final int AUTO
+```
+
+
+Kontrollen renderas horisontellt när kontrollens bredd är större än dess höjd. Kontrollen renderas vertikalt annars.
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Kontrollen renderas horisontellt.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Kontrollen renderas vertikalt.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controlspecialeffecttype/_index.md
+++ b/swedish/java/com.aspose.diagram/controlspecialeffecttype/_index.md
@@ -1,0 +1,174 @@
+---
+title: ControlSpecialEffectType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av specialeffekt.
+type: docs
+weight: 99
+url: /sv/java/com.aspose.diagram/controlspecialeffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlSpecialEffectType
+```
+
+Representerar typen av specialeffekt.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BUMP](#BUMP) | Bump |
+| [ETCHED](#ETCHED) | Etched |
+| [FLAT](#FLAT) | Flat |
+| [RAISED](#RAISED) | Raised |
+| [SUNKEN](#SUNKEN) | Sunken |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUMP {#BUMP}
+```
+public static final int BUMP
+```
+
+
+Bump
+
+### ETCHED {#ETCHED}
+```
+public static final int ETCHED
+```
+
+
+Etched
+
+### FLAT {#FLAT}
+```
+public static final int FLAT
+```
+
+
+Flat
+
+### RAISED {#RAISED}
+```
+public static final int RAISED
+```
+
+
+Raised
+
+### SUNKEN {#SUNKEN}
+```
+public static final int SUNKEN
+```
+
+
+Sunken
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/controltype/_index.md
+++ b/swedish/java/com.aspose.diagram/controltype/_index.md
@@ -1,0 +1,237 @@
+---
+title: ControlType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar alla typer av ActiveX-kontroller.
+type: docs
+weight: 100
+url: /sv/java/com.aspose.diagram/controltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ControlType
+```
+
+Representerar alla typer av ActiveX-kontroller.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CHECK_BOX](#CHECK-BOX) | CheckBox |
+| [COMBO_BOX](#COMBO-BOX) | ComboBox |
+| [COMMAND_BUTTON](#COMMAND-BUTTON) | Button |
+| [IMAGE](#IMAGE) | Bild |
+| [LABEL](#LABEL) | Label |
+| [LIST_BOX](#LIST-BOX) | ListBox |
+| [RADIO_BUTTON](#RADIO-BUTTON) | RadioButton |
+| [SCROLL_BAR](#SCROLL-BAR) | ScrollBar |
+| [SPIN_BUTTON](#SPIN-BUTTON) | Spinner |
+| [TEXT_BOX](#TEXT-BOX) | TextBox |
+| [TOGGLE_BUTTON](#TOGGLE-BUTTON) | ToggleButton |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CHECK_BOX {#CHECK-BOX}
+```
+public static final int CHECK_BOX
+```
+
+
+CheckBox
+
+### COMBO_BOX {#COMBO-BOX}
+```
+public static final int COMBO_BOX
+```
+
+
+ComboBox
+
+### COMMAND_BUTTON {#COMMAND-BUTTON}
+```
+public static final int COMMAND_BUTTON
+```
+
+
+Button
+
+### IMAGE {#IMAGE}
+```
+public static final int IMAGE
+```
+
+
+Bild
+
+### LABEL {#LABEL}
+```
+public static final int LABEL
+```
+
+
+Label
+
+### LIST_BOX {#LIST-BOX}
+```
+public static final int LIST_BOX
+```
+
+
+ListBox
+
+### RADIO_BUTTON {#RADIO-BUTTON}
+```
+public static final int RADIO_BUTTON
+```
+
+
+RadioButton
+
+### SCROLL_BAR {#SCROLL-BAR}
+```
+public static final int SCROLL_BAR
+```
+
+
+ScrollBar
+
+### SPIN_BUTTON {#SPIN-BUTTON}
+```
+public static final int SPIN_BUTTON
+```
+
+
+Spinner
+
+### TEXT_BOX {#TEXT-BOX}
+```
+public static final int TEXT_BOX
+```
+
+
+TextBox
+
+### TOGGLE_BUTTON {#TOGGLE-BUTTON}
+```
+public static final int TOGGLE_BUTTON
+```
+
+
+ToggleButton
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/contype/_index.md
+++ b/swedish/java/com.aspose.diagram/contype/_index.md
@@ -1,0 +1,204 @@
+---
+title: ConType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+type: docs
+weight: 73
+url: /sv/java/com.aspose.diagram/contype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ConType
+```
+
+Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ConType(int value)](#ConType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/contype\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/contype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ConType(int value) {#ConType-int-}
+```
+public ConType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/contype\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/contype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/convalue/_index.md
+++ b/swedish/java/com.aspose.diagram/convalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: ConValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+type: docs
+weight: 74
+url: /sv/java/com.aspose.diagram/convalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ConValue
+```
+
+Anger vilken typ av beteende x- eller y-koordinaten för kontrollhandtaget uppvisar efter att handtaget har flyttats.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [OFFSET_FROM_CENTER](#OFFSET-FROM-CENTER) | Förskjutning från centrum. |
+| [OFFSET_FROM_CENTER_HIDDEN](#OFFSET-FROM-CENTER-HIDDEN) | Förskjutning från centrum, dold. |
+| [OFFSET_FROM_LEFT_EDGE](#OFFSET-FROM-LEFT-EDGE) | Förskjutning från vänster kant. |
+| [OFFSET_FROM_LEFT_EDGE_HIDDEN](#OFFSET-FROM-LEFT-EDGE-HIDDEN) | Förskjutning från vänster kant, dold. |
+| [OFFSET_FROM_RIGHT_EDGE](#OFFSET-FROM-RIGHT-EDGE) | Förskjutning från högra kanten. |
+| [OFFSET_FROM_RIGHT_EDGE_HIDDEN](#OFFSET-FROM-RIGHT-EDGE-HIDDEN) | Förskjutning från högra kanten, dold. |
+| [PROPORTIONAL](#PROPORTIONAL) | Proportionell. |
+| [PROPORTIONAL_HIDDEN](#PROPORTIONAL-HIDDEN) | Proportionell, dold.Samma som 0, men kontrollhandtaget är inte synligt. |
+| [PROPORTIONAL_LOCKED](#PROPORTIONAL-LOCKED) | Proportionell låst. |
+| [PROPORTIONAL_LOCKED_HIDDEN](#PROPORTIONAL-LOCKED-HIDDEN) | Proportionell låst, dold. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OFFSET_FROM_CENTER {#OFFSET-FROM-CENTER}
+```
+public static final int OFFSET_FROM_CENTER
+```
+
+
+Förskjutning från centrum. Kontrollhandtaget är förskjutet ett konstant avstånd från figurens centrum.
+
+### OFFSET_FROM_CENTER_HIDDEN {#OFFSET-FROM-CENTER-HIDDEN}
+```
+public static final int OFFSET_FROM_CENTER_HIDDEN
+```
+
+
+Förskjutning från centrum, dold. Samma som 3, men kontrollhandtaget är inte synligt.
+
+### OFFSET_FROM_LEFT_EDGE {#OFFSET-FROM-LEFT-EDGE}
+```
+public static final int OFFSET_FROM_LEFT_EDGE
+```
+
+
+Förskjutning från vänstra kanten. Kontrollhandtaget är förskjutet ett konstant avstånd från figurens vänstra sida.
+
+### OFFSET_FROM_LEFT_EDGE_HIDDEN {#OFFSET-FROM-LEFT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_LEFT_EDGE_HIDDEN
+```
+
+
+Förskjutning från vänstra kanten, dold. Samma som 2, men kontrollhandtaget är inte synligt.
+
+### OFFSET_FROM_RIGHT_EDGE {#OFFSET-FROM-RIGHT-EDGE}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE
+```
+
+
+Förskjutning från högra kanten. Kontrollhandtaget är förskjutet ett konstant avstånd från figurens högra sida.
+
+### OFFSET_FROM_RIGHT_EDGE_HIDDEN {#OFFSET-FROM-RIGHT-EDGE-HIDDEN}
+```
+public static final int OFFSET_FROM_RIGHT_EDGE_HIDDEN
+```
+
+
+Förskjutning från högra kanten, dold. Samma som 4, men kontrollhandtaget är inte synligt.
+
+### PROPORTIONAL {#PROPORTIONAL}
+```
+public static final int PROPORTIONAL
+```
+
+
+Proportionell. Kontrollhandtaget kan flyttas, och det rör sig också i proportion med figuren när den sträcks.
+
+### PROPORTIONAL_HIDDEN {#PROPORTIONAL-HIDDEN}
+```
+public static final int PROPORTIONAL_HIDDEN
+```
+
+
+Proportionell, dold.Samma som 0, men kontrollhandtaget är inte synligt.
+
+### PROPORTIONAL_LOCKED {#PROPORTIONAL-LOCKED}
+```
+public static final int PROPORTIONAL_LOCKED
+```
+
+
+Proportionell låst. Kontrollhandtaget rör sig i proportion med figuren, men själva kontrollhandtaget kan inte flyttas.
+
+### PROPORTIONAL_LOCKED_HIDDEN {#PROPORTIONAL-LOCKED-HIDDEN}
+```
+public static final int PROPORTIONAL_LOCKED_HIDDEN
+```
+
+
+Proportionell låst, dold. Samma som 1, men kontrollhandtaget är inte synligt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/coordinate/_index.md
+++ b/swedish/java/com.aspose.diagram/coordinate/_index.md
@@ -1,0 +1,197 @@
+---
+title: Koordinat
+second_title: Aspose.Diagram för Java API-referens
+description: Abstrakt klass för x- och y-koordinaterna.
+type: docs
+weight: 101
+url: /sv/java/com.aspose.diagram/coordinate/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Coordinate
+```
+
+Abstrakt klass för x- och y-koordinaterna.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Coordinate()](#Coordinate--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se @PREF1\\_ |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se @PREF0\\_ |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Coordinate() {#Coordinate--}
+```
+public Coordinate()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public abstract int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public abstract int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public abstract void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se @PREF1\\_
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public abstract void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se @PREF0\\_
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/coordinatecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/coordinatecollection/_index.md
@@ -1,0 +1,833 @@
+---
+title: CoordinateCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Koordinatsamling.
+type: docs
+weight: 102
+url: /sv/java/com.aspose.diagram/coordinatecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CoordinateCollection extends Collection
+```
+
+Koordinatsamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(ArcTo item)](#add-com.aspose.diagram.ArcTo-) | Lägg till ArcTo-objektet i samlingen. |
+| [add(Coordinate item)](#add-com.aspose.diagram.Coordinate-) | Lägg till Coordinate-objektet i samlingen. |
+| [add(Ellipse item)](#add-com.aspose.diagram.Ellipse-) | Lägg till Ellipse-objektet i samlingen. |
+| [add(EllipticalArcTo item)](#add-com.aspose.diagram.EllipticalArcTo-) | Lägg till EllipticalArcTo-objektet i samlingen. |
+| [add(InfiniteLine item)](#add-com.aspose.diagram.InfiniteLine-) | Lägg till InfiniteLine-objektet i samlingen. |
+| [add(LineTo item)](#add-com.aspose.diagram.LineTo-) | Lägg till LineTo-objektet i samlingen. |
+| [add(MoveTo item)](#add-com.aspose.diagram.MoveTo-) | Lägg till MoveTo-objektet i samlingen. |
+| [add(NURBSTo item)](#add-com.aspose.diagram.NURBSTo-) | Lägg till NURBSTo-objektet i samlingen. |
+| [add(PolylineTo item)](#add-com.aspose.diagram.PolylineTo-) | Lägg till PolylineTo-objektet i samlingen. |
+| [add(RelCubBezTo item)](#add-com.aspose.diagram.RelCubBezTo-) | Lägg till RelCubBezTo-objektet i samlingen. |
+| [add(RelEllipticalArcTo item)](#add-com.aspose.diagram.RelEllipticalArcTo-) | Lägg till RelEllipticalArcTo-objektet i samlingen. |
+| [add(RelLineTo item)](#add-com.aspose.diagram.RelLineTo-) | Lägg till RelLineTo-objektet i samlingen. |
+| [add(RelMoveTo item)](#add-com.aspose.diagram.RelMoveTo-) | Lägg till RelMoveTo-objektet i samlingen. |
+| [add(RelQuadBezTo item)](#add-com.aspose.diagram.RelQuadBezTo-) | Lägg till RelQuadBezTo-objektet i samlingen. |
+| [add(SplineKnot item)](#add-com.aspose.diagram.SplineKnot-) | Lägg till SplineKnot-objektet i samlingen. |
+| [add(SplineStart item)](#add-com.aspose.diagram.SplineStart-) | Lägg till SplineStart-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getArcToCol()](#getArcToCol--) | Innehåller x- och y-koordinaterna samt bågen för en cirkulär båge som representeras respektive av elementen X, Y och A. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getEllipseCol()](#getEllipseCol--) | Innehåller element som specificerar x- och y-koordinaterna för ellipsens mittpunkt samt två punkter på ellipsen. |
+| [getEllipticalArcToCol()](#getEllipticalArcToCol--) | Innehåller element som specificerar information om en elliptisk båge. |
+| [getInfiniteLineCol()](#getInfiniteLineCol--) | Innehåller element som specificerar x- och y-koordinaterna för två punkter på en oändlig linje. |
+| [getLineToCol()](#getLineToCol--) | Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment. |
+| [getMoveToCol()](#getMoveToCol--) | Innehåller x- och y-koordinaterna för den första hörnpunkten i en form, eller x- och y-koordinaterna för den första hörnpunkten efter ett avbrott i en bana. |
+| [getNURBSToCol()](#getNURBSToCol--) | Innehåller x- och y-koordinaterna, positionen för den näst sista knuten, positionen för den sista vikten, positionen för den första knuten, positionen för den första vikten samt formeln för en icke‑uniform rationell B-spline (NURBS). |
+| [getPolylineToCol()](#getPolylineToCol--) | Innehåller x- och y-koordinater för den sista punkten i en polylinje samt en polylinjeformel. |
+| [getRelCubBezToCol()](#getRelCubBezToCol--) | Innehåller x- och y-koordinater för en RelCubBezTo:s punkter. Koordinaterna anges som relativa koordinater. |
+| [getRelEllipticalArcToCol()](#getRelEllipticalArcToCol--) | Innehåller element som specificerar information om en elliptisk båge. Koordinaterna anges som relativa koordinater. |
+| [getRelLineToCol()](#getRelLineToCol--) | Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment. |
+| [getRelMoveToCol()](#getRelMoveToCol--) | Innehåller x- och y-koordinaterna för den första vertexen i en form, eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana. Koordinaterna anges som relativa koordinater. |
+| [getRelQuadBezToCol()](#getRelQuadBezToCol--) | Innehåller x- och y-koordinater för en RelQuadBezTo:s punkter. Koordinaterna anges som relativa koordinater. |
+| [getSplineKnotCol()](#getSplineKnotCol--) | Innehåller x- och y-koordinater för en splines kontrollpunkt och en splines knut, representerade av X-, Y- och A-elementen respektive. |
+| [getSplineStartCol()](#getSplineStartCol--) | Innehåller x- och y-koordinater för en splines andra kontrollpunkt, dess andra knut, dess första knut, den sista knuten och splinens grad. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(ArcTo item)](#remove-com.aspose.diagram.ArcTo-) | Ta bort ArcTo-objektet från samlingen. |
+| [remove(Coordinate item)](#remove-com.aspose.diagram.Coordinate-) | Ta bort Coordinate-objektet från samlingen. |
+| [remove(Ellipse item)](#remove-com.aspose.diagram.Ellipse-) | Ta bort Ellipse-objektet från samlingen. |
+| [remove(EllipticalArcTo item)](#remove-com.aspose.diagram.EllipticalArcTo-) | Ta bort EllipticalArcTo-objektet från samlingen. |
+| [remove(InfiniteLine item)](#remove-com.aspose.diagram.InfiniteLine-) | Ta bort InfiniteLine-objektet från samlingen. |
+| [remove(LineTo item)](#remove-com.aspose.diagram.LineTo-) | Ta bort LineTo-objektet från samlingen. |
+| [remove(MoveTo item)](#remove-com.aspose.diagram.MoveTo-) | Ta bort MoveTo-objektet från samlingen. |
+| [remove(NURBSTo item)](#remove-com.aspose.diagram.NURBSTo-) | Ta bort NURBSTo-objektet från samlingen. |
+| [remove(PolylineTo item)](#remove-com.aspose.diagram.PolylineTo-) | Ta bort PolylineTo-objektet från samlingen. |
+| [remove(RelCubBezTo item)](#remove-com.aspose.diagram.RelCubBezTo-) | Ta bort RelCubBezTo-objektet från samlingen. |
+| [remove(RelEllipticalArcTo item)](#remove-com.aspose.diagram.RelEllipticalArcTo-) | Ta bort RelEllipticalArcTo-objektet från samlingen. |
+| [remove(RelLineTo item)](#remove-com.aspose.diagram.RelLineTo-) | Ta bort RelLineTo-objektet från samlingen. |
+| [remove(RelMoveTo item)](#remove-com.aspose.diagram.RelMoveTo-) | Ta bort RelMoveTo-objektet från samlingen. |
+| [remove(RelQuadBezTo item)](#remove-com.aspose.diagram.RelQuadBezTo-) | Ta bort RelQuadBezTo-objektet från samlingen. |
+| [remove(SplineKnot item)](#remove-com.aspose.diagram.SplineKnot-) | Ta bort SplineKnot-objektet från samlingen. |
+| [remove(SplineStart item)](#remove-com.aspose.diagram.SplineStart-) | Ta bort SplineStart-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(ArcTo item) {#add-com.aspose.diagram.ArcTo-}
+```
+public int add(ArcTo item)
+```
+
+
+Lägg till ArcTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+**Returns:**
+int -
+### add(Coordinate item) {#add-com.aspose.diagram.Coordinate-}
+```
+public int add(Coordinate item)
+```
+
+
+Lägg till Coordinate-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+**Returns:**
+int
+### add(Ellipse item) {#add-com.aspose.diagram.Ellipse-}
+```
+public int add(Ellipse item)
+```
+
+
+Lägg till Ellipse-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+**Returns:**
+int -
+### add(EllipticalArcTo item) {#add-com.aspose.diagram.EllipticalArcTo-}
+```
+public int add(EllipticalArcTo item)
+```
+
+
+Lägg till EllipticalArcTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(InfiniteLine item) {#add-com.aspose.diagram.InfiniteLine-}
+```
+public int add(InfiniteLine item)
+```
+
+
+Lägg till InfiniteLine-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+**Returns:**
+int -
+### add(LineTo item) {#add-com.aspose.diagram.LineTo-}
+```
+public int add(LineTo item)
+```
+
+
+Lägg till LineTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+**Returns:**
+int -
+### add(MoveTo item) {#add-com.aspose.diagram.MoveTo-}
+```
+public int add(MoveTo item)
+```
+
+
+Lägg till MoveTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+**Returns:**
+int -
+### add(NURBSTo item) {#add-com.aspose.diagram.NURBSTo-}
+```
+public int add(NURBSTo item)
+```
+
+
+Lägg till NURBSTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+**Returns:**
+int -
+### add(PolylineTo item) {#add-com.aspose.diagram.PolylineTo-}
+```
+public int add(PolylineTo item)
+```
+
+
+Lägg till PolylineTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+**Returns:**
+int -
+### add(RelCubBezTo item) {#add-com.aspose.diagram.RelCubBezTo-}
+```
+public int add(RelCubBezTo item)
+```
+
+
+Lägg till RelCubBezTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+**Returns:**
+int -
+### add(RelEllipticalArcTo item) {#add-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public int add(RelEllipticalArcTo item)
+```
+
+
+Lägg till RelEllipticalArcTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+**Returns:**
+int -
+### add(RelLineTo item) {#add-com.aspose.diagram.RelLineTo-}
+```
+public int add(RelLineTo item)
+```
+
+
+Lägg till RelLineTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+**Returns:**
+int -
+### add(RelMoveTo item) {#add-com.aspose.diagram.RelMoveTo-}
+```
+public int add(RelMoveTo item)
+```
+
+
+Lägg till RelMoveTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+**Returns:**
+int -
+### add(RelQuadBezTo item) {#add-com.aspose.diagram.RelQuadBezTo-}
+```
+public int add(RelQuadBezTo item)
+```
+
+
+Lägg till RelQuadBezTo-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+**Returns:**
+int -
+### add(SplineKnot item) {#add-com.aspose.diagram.SplineKnot-}
+```
+public int add(SplineKnot item)
+```
+
+
+Lägg till SplineKnot-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+**Returns:**
+int -
+### add(SplineStart item) {#add-com.aspose.diagram.SplineStart-}
+```
+public int add(SplineStart item)
+```
+
+
+Lägg till SplineStart-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Coordinate get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Coordinate](../../com.aspose.diagram/coordinate) - 
+### getArcToCol() {#getArcToCol--}
+```
+public ArcToCollection getArcToCol()
+```
+
+
+Innehåller x- och y-koordinaterna samt bågen för en cirkulär båge som representeras respektive av elementen X, Y och A.
+
+**Returns:**
+[ArcToCollection](../../com.aspose.diagram/arctocollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getEllipseCol() {#getEllipseCol--}
+```
+public EllipseCollection getEllipseCol()
+```
+
+
+Innehåller element som specificerar x- och y-koordinaterna för ellipsens mittpunkt samt två punkter på ellipsen.
+
+**Returns:**
+[EllipseCollection](../../com.aspose.diagram/ellipsecollection)
+### getEllipticalArcToCol() {#getEllipticalArcToCol--}
+```
+public EllipticalArcToCollection getEllipticalArcToCol()
+```
+
+
+Innehåller element som specificerar information om en elliptisk båge.
+
+**Returns:**
+[EllipticalArcToCollection](../../com.aspose.diagram/ellipticalarctocollection)
+### getInfiniteLineCol() {#getInfiniteLineCol--}
+```
+public InfiniteLineCollection getInfiniteLineCol()
+```
+
+
+Innehåller element som specificerar x- och y-koordinaterna för två punkter på en oändlig linje. X- och Y-elementen specificerar x- och y-koordinaterna för den första punkten, och A- och B-elementen specificerar x- och y-koordinaterna för den andra punkten.
+
+**Returns:**
+[InfiniteLineCollection](../../com.aspose.diagram/infinitelinecollection)
+### getLineToCol() {#getLineToCol--}
+```
+public LineToCollection getLineToCol()
+```
+
+
+Innehåller x- och y-koordinater för den avslutande vertexen i ett rakt linjesegment. Dessa koordinater finns i X- respektive Y-elementen.
+
+**Returns:**
+[LineToCollection](../../com.aspose.diagram/linetocollection)
+### getMoveToCol() {#getMoveToCol--}
+```
+public MoveToCollection getMoveToCol()
+```
+
+
+Innehåller x- och y-koordinaterna för den första hörnpunkten i en form, eller x- och y-koordinaterna för den första hörnpunkten efter ett avbrott i en bana.
+
+**Returns:**
+[MoveToCollection](../../com.aspose.diagram/movetocollection)
+### getNURBSToCol() {#getNURBSToCol--}
+```
+public NURBSToCollection getNURBSToCol()
+```
+
+
+Innehåller x- och y-koordinaterna, positionen för den näst sista knuten, positionen för den sista vikten, positionen för den första knuten, positionen för den första vikten samt formeln för en icke-uniform rationell B-spline (NURBS). Denna information anges i elementen X, Y, A, B, C, D och E, i den ordningen.
+
+**Returns:**
+[NURBSToCollection](../../com.aspose.diagram/nurbstocollection)
+### getPolylineToCol() {#getPolylineToCol--}
+```
+public PolylineToCollection getPolylineToCol()
+```
+
+
+Innehåller x- och y-koordinater för den sista punkten i en polyline och en polyline-formel. Koordinaterna anges i X- och Y-elementen, och formeln anges i A-elementet.
+
+**Returns:**
+[PolylineToCollection](../../com.aspose.diagram/polylinetocollection)
+### getRelCubBezToCol() {#getRelCubBezToCol--}
+```
+public RelCubBezToCollection getRelCubBezToCol()
+```
+
+
+Innehåller x- och y-koordinater för en RelCubBezTo:s punkter. Koordinaterna anges som relativa koordinater.
+
+**Returns:**
+[RelCubBezToCollection](../../com.aspose.diagram/relcubbeztocollection)
+### getRelEllipticalArcToCol() {#getRelEllipticalArcToCol--}
+```
+public RelEllipticalArcToCollection getRelEllipticalArcToCol()
+```
+
+
+Innehåller element som specificerar information om en elliptisk båge. Koordinaterna anges som relativa koordinater.
+
+**Returns:**
+[RelEllipticalArcToCollection](../../com.aspose.diagram/relellipticalarctocollection)
+### getRelLineToCol() {#getRelLineToCol--}
+```
+public RelLineToCollection getRelLineToCol()
+```
+
+
+Innehåller x- och y-koordinater för den avslutande vertexen i ett rakt linjesegment. Dessa koordinater finns i X- respektive Y-elementen. Koordinaterna anges som relativa koordinater.
+
+**Returns:**
+[RelLineToCollection](../../com.aspose.diagram/rellinetocollection)
+### getRelMoveToCol() {#getRelMoveToCol--}
+```
+public RelMoveToCollection getRelMoveToCol()
+```
+
+
+Innehåller x- och y-koordinaterna för den första vertexen i en form, eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana. Koordinaterna anges som relativa koordinater.
+
+**Returns:**
+[RelMoveToCollection](../../com.aspose.diagram/relmovetocollection)
+### getRelQuadBezToCol() {#getRelQuadBezToCol--}
+```
+public RelQuadBezToCollection getRelQuadBezToCol()
+```
+
+
+Innehåller x- och y-koordinater för en RelQuadBezTo:s punkter. Koordinaterna anges som relativa koordinater.
+
+**Returns:**
+[RelQuadBezToCollection](../../com.aspose.diagram/relquadbeztocollection)
+### getSplineKnotCol() {#getSplineKnotCol--}
+```
+public SplineKnotCollection getSplineKnotCol()
+```
+
+
+Innehåller x- och y-koordinater för en splines kontrollpunkt och en splines knut, representerade av X-, Y- och A-elementen respektive.
+
+**Returns:**
+[SplineKnotCollection](../../com.aspose.diagram/splineknotcollection)
+### getSplineStartCol() {#getSplineStartCol--}
+```
+public SplineStartCollection getSplineStartCol()
+```
+
+
+Innehåller x- och y-koordinater för en splines andra kontrollpunkt, dess andra knut, dess första knut, den sista knuten och graden av splinen. Denna information finns i elementen X, Y, A, B, C och D, respektive.
+
+**Returns:**
+[SplineStartCollection](../../com.aspose.diagram/splinestartcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(ArcTo item) {#remove-com.aspose.diagram.ArcTo-}
+```
+public void remove(ArcTo item)
+```
+
+
+Ta bort ArcTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [ArcTo](../../com.aspose.diagram/arcto) |  |
+
+### remove(Coordinate item) {#remove-com.aspose.diagram.Coordinate-}
+```
+public void remove(Coordinate item)
+```
+
+
+Ta bort Coordinate-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Coordinate](../../com.aspose.diagram/coordinate) |  |
+
+### remove(Ellipse item) {#remove-com.aspose.diagram.Ellipse-}
+```
+public void remove(Ellipse item)
+```
+
+
+Ta bort Ellipse-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Ellipse](../../com.aspose.diagram/ellipse) |  |
+
+### remove(EllipticalArcTo item) {#remove-com.aspose.diagram.EllipticalArcTo-}
+```
+public void remove(EllipticalArcTo item)
+```
+
+
+Ta bort EllipticalArcTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) |  |
+
+### remove(InfiniteLine item) {#remove-com.aspose.diagram.InfiniteLine-}
+```
+public void remove(InfiniteLine item)
+```
+
+
+Ta bort InfiniteLine-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [InfiniteLine](../../com.aspose.diagram/infiniteline) |  |
+
+### remove(LineTo item) {#remove-com.aspose.diagram.LineTo-}
+```
+public void remove(LineTo item)
+```
+
+
+Ta bort LineTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [LineTo](../../com.aspose.diagram/lineto) |  |
+
+### remove(MoveTo item) {#remove-com.aspose.diagram.MoveTo-}
+```
+public void remove(MoveTo item)
+```
+
+
+Ta bort MoveTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [MoveTo](../../com.aspose.diagram/moveto) |  |
+
+### remove(NURBSTo item) {#remove-com.aspose.diagram.NURBSTo-}
+```
+public void remove(NURBSTo item)
+```
+
+
+Ta bort NURBSTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [NURBSTo](../../com.aspose.diagram/nurbsto) |  |
+
+### remove(PolylineTo item) {#remove-com.aspose.diagram.PolylineTo-}
+```
+public void remove(PolylineTo item)
+```
+
+
+Ta bort PolylineTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [PolylineTo](../../com.aspose.diagram/polylineto) |  |
+
+### remove(RelCubBezTo item) {#remove-com.aspose.diagram.RelCubBezTo-}
+```
+public void remove(RelCubBezTo item)
+```
+
+
+Ta bort RelCubBezTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelCubBezTo](../../com.aspose.diagram/relcubbezto) |  |
+
+### remove(RelEllipticalArcTo item) {#remove-com.aspose.diagram.RelEllipticalArcTo-}
+```
+public void remove(RelEllipticalArcTo item)
+```
+
+
+Ta bort RelEllipticalArcTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) |  |
+
+### remove(RelLineTo item) {#remove-com.aspose.diagram.RelLineTo-}
+```
+public void remove(RelLineTo item)
+```
+
+
+Ta bort RelLineTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelLineTo](../../com.aspose.diagram/rellineto) |  |
+
+### remove(RelMoveTo item) {#remove-com.aspose.diagram.RelMoveTo-}
+```
+public void remove(RelMoveTo item)
+```
+
+
+Ta bort RelMoveTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelMoveTo](../../com.aspose.diagram/relmoveto) |  |
+
+### remove(RelQuadBezTo item) {#remove-com.aspose.diagram.RelQuadBezTo-}
+```
+public void remove(RelQuadBezTo item)
+```
+
+
+Ta bort RelQuadBezTo-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [RelQuadBezTo](../../com.aspose.diagram/relquadbezto) |  |
+
+### remove(SplineKnot item) {#remove-com.aspose.diagram.SplineKnot-}
+```
+public void remove(SplineKnot item)
+```
+
+
+Ta bort SplineKnot-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SplineKnot](../../com.aspose.diagram/splineknot) |  |
+
+### remove(SplineStart item) {#remove-com.aspose.diagram.SplineStart-}
+```
+public void remove(SplineStart item)
+```
+
+
+Ta bort SplineStart-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SplineStart](../../com.aspose.diagram/splinestart) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/countrycode/_index.md
+++ b/swedish/java/com.aspose.diagram/countrycode/_index.md
@@ -1,0 +1,579 @@
+---
+title: Landskod
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar diagrammets landsidentifierare.
+type: docs
+weight: 103
+url: /sv/java/com.aspose.diagram/countrycode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class CountryCode
+```
+
+Representerar diagrammets landsidentifierare.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALGERIA](#ALGERIA) | Algeriet |
+| [AUSTRALIA](#AUSTRALIA) | Australien |
+| [AUSTRIA](#AUSTRIA) | Österrike |
+| [BELGIUM](#BELGIUM) | Belgien |
+| [BRAZIL](#BRAZIL) | Brasilien |
+| [CANADA](#CANADA) | Kanada |
+| [CHINA](#CHINA) | Folkrepubliken Kina |
+| [CZECH](#CZECH) | Tjeckien |
+| [DEFAULT](#DEFAULT) |  |
+| [DENMARK](#DENMARK) | Danmark |
+| [EGYPT](#EGYPT) | Egypten |
+| [FINLAND](#FINLAND) | Finland |
+| [FRANCE](#FRANCE) | Frankrike |
+| [GERMANY](#GERMANY) | Tyskland |
+| [GREECE](#GREECE) | Grekland |
+| [HUNGARY](#HUNGARY) | Ungern |
+| [ICELAND](#ICELAND) | Island |
+| [INDIA](#INDIA) | Indien |
+| [IRAN](#IRAN) | Iran |
+| [IRAQ](#IRAQ) | Irak |
+| [ISRAEL](#ISRAEL) | Israel |
+| [ITALY](#ITALY) | Italien |
+| [JAPAN](#JAPAN) | Japan |
+| [JORDAN](#JORDAN) | Jordanien |
+| [KUWAIT](#KUWAIT) | Kuwait |
+| [LATIN_AMERIC](#LATIN-AMERIC) | Latinamerika, förutom Brasilien |
+| [LEBANON](#LEBANON) | Libanon |
+| [LIBYA](#LIBYA) | Libyen |
+| [MEXICO](#MEXICO) | Mexiko |
+| [MOROCCO](#MOROCCO) | Morocco |
+| [NETHERLANDS](#NETHERLANDS) | Netherlands |
+| [NEW_ZEALAND](#NEW-ZEALAND) | New Zealand |
+| [NORWAY](#NORWAY) | Norway |
+| [POLAND](#POLAND) | Poland |
+| [PORTUGAL](#PORTUGAL) | Portugal |
+| [QATAR](#QATAR) | Qatar |
+| [RUSSIA](#RUSSIA) | Russia |
+| [SAUDI](#SAUDI) | Saudi Arabia |
+| [SOUTH_KOREA](#SOUTH-KOREA) | SouthKorea |
+| [SPAIN](#SPAIN) | Spain |
+| [SWEDEN](#SWEDEN) | Sweden |
+| [SWITZERLAND](#SWITZERLAND) | Switzerland |
+| [SYRIA](#SYRIA) | Syria |
+| [TAIWAN](#TAIWAN) | Taiwan |
+| [THAILAND](#THAILAND) | Thailand |
+| [TURKEY](#TURKEY) | Turkey |
+| [UNITED_ARAB_EMIRATES](#UNITED-ARAB-EMIRATES) | United Arab Emirates |
+| [UNITED_KINGDOM](#UNITED-KINGDOM) | United Kingdom |
+| [USA](#USA) | United States |
+| [VIET_NAM](#VIET-NAM) | Viet Nam |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALGERIA {#ALGERIA}
+```
+public static final int ALGERIA
+```
+
+
+Algeriet
+
+### AUSTRALIA {#AUSTRALIA}
+```
+public static final int AUSTRALIA
+```
+
+
+Australien
+
+### AUSTRIA {#AUSTRIA}
+```
+public static final int AUSTRIA
+```
+
+
+Österrike
+
+### BELGIUM {#BELGIUM}
+```
+public static final int BELGIUM
+```
+
+
+Belgien
+
+### BRAZIL {#BRAZIL}
+```
+public static final int BRAZIL
+```
+
+
+Brasilien
+
+### CANADA {#CANADA}
+```
+public static final int CANADA
+```
+
+
+Kanada
+
+### CHINA {#CHINA}
+```
+public static final int CHINA
+```
+
+
+Folkrepubliken Kina
+
+### CZECH {#CZECH}
+```
+public static final int CZECH
+```
+
+
+Tjeckien
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+
+
+### DENMARK {#DENMARK}
+```
+public static final int DENMARK
+```
+
+
+Danmark
+
+### EGYPT {#EGYPT}
+```
+public static final int EGYPT
+```
+
+
+Egypten
+
+### FINLAND {#FINLAND}
+```
+public static final int FINLAND
+```
+
+
+Finland
+
+### FRANCE {#FRANCE}
+```
+public static final int FRANCE
+```
+
+
+Frankrike
+
+### GERMANY {#GERMANY}
+```
+public static final int GERMANY
+```
+
+
+Tyskland
+
+### GREECE {#GREECE}
+```
+public static final int GREECE
+```
+
+
+Grekland
+
+### HUNGARY {#HUNGARY}
+```
+public static final int HUNGARY
+```
+
+
+Ungern
+
+### ICELAND {#ICELAND}
+```
+public static final int ICELAND
+```
+
+
+Island
+
+### INDIA {#INDIA}
+```
+public static final int INDIA
+```
+
+
+Indien
+
+### IRAN {#IRAN}
+```
+public static final int IRAN
+```
+
+
+Iran
+
+### IRAQ {#IRAQ}
+```
+public static final int IRAQ
+```
+
+
+Irak
+
+### ISRAEL {#ISRAEL}
+```
+public static final int ISRAEL
+```
+
+
+Israel
+
+### ITALY {#ITALY}
+```
+public static final int ITALY
+```
+
+
+Italien
+
+### JAPAN {#JAPAN}
+```
+public static final int JAPAN
+```
+
+
+Japan
+
+### JORDAN {#JORDAN}
+```
+public static final int JORDAN
+```
+
+
+Jordanien
+
+### KUWAIT {#KUWAIT}
+```
+public static final int KUWAIT
+```
+
+
+Kuwait
+
+### LATIN_AMERIC {#LATIN-AMERIC}
+```
+public static final int LATIN_AMERIC
+```
+
+
+Latinamerika, förutom Brasilien
+
+### LEBANON {#LEBANON}
+```
+public static final int LEBANON
+```
+
+
+Libanon
+
+### LIBYA {#LIBYA}
+```
+public static final int LIBYA
+```
+
+
+Libyen
+
+### MEXICO {#MEXICO}
+```
+public static final int MEXICO
+```
+
+
+Mexiko
+
+### MOROCCO {#MOROCCO}
+```
+public static final int MOROCCO
+```
+
+
+Morocco
+
+### NETHERLANDS {#NETHERLANDS}
+```
+public static final int NETHERLANDS
+```
+
+
+Netherlands
+
+### NEW_ZEALAND {#NEW-ZEALAND}
+```
+public static final int NEW_ZEALAND
+```
+
+
+New Zealand
+
+### NORWAY {#NORWAY}
+```
+public static final int NORWAY
+```
+
+
+Norway
+
+### POLAND {#POLAND}
+```
+public static final int POLAND
+```
+
+
+Poland
+
+### PORTUGAL {#PORTUGAL}
+```
+public static final int PORTUGAL
+```
+
+
+Portugal
+
+### QATAR {#QATAR}
+```
+public static final int QATAR
+```
+
+
+Qatar
+
+### RUSSIA {#RUSSIA}
+```
+public static final int RUSSIA
+```
+
+
+Russia
+
+### SAUDI {#SAUDI}
+```
+public static final int SAUDI
+```
+
+
+Saudi Arabia
+
+### SOUTH_KOREA {#SOUTH-KOREA}
+```
+public static final int SOUTH_KOREA
+```
+
+
+SouthKorea
+
+### SPAIN {#SPAIN}
+```
+public static final int SPAIN
+```
+
+
+Spain
+
+### SWEDEN {#SWEDEN}
+```
+public static final int SWEDEN
+```
+
+
+Sweden
+
+### SWITZERLAND {#SWITZERLAND}
+```
+public static final int SWITZERLAND
+```
+
+
+Switzerland
+
+### SYRIA {#SYRIA}
+```
+public static final int SYRIA
+```
+
+
+Syria
+
+### TAIWAN {#TAIWAN}
+```
+public static final int TAIWAN
+```
+
+
+Taiwan
+
+### THAILAND {#THAILAND}
+```
+public static final int THAILAND
+```
+
+
+Thailand
+
+### TURKEY {#TURKEY}
+```
+public static final int TURKEY
+```
+
+
+Turkey
+
+### UNITED_ARAB_EMIRATES {#UNITED-ARAB-EMIRATES}
+```
+public static final int UNITED_ARAB_EMIRATES
+```
+
+
+United Arab Emirates
+
+### UNITED_KINGDOM {#UNITED-KINGDOM}
+```
+public static final int UNITED_KINGDOM
+```
+
+
+United Kingdom
+
+### USA {#USA}
+```
+public static final int USA
+```
+
+
+United States
+
+### VIET_NAM {#VIET-NAM}
+```
+public static final int VIET_NAM
+```
+
+
+Viet Nam
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/cp/_index.md
+++ b/swedish/java/com.aspose.diagram/cp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Cp
+second_title: Aspose.Diagram för Java API-referens
+description: Markerar början på ett teckenegenskapsintervall som är formaterat enligt motsvarande Char-element.
+type: docs
+weight: 104
+url: /sv/java/com.aspose.diagram/cp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Cp extends FormatTxt
+```
+
+Markerar början på ett teckenegenskapsintervall som är formaterat enligt motsvarande Char-element. Intervallet definieras fram till slutet av texten eller tills nästa.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Cp(int IX)](#Cp-int-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Cp(int IX) {#Cp-int-}
+```
+public Cp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int | Char-elementets index som detta egenskapsintervall representerar. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/customprop/_index.md
+++ b/swedish/java/com.aspose.diagram/customprop/_index.md
@@ -1,0 +1,211 @@
+---
+title: CustomProp
+second_title: Aspose.Diagram för Java API-referens
+description: CustomProp-struktur.
+type: docs
+weight: 105
+url: /sv/java/com.aspose.diagram/customprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomProp
+```
+
+CustomProp-struktur.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CustomProp()](#CustomProp--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomValue()](#getCustomValue--) | Egenskapens värde. |
+| [getName()](#getName--) | Namnet på den anpassade egenskapen. |
+| [getPropType()](#getPropType--) | Datatypen för den anpassade egenskapen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomValue(CustomValue value)](#setCustomValue-com.aspose.diagram.CustomValue-) | För beskrivningen av den här egenskapen, se [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/customprop\#getName--) |
+| [setPropType(int value)](#setPropType-int-) | För beskrivningen av den här egenskapen, se [getPropType()](../../com.aspose.diagram/customprop\#getPropType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomProp() {#CustomProp--}
+```
+public CustomProp()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomValue() {#getCustomValue--}
+```
+public CustomValue getCustomValue()
+```
+
+
+Egenskapens värde.
+
+**Returns:**
+[CustomValue](../../com.aspose.diagram/customvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Namnet på den anpassade egenskapen.
+
+**Returns:**
+java.lang.String
+### getPropType() {#getPropType--}
+```
+public int getPropType()
+```
+
+
+Datatypen för den anpassade egenskapen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomValue(CustomValue value) {#setCustomValue-com.aspose.diagram.CustomValue-}
+```
+public void setCustomValue(CustomValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getCustomValue()](../../com.aspose.diagram/customprop\#getCustomValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [CustomValue](../../com.aspose.diagram/customvalue) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/customprop\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPropType(int value) {#setPropType-int-}
+```
+public void setPropType(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPropType()](../../com.aspose.diagram/customprop\#getPropType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/custompropcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/custompropcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: CustomPropCollection
+second_title: Aspose.Diagram för Java API-referens
+description: CustomProps-samling.
+type: docs
+weight: 106
+url: /sv/java/com.aspose.diagram/custompropcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class CustomPropCollection extends Collection
+```
+
+CustomProps-samling.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CustomPropCollection()](#CustomPropCollection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(CustomProp customProp)](#add-com.aspose.diagram.CustomProp-) | Lägg till CustomProp‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på angivet index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(CustomProp customProp)](#remove-com.aspose.diagram.CustomProp-) | Ta bort CustomProp‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomPropCollection() {#CustomPropCollection--}
+```
+public CustomPropCollection()
+```
+
+
+Konstruktor.
+
+### add(CustomProp customProp) {#add-com.aspose.diagram.CustomProp-}
+```
+public int add(CustomProp customProp)
+```
+
+
+Lägg till CustomProp‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public CustomProp get(int index)
+```
+
+
+Hämtar elementet på angivet index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[CustomProp](../../com.aspose.diagram/customprop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(CustomProp customProp) {#remove-com.aspose.diagram.CustomProp-}
+```
+public void remove(CustomProp customProp)
+```
+
+
+Ta bort CustomProp‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| customProp | [CustomProp](../../com.aspose.diagram/customprop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/customvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/customvalue/_index.md
@@ -1,0 +1,236 @@
+---
+title: CustomValue
+second_title: Aspose.Diagram för Java API-referens
+description: Egenskapens värde.
+type: docs
+weight: 107
+url: /sv/java/com.aspose.diagram/customvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class CustomValue
+```
+
+Egenskapens värde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [CustomValue()](#CustomValue--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValueBool()](#getValueBool--) | Booleskt värde. |
+| [getValueDate()](#getValueDate--) | Datum- och tidsvärde. |
+| [getValueNumber()](#getValueNumber--) | Talvärde. |
+| [getValueString()](#getValueString--) | Strängvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValueBool(boolean value)](#setValueBool-boolean-) | För beskrivningen av denna egenskap, se [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--) |
+| [setValueDate(DateTime value)](#setValueDate-com.aspose.diagram.DateTime-) | För beskrivningen av den här egenskapen, se [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--) |
+| [setValueNumber(double value)](#setValueNumber-double-) | För beskrivningen av den här egenskapen, se [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--) |
+| [setValueString(String value)](#setValueString-java.lang.String-) | För beskrivningen av den här egenskapen, se [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CustomValue() {#CustomValue--}
+```
+public CustomValue()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValueBool() {#getValueBool--}
+```
+public boolean getValueBool()
+```
+
+
+Booleskt värde.
+
+**Returns:**
+boolean
+### getValueDate() {#getValueDate--}
+```
+public DateTime getValueDate()
+```
+
+
+Datum- och tidsvärde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getValueNumber() {#getValueNumber--}
+```
+public double getValueNumber()
+```
+
+
+Talvärde.
+
+**Returns:**
+double
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+Strängvärde.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValueBool(boolean value) {#setValueBool-boolean-}
+```
+public void setValueBool(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValueBool()](../../com.aspose.diagram/customvalue\#getValueBool--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValueDate(DateTime value) {#setValueDate-com.aspose.diagram.DateTime-}
+```
+public void setValueDate(DateTime value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValueDate()](../../com.aspose.diagram/customvalue\#getValueDate--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setValueNumber(double value) {#setValueNumber-double-}
+```
+public void setValueNumber(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValueNumber()](../../com.aspose.diagram/customvalue\#getValueNumber--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setValueString(String value) {#setValueString-java.lang.String-}
+```
+public void setValueString(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValueString()](../../com.aspose.diagram/customvalue\#getValueString--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datacolumn/_index.md
+++ b/swedish/java/com.aspose.diagram/datacolumn/_index.md
@@ -1,0 +1,488 @@
+---
+title: DataColumn
+second_title: Aspose.Diagram för Java API-referens
+description: Definierar hur en datakolumn visas i fönstret Externa data i Visios användargränssnitt och kvalificerar data i kolumnen genom att ange dess datatyp och formatering.
+type: docs
+weight: 108
+url: /sv/java/com.aspose.diagram/datacolumn/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataColumn
+```
+
+Definierar hur en datakolumn visas i fönstret Externa data i Visios användargränssnitt och kvalificerar data i kolumnen genom att ange dess datatyp och formatering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DataColumn()](#DataColumn--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Kalender-ID för datakolumnen. |
+| [getClass()](#getClass--) |  |
+| [getColumnNameID()](#getColumnNameID--) | Externt namn för datakolumnen. |
+| [getCurrency()](#getCurrency--) | Valuta-ID för datakolumnen. |
+| [getDataType()](#getDataType--) | Typ av data i datakolumnen. |
+| [getDegree()](#getDegree--) | Anger graden (potensen) för enheterna, till exempel kvadrat eller kub. |
+| [getDisplayOrder()](#getDisplayOrder--) | Definierar visningspositionen för datakolumnen i fönstret Extern data, från den vänstra kolumnen (0) till den högra kolumnen (största värdet). |
+| [getDisplayWidth()](#getDisplayWidth--) | Bredd på datakolumnen i fönstret Extern data. |
+| [getHyperlink()](#getHyperlink--) | Om datakolumnen skapar en hyperlänk i en form när formen är länkad till data. |
+| [getLabel()](#getLabel--) | Etikett för datakolumnen. |
+| [getLangID()](#getLangID--) | Språk-ID för datakolumnen |
+| [getMapped()](#getMapped--) | Anger om kolumnen är synlig i fönstret Extern data. |
+| [getName()](#getName--) | Internt namn för datakolumnen. |
+| [getOrigLabel()](#getOrigLabel--) | Kolumnetikett som returneras till Visio av det underliggande ADO-gränssnittet. |
+| [getUnitType()](#getUnitType--) | Enhetstyp för data i datakolumnen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCalendar(int value)](#setCalendar-int-) | För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getCalendar() & 0xFFFF)\\} |
+| [setColumnNameID(String value)](#setColumnNameID-java.lang.String-) | För beskrivningen av denna egenskap, se [getColumnNameID()](../../com.aspose.diagram/datacolumn\\#getColumnNameID--) |
+| [setCurrency(int value)](#setCurrency-int-) | För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getCurrency() & 0xFFFF)\\} |
+| [setDataType(int value)](#setDataType-int-) | För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getDataType() & 0xFFFF)\\} |
+| [setDegree(long value)](#setDegree-long-) | För beskrivningen av denna egenskap, se [getDegree()](../../com.aspose.diagram/datacolumn\\#getDegree--) |
+| [setDisplayOrder(long value)](#setDisplayOrder-long-) | För beskrivningen av denna egenskap, se [getDisplayOrder()](../../com.aspose.diagram/datacolumn\\#getDisplayOrder--) |
+| [setDisplayWidth(long value)](#setDisplayWidth-long-) | För beskrivningen av denna egenskap, se [getDisplayWidth()](../../com.aspose.diagram/datacolumn\\#getDisplayWidth--) |
+| [setHyperlink(int value)](#setHyperlink-int-) | För beskrivningen av denna egenskap, se [getHyperlink()](../../com.aspose.diagram/datacolumn\\#getHyperlink--) |
+| [setLabel(String value)](#setLabel-java.lang.String-) | För beskrivningen av denna egenskap, se [getLabel()](../../com.aspose.diagram/datacolumn\\#getLabel--) |
+| [setLangID(long value)](#setLangID-long-) | För beskrivningen av denna egenskap, se [getLangID()](../../com.aspose.diagram/datacolumn\\#getLangID--) |
+| [setMapped(int value)](#setMapped-int-) | För beskrivningen av denna egenskap, se [getMapped()](../../com.aspose.diagram/datacolumn\\#getMapped--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/datacolumn\\#getName--) |
+| [setOrigLabel(String value)](#setOrigLabel-java.lang.String-) | För beskrivningen av denna egenskap, se [getOrigLabel()](../../com.aspose.diagram/datacolumn\\#getOrigLabel--) |
+| [setUnitType(String value)](#setUnitType-java.lang.String-) | För beskrivningen av denna egenskap, se [getUnitType()](../../com.aspose.diagram/datacolumn\\#getUnitType--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataColumn() {#DataColumn--}
+```
+public DataColumn()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public int getCalendar()
+```
+
+
+Kalender-ID för datakolumnen.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnNameID() {#getColumnNameID--}
+```
+public String getColumnNameID()
+```
+
+
+Externt namn på datakolumnen. Visas i rubrikerna i fönstret Extern data och i etiketter i datagrafik.
+
+**Returns:**
+java.lang.String
+### getCurrency() {#getCurrency--}
+```
+public int getCurrency()
+```
+
+
+Valuta-ID för datakolumnen.
+
+**Returns:**
+int
+### getDataType() {#getDataType--}
+```
+public int getDataType()
+```
+
+
+Typ av data i datakolumnen.
+
+**Returns:**
+int
+### getDegree() {#getDegree--}
+```
+public long getDegree()
+```
+
+
+Anger graden (potensen) för enheterna, till exempel kvadrat eller kub. Standardvärdet (attributet saknas) är 1.
+
+**Returns:**
+long
+### getDisplayOrder() {#getDisplayOrder--}
+```
+public long getDisplayOrder()
+```
+
+
+Definierar visningspositionen för datakolumnen i fönstret Extern data, från den vänstra kolumnen (0) till den högra kolumnen (största värdet).
+
+**Returns:**
+long
+### getDisplayWidth() {#getDisplayWidth--}
+```
+public long getDisplayWidth()
+```
+
+
+Bredd på datakolumnen i fönstret Extern data.
+
+**Returns:**
+long
+### getHyperlink() {#getHyperlink--}
+```
+public int getHyperlink()
+```
+
+
+Om datakolumnen skapar en hyperlänk i en form när formen är länkad till data.
+
+**Returns:**
+int
+### getLabel() {#getLabel--}
+```
+public String getLabel()
+```
+
+
+Etikett för datakolumnen.
+
+**Returns:**
+java.lang.String
+### getLangID() {#getLangID--}
+```
+public long getLangID()
+```
+
+
+Språk-ID för datakolumnen
+
+**Returns:**
+long
+### getMapped() {#getMapped--}
+```
+public int getMapped()
+```
+
+
+Anger om kolumnen är synlig i fönstret Extern data. True (1) betyder att kolumnen ska vara synlig; false (0) betyder att kolumnen inte ska vara synlig. Standardvärdet (attributet saknas) är att kolumnen är synlig.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Internt namn på datakolumnen. Används som radnamn för shape-dataobjektet (anpassad egenskap) som läggs till en form när formen länkas till en datarad.
+
+**Returns:**
+java.lang.String
+### getOrigLabel() {#getOrigLabel--}
+```
+public String getOrigLabel()
+```
+
+
+Kolumnetikett som returneras till Visio av det underliggande ADO-gränssnittet.
+
+**Returns:**
+java.lang.String
+### getUnitType() {#getUnitType--}
+```
+public String getUnitType()
+```
+
+
+Enhetstyp för data i datakolumnen.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCalendar(int value) {#setCalendar-int-}
+```
+public void setCalendar(int value)
+```
+
+
+För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getCalendar() & 0xFFFF)\\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setColumnNameID(String value) {#setColumnNameID-java.lang.String-}
+```
+public void setColumnNameID(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getColumnNameID()](../../com.aspose.diagram/datacolumn\\#getColumnNameID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setCurrency(int value) {#setCurrency-int-}
+```
+public void setCurrency(int value)
+```
+
+
+För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getCurrency() & 0xFFFF)\\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDataType(int value) {#setDataType-int-}
+```
+public void setDataType(int value)
+```
+
+
+För beskrivningen av denna egenskap, se \\{@link DataColumn\\#(getDataType() & 0xFFFF)\\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDegree(long value) {#setDegree-long-}
+```
+public void setDegree(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDegree()](../../com.aspose.diagram/datacolumn\\#getDegree--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setDisplayOrder(long value) {#setDisplayOrder-long-}
+```
+public void setDisplayOrder(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDisplayOrder()](../../com.aspose.diagram/datacolumn\\#getDisplayOrder--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setDisplayWidth(long value) {#setDisplayWidth-long-}
+```
+public void setDisplayWidth(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDisplayWidth()](../../com.aspose.diagram/datacolumn\\#getDisplayWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setHyperlink(int value) {#setHyperlink-int-}
+```
+public void setHyperlink(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHyperlink()](../../com.aspose.diagram/datacolumn\\#getHyperlink--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLabel(String value) {#setLabel-java.lang.String-}
+```
+public void setLabel(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLabel()](../../com.aspose.diagram/datacolumn\\#getLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setLangID(long value) {#setLangID-long-}
+```
+public void setLangID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLangID()](../../com.aspose.diagram/datacolumn\\#getLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setMapped(int value) {#setMapped-int-}
+```
+public void setMapped(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getMapped()](../../com.aspose.diagram/datacolumn\\#getMapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/datacolumn\\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setOrigLabel(String value) {#setOrigLabel-java.lang.String-}
+```
+public void setOrigLabel(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getOrigLabel()](../../com.aspose.diagram/datacolumn\\#getOrigLabel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setUnitType(String value) {#setUnitType-java.lang.String-}
+```
+public void setUnitType(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUnitType()](../../com.aspose.diagram/datacolumn\\#getUnitType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datacolumncollection/_index.md
+++ b/swedish/java/com.aspose.diagram/datacolumncollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataColumnCollection
+second_title: Aspose.Diagram för Java API-referens
+description: DataColumn-samling.
+type: docs
+weight: 109
+url: /sv/java/com.aspose.diagram/datacolumncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataColumnCollection extends Collection
+```
+
+DataColumn-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(DataColumn dataColumn)](#add-com.aspose.diagram.DataColumn-) | Lägg till dataColumn i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getSortAsc()](#getSortAsc--) | Anger om SortColumn-kolumnen ska sorteras i stigande (1) eller fallande (0) ordning. |
+| [getSortColumn()](#getSortColumn--) | Kolumnen som datan ska sorteras efter. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataColumn dataColumn)](#remove-com.aspose.diagram.DataColumn-) | Ta bort dataColumn från samlingen. |
+| [setSortAsc(int value)](#setSortAsc-int-) | För beskrivningen av denna egenskap, se [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--) |
+| [setSortColumn(String value)](#setSortColumn-java.lang.String-) | För beskrivningen av denna egenskap, se [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataColumn dataColumn) {#add-com.aspose.diagram.DataColumn-}
+```
+public int add(DataColumn dataColumn)
+```
+
+
+Lägg till dataColumn i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataColumn get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[DataColumn](../../com.aspose.diagram/datacolumn) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getSortAsc() {#getSortAsc--}
+```
+public int getSortAsc()
+```
+
+
+Anger om SortColumn-kolumnen ska sorteras i stigande (1) eller fallande (0) ordning.
+
+**Returns:**
+int
+### getSortColumn() {#getSortColumn--}
+```
+public String getSortColumn()
+```
+
+
+Kolumnen som datan ska sorteras efter.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataColumn dataColumn) {#remove-com.aspose.diagram.DataColumn-}
+```
+public void remove(DataColumn dataColumn)
+```
+
+
+Ta bort dataColumn från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataColumn | [DataColumn](../../com.aspose.diagram/datacolumn) |  |
+
+### setSortAsc(int value) {#setSortAsc-int-}
+```
+public void setSortAsc(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSortAsc()](../../com.aspose.diagram/datacolumncollection\#getSortAsc--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSortColumn(String value) {#setSortColumn-java.lang.String-}
+```
+public void setSortColumn(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSortColumn()](../../com.aspose.diagram/datacolumncollection\#getSortColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dataconnection/_index.md
+++ b/swedish/java/com.aspose.diagram/dataconnection/_index.md
@@ -1,0 +1,288 @@
+---
+title: DataConnection
+second_title: Aspose.Diagram för Java API-referens
+description: Abstraherar kommunikationen mellan ett eller flera DataRecordset-element och en icke-XML-datakälla.
+type: docs
+weight: 110
+url: /sv/java/com.aspose.diagram/dataconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataConnection
+```
+
+Abstraherar kommunikationen mellan ett eller flera DataRecordset-element och en icke-XML-datakälla.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DataConnection()](#DataConnection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlwaysUseConnectionFile()](#getAlwaysUseConnectionFile--) | Standardvärdet är falskt. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | Kommandosträngen som används för att fråga datakällan. |
+| [getConnectionString()](#getConnectionString--) | Anslutningssträngen som definierar de parametrar som behövs för att ansluta till en datakälla. |
+| [getFileName()](#getFileName--) | Namnet på anslutningsfilen. |
+| [getID()](#getID--) | ID:t som tilldelas av Visio för en given anslutning, unikt inom dokumentet. |
+| [getTimeout()](#getTimeout--) | Väntetid i minuter när du försöker etablera en anslutning innan försöket avbryts. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlwaysUseConnectionFile(int value)](#setAlwaysUseConnectionFile-int-) | För beskrivningen av denna egenskap, se [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--) |
+| [setCommand(String value)](#setCommand-java.lang.String-) | För beskrivningen av denna egenskap, se [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--) |
+| [setConnectionString(String value)](#setConnectionString-java.lang.String-) | För beskrivningen av denna egenskap, se [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--) |
+| [setFileName(String value)](#setFileName-java.lang.String-) | För beskrivningen av denna egenskap, se [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--) |
+| [setID(long value)](#setID-long-) | För beskrivningen av denna egenskap, se \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\} |
+| [setTimeout(long value)](#setTimeout-long-) | För beskrivningen av denna egenskap, se [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataConnection() {#DataConnection--}
+```
+public DataConnection()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlwaysUseConnectionFile() {#getAlwaysUseConnectionFile--}
+```
+public int getAlwaysUseConnectionFile()
+```
+
+
+Standardvärdet är false. Se Anmärkningar för mer information.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+Kommandosträngen som används för att fråga datakällan.
+
+**Returns:**
+java.lang.String
+### getConnectionString() {#getConnectionString--}
+```
+public String getConnectionString()
+```
+
+
+Anslutningssträngen som definierar de parametrar som behövs för att ansluta till en datakälla.
+
+**Returns:**
+java.lang.String
+### getFileName() {#getFileName--}
+```
+public String getFileName()
+```
+
+
+Namnet på anslutningsfilen. Se Anmärkningar för mer information.
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+ID:t som tilldelas av Visio för en given anslutning, unikt inom dokumentet.
+
+**Returns:**
+long
+### getTimeout() {#getTimeout--}
+```
+public long getTimeout()
+```
+
+
+Väntetid i minuter när du försöker etablera en anslutning innan försöket avbryts.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlwaysUseConnectionFile(int value) {#setAlwaysUseConnectionFile-int-}
+```
+public void setAlwaysUseConnectionFile(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAlwaysUseConnectionFile()](../../com.aspose.diagram/dataconnection\#getAlwaysUseConnectionFile--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCommand()](../../com.aspose.diagram/dataconnection\#getCommand--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setConnectionString(String value) {#setConnectionString-java.lang.String-}
+```
+public void setConnectionString(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getConnectionString()](../../com.aspose.diagram/dataconnection\#getConnectionString--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFileName(String value) {#setFileName-java.lang.String-}
+```
+public void setFileName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFileName()](../../com.aspose.diagram/dataconnection\#getFileName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataConnection\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setTimeout(long value) {#setTimeout-long-}
+```
+public void setTimeout(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimeout()](../../com.aspose.diagram/dataconnection\#getTimeout--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dataconnectioncollection/_index.md
+++ b/swedish/java/com.aspose.diagram/dataconnectioncollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: DataConnectionCollection
+second_title: Aspose.Diagram för Java API-referens
+description: DataConnection-samling.
+type: docs
+weight: 111
+url: /sv/java/com.aspose.diagram/dataconnectioncollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataConnectionCollection extends Collection
+```
+
+DataConnection-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(DataConnection dataConnection)](#add-com.aspose.diagram.DataConnection-) | Lägg till dataConnection i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getDataConnection(long ID)](#getDataConnection-long-) | Hämtar elementet med angivet ID. |
+| [getNextID()](#getNextID--) | Nästa tillgängliga ID för nya anslutningar. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataConnection dataConnection)](#remove-com.aspose.diagram.DataConnection-) | Ta bort dataConnection från samlingen. |
+| [setNextID(long value)](#setNextID-long-) | För beskrivningen av den här egenskapen, se \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\} |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataConnection dataConnection) {#add-com.aspose.diagram.DataConnection-}
+```
+public int add(DataConnection dataConnection)
+```
+
+
+Lägg till dataConnection i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataConnection get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getDataConnection(long ID) {#getDataConnection-long-}
+```
+public DataConnection getDataConnection(long ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | long | ID för DataConnectionUInt32. |
+
+**Returns:**
+[DataConnection](../../com.aspose.diagram/dataconnection) - DataConnection [DataConnection](../../com.aspose.diagram/dataconnection).
+### getNextID() {#getNextID--}
+```
+public long getNextID()
+```
+
+
+Nästa tillgängliga ID för nya anslutningar.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataConnection dataConnection) {#remove-com.aspose.diagram.DataConnection-}
+```
+public void remove(DataConnection dataConnection)
+```
+
+
+Ta bort dataConnection från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataConnection | [DataConnection](../../com.aspose.diagram/dataconnection) |  |
+
+### setNextID(long value) {#setNextID-long-}
+```
+public void setNextID(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se \{@link DataConnectionCollection\#(getNextID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dataconnectiontype/_index.md
+++ b/swedish/java/com.aspose.diagram/dataconnectiontype/_index.md
@@ -1,0 +1,165 @@
+---
+title: DataConnectionType
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att konfigurera alternativ för anslutningarna till databasen.
+type: docs
+weight: 112
+url: /sv/java/com.aspose.diagram/dataconnectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DataConnectionType
+```
+
+Tillåter att konfigurera alternativ för anslutningarna till databasen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ODBC](#ODBC) | Användning System.Data.Odbc.OdbcConnection. |
+| [QLEDB](#QLEDB) | Användning System.Data.OleDb.OleDbConnection. |
+| [SQL](#SQL) | Användning System.Data.SqlClient.SqlConnection. |
+| [UNKNOWN](#UNKNOWN) | Okänd typ av anslutning. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ODBC {#ODBC}
+```
+public static final int ODBC
+```
+
+
+Användning System.Data.Odbc.OdbcConnection.
+
+### QLEDB {#QLEDB}
+```
+public static final int QLEDB
+```
+
+
+Användning System.Data.OleDb.OleDbConnection.
+
+### SQL {#SQL}
+```
+public static final int SQL
+```
+
+
+Användning System.Data.SqlClient.SqlConnection.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Okänd typ av anslutning.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datarecordset/_index.md
+++ b/swedish/java/com.aspose.diagram/datarecordset/_index.md
@@ -1,0 +1,557 @@
+---
+title: DataRecordSet
+second_title: Aspose.Diagram för Java API-referens
+description: Lagrar format, uppdateringar och exponerar data som hämtas från en databas i Microsoft Visio.
+type: docs
+weight: 113
+url: /sv/java/com.aspose.diagram/datarecordset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DataRecordSet
+```
+
+Lagrar, formaterar, uppdaterar och exponerar data som hämtats från en databas i Microsoft Visio.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DataRecordSet()](#DataRecordSet--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getADOData()](#getADOData--) | Innehåller XML som följer ADO:s klassiska XML-schema för ett ADO‑recordset och som beskriver data i data‑recordsetet. |
+| [getAutoLinkComparison()](#getAutoLinkComparison--) | Definierar en regel som jämför en kolumn i det överordnade DataRecordset-elementet med ett formdataobjekt från den senaste lyckade automatiska länkningsåtgärden som utförts i användargränssnittet. |
+| [getChecksum()](#getChecksum--) | Ett kontrollsummavärde, genererat av Visio, och baserat på egenskaper för data‑recordsetet. |
+| [getClass()](#getClass--) |  |
+| [getCommand()](#getCommand--) | Kommandosträngen som används för att fråga data från datakällan. |
+| [getConnectionID()](#getConnectionID--) | Anslutnings‑ID för det associerade DataConnection‑objektet. |
+| [getDataColumns()](#getDataColumns--) | Innehåller alla DataColumn‑element i ett data‑recordset. |
+| [getID()](#getID--) | Data‑recordset‑ID, unikt inom dokumentet. |
+| [getName()](#getName--) | Visningsnamnet (eller "vänliga" namnet) för data‑recordsetet. |
+| [getNextRowID()](#getNextRowID--) | Nästa tillgängliga Visio‑rad‑ID. |
+| [getOptions()](#getOptions--) | Alternativ att tillämpa på data‑recordsetet. |
+| [getPrimaryKeys()](#getPrimaryKeys--) | Identifierar en eller flera primärnyckelkolumner i data‑recordsetet. |
+| [getRefreshConflicts()](#getRefreshConflicts--) | Anger en rad i data‑recordsetet som är länkad till en form som är i konflikt efter att data‑recordsetet har uppdaterats. |
+| [getRefreshInterval()](#getRefreshInterval--) | Hur ofta (i minuter) Visio automatiskt uppdaterar data‑recordsetet. |
+| [getRefreshNoReconciliationUI()](#getRefreshNoReconciliationUI--) | Om användargränssnittet för dataåterställning ska inaktiveras. |
+| [getRefreshOverwriteAll()](#getRefreshOverwriteAll--) | Om användarändringar av formdataobjekt i former som är länkade till data ska skrivas över när data‑recordsetet uppdateras. |
+| [getReplaceLinks()](#getReplaceLinks--) | Definierar hur länkar mellan former och data behandlas när former kopieras eller klipps. 1 för att ersätta befintliga länkar i målformen. 0 för att behålla befintliga länkar i målformen. |
+| [getRowMaps()](#getRowMaps--) | Mappar en rad i data‑recordsetet till en form. |
+| [getRowOrder()](#getRowOrder--) | Om ordningen på raderna i data‑recordsetet ska användas som primärnyckel. |
+| [getTimeRefreshed()](#getTimeRefreshed--) | Datum och tid då data‑recordsetet senast uppdaterades. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refresh(int connectionType)](#refresh-int-) | Kör frågesträngen som är associerad med den anslutna (icke‑XML‑baserade) DataRecordset och uppdaterar länkade former med ny data från datakällan som returneras av frågan. |
+| [setADOData(String value)](#setADOData-java.lang.String-) | För beskrivningen av denna egenskap, se [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--) |
+| [setChecksum(long value)](#setChecksum-long-) | För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\} |
+| [setCommand(String value)](#setCommand-java.lang.String-) | För beskrivningen av denna egenskap, se [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--) |
+| [setConnectionID(long value)](#setConnectionID-long-) | För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\} |
+| [setID(long value)](#setID-long-) | För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\} |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/datarecordset\#getName--) |
+| [setNextRowID(long value)](#setNextRowID-long-) | För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\} |
+| [setOptions(int value)](#setOptions-int-) | För beskrivningen av denna egenskap, se [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--) |
+| [setRefreshInterval(long value)](#setRefreshInterval-long-) | För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\} |
+| [setRefreshNoReconciliationUI(int value)](#setRefreshNoReconciliationUI-int-) | För beskrivningen av denna egenskap, se [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--) |
+| [setRefreshOverwriteAll(int value)](#setRefreshOverwriteAll-int-) | För beskrivningen av denna egenskap, se [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--) |
+| [setReplaceLinks(int value)](#setReplaceLinks-int-) | För beskrivningen av denna egenskap, se [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--) |
+| [setRowOrder(int value)](#setRowOrder-int-) | För beskrivningen av denna egenskap, se [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--) |
+| [setTimeRefreshed(DateTime value)](#setTimeRefreshed-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DataRecordSet() {#DataRecordSet--}
+```
+public DataRecordSet()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getADOData() {#getADOData--}
+```
+public String getADOData()
+```
+
+
+Innehåller XML som följer ADO:s klassiska XML-schema för ett ADO‑recordset och som beskriver data i data‑recordsetet.
+
+**Returns:**
+java.lang.String
+### getAutoLinkComparison() {#getAutoLinkComparison--}
+```
+public AutoLinkComparison getAutoLinkComparison()
+```
+
+
+Definierar en regel som jämför en kolumn i det överordnade DataRecordset-elementet med ett formdataobjekt från den senaste lyckade automatiska länkningsåtgärden som utförts i användargränssnittet.
+
+**Returns:**
+[AutoLinkComparison](../../com.aspose.diagram/autolinkcomparison)
+### getChecksum() {#getChecksum--}
+```
+public long getChecksum()
+```
+
+
+Ett kontrollsummevärde, genererat av Visio, och baserat på data-recordset-egenskaper. Sätt detta attribut till 0; Visio beräknar om detta värde vid körning.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCommand() {#getCommand--}
+```
+public String getCommand()
+```
+
+
+Kommandosträngen som används för att fråga data från datakällan.
+
+**Returns:**
+java.lang.String
+### getConnectionID() {#getConnectionID--}
+```
+public long getConnectionID()
+```
+
+
+Anslutnings-ID för det associerade DataConnection-objektet. Finns inte för XML-datakällor.
+
+**Returns:**
+long
+### getDataColumns() {#getDataColumns--}
+```
+public DataColumnCollection getDataColumns()
+```
+
+
+Innehåller alla DataColumn‑element i ett data‑recordset.
+
+**Returns:**
+[DataColumnCollection](../../com.aspose.diagram/datacolumncollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Data‑recordset‑ID, unikt inom dokumentet.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Visningsnamnet (eller "vänliga" namnet) för data‑recordsetet.
+
+**Returns:**
+java.lang.String
+### getNextRowID() {#getNextRowID--}
+```
+public long getNextRowID()
+```
+
+
+Nästa tillgängliga Visio‑rad‑ID.
+
+**Returns:**
+long
+### getOptions() {#getOptions--}
+```
+public int getOptions()
+```
+
+
+Alternativ att tillämpa på datarecordsetet. Möjliga värden kan vara en kombination av en eller flera av de som visas i följande tabell.
+
+**Returns:**
+int
+### getPrimaryKeys() {#getPrimaryKeys--}
+```
+public ArrayList<String> getPrimaryKeys()
+```
+
+
+Identifierar en eller flera primärnyckelkolumner i data‑recordsetet.
+
+**Returns:**
+java.util.ArrayList<java.lang.String>
+### getRefreshConflicts() {#getRefreshConflicts--}
+```
+public RowCollection getRefreshConflicts()
+```
+
+
+Anger en rad i datarecordsetet som är länkad till en form som är i konflikt efter att datarecordsetet har uppdaterats. RowID - Anger en rad i datarecordsetet som är länkad till en form som är i konflikt efter att datarecordsetet har uppdaterats. ShapeID - Formens ID för den form som är inblandad i konflikten. PageID - Sidans ID för den form som är inblandad i konflikten.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRefreshInterval() {#getRefreshInterval--}
+```
+public long getRefreshInterval()
+```
+
+
+Hur ofta (i minuter) Visio uppdaterar datarecordsetet automatiskt. Detta värde måste vara 1 eller större.
+
+**Returns:**
+long
+### getRefreshNoReconciliationUI() {#getRefreshNoReconciliationUI--}
+```
+public int getRefreshNoReconciliationUI()
+```
+
+
+Om dataåterställnings-användargränssnittet ska vara inaktiverat. True (1) för att inaktivera användargränssnittet (UI). False (0) för att aktivera UI.
+
+**Returns:**
+int
+### getRefreshOverwriteAll() {#getRefreshOverwriteAll--}
+```
+public int getRefreshOverwriteAll()
+```
+
+
+Om användarändringar av formdataobjekt i former som är länkade till data ska skrivas över när data‑recordsetet uppdateras.
+
+**Returns:**
+int
+### getReplaceLinks() {#getReplaceLinks--}
+```
+public int getReplaceLinks()
+```
+
+
+Definierar hur shape-data-länkar behandlas när former kopieras eller klipps. 1 för att ersätta befintliga länkar i målformen. 0 för att behålla befintliga länkar i målformen. Om detta attribut saknas frågar Visio användaren om länkar ska ersättas vid kopiering eller klippning.
+
+**Returns:**
+int
+### getRowMaps() {#getRowMaps--}
+```
+public RowCollection getRowMaps()
+```
+
+
+Mappar en data-recordset-rad till en form. RowID - Radens ID, unik inom datarecordsetet. ShapeID - Formens ID för den form som är länkad till data i data-recordset-raden identifierad av RowID. PageID - Sidans ID för den form som är länkad till data i data-recordset-raden identifierad av RowID.
+
+**Returns:**
+[RowCollection](../../com.aspose.diagram/rowcollection)
+### getRowOrder() {#getRowOrder--}
+```
+public int getRowOrder()
+```
+
+
+Om ordningen på raderna i datarecordsetet ska användas som primärnyckel. True (1) om rad-ID:n bestäms av radordning. False (0) om rad-ID:n bestäms av värden i primärnyckelkolumnen/kolumnerna i datarecordsetet.
+
+**Returns:**
+int
+### getTimeRefreshed() {#getTimeRefreshed--}
+```
+public DateTime getTimeRefreshed()
+```
+
+
+Datum och tid då data‑recordsetet senast uppdaterades.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refresh(int connectionType) {#refresh-int-}
+```
+public void refresh(int connectionType)
+```
+
+
+Kör frågesträngen som är associerad med den anslutna (icke‑XML‑baserade) DataRecordset och uppdaterar länkade former med ny data från datakällan som returneras av frågan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| connectionType | int | Typen av leverantör som kommer att användas för connectionAspose.Diagram.Manipulation.DataConnectionType. |
+
+### setADOData(String value) {#setADOData-java.lang.String-}
+```
+public void setADOData(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getADOData()](../../com.aspose.diagram/datarecordset\#getADOData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setChecksum(long value) {#setChecksum-long-}
+```
+public void setChecksum(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getChecksum() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setCommand(String value) {#setCommand-java.lang.String-}
+```
+public void setCommand(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCommand()](../../com.aspose.diagram/datarecordset\#getCommand--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setConnectionID(long value) {#setConnectionID-long-}
+```
+public void setConnectionID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getConnectionID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/datarecordset\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNextRowID(long value) {#setNextRowID-long-}
+```
+public void setNextRowID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getNextRowID() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setOptions(int value) {#setOptions-int-}
+```
+public void setOptions(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getOptions()](../../com.aspose.diagram/datarecordset\#getOptions--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setRefreshInterval(long value) {#setRefreshInterval-long-}
+```
+public void setRefreshInterval(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link DataRecordSet\#(getRefreshInterval() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setRefreshNoReconciliationUI(int value) {#setRefreshNoReconciliationUI-int-}
+```
+public void setRefreshNoReconciliationUI(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRefreshNoReconciliationUI()](../../com.aspose.diagram/datarecordset\#getRefreshNoReconciliationUI--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setRefreshOverwriteAll(int value) {#setRefreshOverwriteAll-int-}
+```
+public void setRefreshOverwriteAll(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRefreshOverwriteAll()](../../com.aspose.diagram/datarecordset\#getRefreshOverwriteAll--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setReplaceLinks(int value) {#setReplaceLinks-int-}
+```
+public void setReplaceLinks(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getReplaceLinks()](../../com.aspose.diagram/datarecordset\#getReplaceLinks--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setRowOrder(int value) {#setRowOrder-int-}
+```
+public void setRowOrder(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRowOrder()](../../com.aspose.diagram/datarecordset\#getRowOrder--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTimeRefreshed(DateTime value) {#setTimeRefreshed-com.aspose.diagram.DateTime-}
+```
+public void setTimeRefreshed(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimeRefreshed()](../../com.aspose.diagram/datarecordset\#getTimeRefreshed--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datarecordsetcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/datarecordsetcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: DataRecordSetCollection
+second_title: Aspose.Diagram för Java API-referens
+description: DataRecordSet-samling.
+type: docs
+weight: 114
+url: /sv/java/com.aspose.diagram/datarecordsetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class DataRecordSetCollection extends Collection
+```
+
+DataRecordSet-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(DataRecordSet dataRecordSet)](#add-com.aspose.diagram.DataRecordSet-) | Lägg till dataRecordSet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getActiveRecordsetId()](#getActiveRecordsetId--) | ActiveRecordsetID |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getNextId()](#getNextId--) | NextID |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(DataRecordSet dataRecordSet)](#remove-com.aspose.diagram.DataRecordSet-) | Ta bort dataRecordSet från samlingen. |
+| [setActiveRecordsetId(String value)](#setActiveRecordsetId-java.lang.String-) | För beskrivningen av den här egenskapen, se [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--) |
+| [setNextId(String value)](#setNextId-java.lang.String-) | För beskrivningen av den här egenskapen, se [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DataRecordSet dataRecordSet) {#add-com.aspose.diagram.DataRecordSet-}
+```
+public int add(DataRecordSet dataRecordSet)
+```
+
+
+Lägg till dataRecordSet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public DataRecordSet get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[DataRecordSet](../../com.aspose.diagram/datarecordset) - 
+### getActiveRecordsetId() {#getActiveRecordsetId--}
+```
+public String getActiveRecordsetId()
+```
+
+
+ActiveRecordsetID
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getNextId() {#getNextId--}
+```
+public String getNextId()
+```
+
+
+NextID
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(DataRecordSet dataRecordSet) {#remove-com.aspose.diagram.DataRecordSet-}
+```
+public void remove(DataRecordSet dataRecordSet)
+```
+
+
+Ta bort dataRecordSet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dataRecordSet | [DataRecordSet](../../com.aspose.diagram/datarecordset) |  |
+
+### setActiveRecordsetId(String value) {#setActiveRecordsetId-java.lang.String-}
+```
+public void setActiveRecordsetId(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getActiveRecordsetId()](../../com.aspose.diagram/datarecordsetcollection\#getActiveRecordsetId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNextId(String value) {#setNextId-java.lang.String-}
+```
+public void setNextId(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNextId()](../../com.aspose.diagram/datarecordsetcollection\#getNextId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datetime/_index.md
+++ b/swedish/java/com.aspose.diagram/datetime/_index.md
@@ -1,0 +1,510 @@
+---
+title: DateTime
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ett ögonblick i tiden som vanligtvis uttrycks som ett datum och en tid på dagen.
+type: docs
+weight: 115
+url: /sv/java/com.aspose.diagram/datetime/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateTime
+```
+
+Representerar ett ögonblick i tiden, vanligtvis uttryckt som ett datum och en tid på dagen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DateTime(int year, int month, int day)](#DateTime-int-int-int-) | Initierar en ny instans av DateTime-objektet med det angivna året, månaden och dagen. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second)](#DateTime-int-int-int-int-int-int-) | Initierar en ny instans av DateTime-objektet med det angivna året, månaden, dagen, timmen, minuten och sekunden. |
+| [DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)](#DateTime-int-int-int-int-int-int-int-) | Initierar en ny instans av DateTime-objektet med det angivna året, månaden, dagen, timmen, minuten, sekunden och millisekunden. |
+| [DateTime(Date date)](#DateTime-java.util.Date-) | Initierar en ny instans av DateTime-objektet med det angivna Date-objektet |
+| [DateTime(Calendar cld)](#DateTime-java.util.Calendar-) | Initierar en ny instans av DateTime-objektet med det angivna Calendar-objektet |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addDays(double value)](#addDays-double-) | Lägger till det angivna antalet dagar till värdet av den här instansen. |
+| [addHours(double value)](#addHours-double-) | Lägger till det angivna antalet timmar till värdet av den här instansen. |
+| [addMilliseconds(double value)](#addMilliseconds-double-) | Lägger till det angivna antalet millisekunder till värdet av den här instansen. |
+| [addMinutes(double value)](#addMinutes-double-) | Lägger till det angivna antalet minuter till värdet av den här instansen. |
+| [addMonths(int months)](#addMonths-int-) | Lägger till det angivna antalet månader till värdet av den här instansen. |
+| [addSeconds(double value)](#addSeconds-double-) | Lägger till det angivna antalet sekunder till värdet av den här instansen. |
+| [addYears(int value)](#addYears-int-) | Lägger till det angivna antalet år till värdet av den här instansen. |
+| [compareTo(DateTime value)](#compareTo-com.aspose.diagram.DateTime-) | Jämför värdet av den här instansen med ett angivet DateTime‑värde och returnerar ett heltal som indikerar om denna instans är tidigare än, samma som eller senare än det angivna DateTime‑värdet. |
+| [compareTo(Object value)](#compareTo-java.lang.Object-) | Jämför värdet av den här instansen med ett angivet objekt som innehåller ett angivet DateTime‑värde och returnerar ett heltal som indikerar om denna instans är tidigare än, samma som eller senare än det angivna DateTime‑värdet. |
+| [equals(Object value)](#equals-java.lang.Object-) | Returnerar ett värde som indikerar om denna instans är lika med ett angivet objekt. |
+| [getClass()](#getClass--) |  |
+| [getDay()](#getDay--) | Hämtar dagen i månaden som representeras av den här instansen. |
+| [getDayOfWeek()](#getDayOfWeek--) | Hämtar veckodagen som representeras av den här instansen. |
+| [getDayOfYear()](#getDayOfYear--) | Hämtar dagen på året som representeras av detta objekt. |
+| [getHour()](#getHour--) | Hämtar timkomponenten i datumet som representeras av detta objekt. |
+| [getMillisecond()](#getMillisecond--) | Hämtar millisekundkomponenten i datumet som representeras av detta objekt. |
+| [getMinute()](#getMinute--) | Hämtar minutkomponenten i datumet som representeras av detta objekt. |
+| [getMonth()](#getMonth--) | Hämtar månadsdelen i datumet som representeras av detta objekt. |
+| [getNow()](#getNow--) | Hämtar ett DateTime-objekt som är inställt på det aktuella datumet och tiden på den här datorn, uttryckt i lokal tid. |
+| [getSecond()](#getSecond--) | Hämtar sekundkomponenten i datumet som representeras av detta objekt. |
+| [getYear()](#getYear--) | Hämtar årskomponenten i datumet som representeras av detta objekt. |
+| [hashCode()](#hashCode--) | Returnerar hashkoden för detta objekt. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toCalendar()](#toCalendar--) | Konverterar värdet av det aktuella DateTime-objektet till ett Calendar-objekt. |
+| [toDate()](#toDate--) | Konverterar värdet av det aktuella DateTime-objektet till ett Date-objekt. |
+| [toLocalTime()](#toLocalTime--) | Konverterar värdet av det aktuella DateTime-objektet till lokal tid. |
+| [toString()](#toString--) | Konverterar värdet av det aktuella DateTime-objektet till dess motsvarande strängrepresentation. |
+| [toUniversalTime()](#toUniversalTime--) | Konverterar värdet av det aktuella DateTime-objektet till koordinerad universell tid (UTC). |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateTime(int year, int month, int day) {#DateTime-int-int-int-}
+```
+public DateTime(int year, int month, int day)
+```
+
+
+Initierar en ny instans av DateTime-objektet med det angivna året, månaden och dagen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| år | int | Året (1 till 9999). |
+| månad | int | Månad (1 till 12). |
+| dag | int | Dag (1 till antalet dagar i månaden). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second) {#DateTime-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second)
+```
+
+
+Initierar en ny instans av DateTime-objektet med det angivna året, månaden, dagen, timmen, minuten och sekunden.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| år | int | Året (1 till 9999). |
+| månad | int | Månad (1 till 12). |
+| dag | int | Dag (1 till antalet dagar i månaden). |
+| timme | int | Timmar (0 till 23). |
+| minut | int | Minuter (0 till 59). |
+| sekund | int | Sekunderna (0 till 59). |
+
+### DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond) {#DateTime-int-int-int-int-int-int-int-}
+```
+public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
+```
+
+
+Initierar en ny instans av DateTime-objektet med det angivna året, månaden, dagen, timmen, minuten, sekunden och millisekunden.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| år | int | Året (1 till 9999). |
+| månad | int | Månad (1 till 12). |
+| dag | int | Dag (1 till antalet dagar i månaden). |
+| timme | int | Timmar (0 till 23). |
+| minut | int | Minuter (0 till 59). |
+| sekund | int | Sekunderna (0 till 59). |
+| millisekund | int | Millisekunderna (0 till 999). |
+
+### DateTime(Date date) {#DateTime-java.util.Date-}
+```
+public DateTime(Date date)
+```
+
+
+Initierar en ny instans av DateTime-objektet med det angivna Date-objektet
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| datum | java.util.Date | Date-objektet |
+
+### DateTime(Calendar cld) {#DateTime-java.util.Calendar-}
+```
+public DateTime(Calendar cld)
+```
+
+
+Initierar en ny instans av DateTime-objektet med det angivna Calendar-objektet
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| cld | java.util.Calendar | Calendar-objektet |
+
+### addDays(double value) {#addDays-double-}
+```
+public DateTime addDays(double value)
+```
+
+
+Lägger till det angivna antalet dagar till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ett antal hela och bråkdelar av dagar. Parametern value kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of days represented by value.
+### addHours(double value) {#addHours-double-}
+```
+public DateTime addHours(double value)
+```
+
+
+Lägger till det angivna antalet timmar till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ett antal hela och bråkdelar av timmar. Parametern value kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of hours represented by value.
+### addMilliseconds(double value) {#addMilliseconds-double-}
+```
+public DateTime addMilliseconds(double value)
+```
+
+
+Lägger till det angivna antalet millisekunder till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ett antal hela och bråkdelar av millisekunder. Parametern value kan vara negativ eller positiv. Observera att detta värde avrundas till närmaste heltal. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of milliseconds represented by value.
+### addMinutes(double value) {#addMinutes-double-}
+```
+public DateTime addMinutes(double value)
+```
+
+
+Lägger till det angivna antalet minuter till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ett antal hela och bråkdelar av minuter. Parametern value kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of minutes represented by value.
+### addMonths(int months) {#addMonths-int-}
+```
+public DateTime addMonths(int months)
+```
+
+
+Lägger till det angivna antalet månader till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| månader | int | Ett antal månader. Parametern months kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and months.
+### addSeconds(double value) {#addSeconds-double-}
+```
+public DateTime addSeconds(double value)
+```
+
+
+Lägger till det angivna antalet sekunder till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double | Ett antal hela och bråkdelar av sekunder. Parametern value kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of seconds represented by value.
+### addYears(int value) {#addYears-int-}
+```
+public DateTime addYears(int value)
+```
+
+
+Lägger till det angivna antalet år till värdet av den här instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int | Ett antal år. Parametern value kan vara negativ eller positiv. |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the sum of the date and time represented by this instance and the number of years represented by value.
+### compareTo(DateTime value) {#compareTo-com.aspose.diagram.DateTime-}
+```
+public int compareTo(DateTime value)
+```
+
+
+Jämför värdet av den här instansen med ett angivet DateTime‑värde och returnerar ett heltal som indikerar om denna instans är tidigare än, samma som eller senare än det angivna DateTime‑värdet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) | Ett DateTime-objekt att jämföra. |
+
+**Returns:**
+int - Ett signerat tal som indikerar de relativa värdena för detta objekt och value‑parametern. Värdebeskrivning Mindre än noll Detta objekt är tidigare än value. Noll Detta objekt är samma som value. Större än noll Detta objekt är senare än value.
+### compareTo(Object value) {#compareTo-java.lang.Object-}
+```
+public int compareTo(Object value)
+```
+
+
+Jämför värdet av den här instansen med ett angivet objekt som innehåller ett angivet DateTime‑värde och returnerar ett heltal som indikerar om denna instans är tidigare än, samma som eller senare än det angivna DateTime‑värdet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object | Ett inbäddat DateTime-objekt att jämföra, eller null. |
+
+**Returns:**
+int - Ett signerat tal som indikerar de relativa värdena för detta objekt och value. Värdebeskrivning Mindre än noll Detta objekt är tidigare än value. Noll Detta objekt är samma som value. Större än noll Detta objekt är senare än value, eller value är null.
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Returnerar ett värde som indikerar om denna instans är lika med ett angivet objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object | Ett objekt att jämföra med detta objekt. |
+
+**Returns:**
+boolean - true om value är en instans av DateTime och är lika med värdet för detta objekt; annars false.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDay() {#getDay--}
+```
+public int getDay()
+```
+
+
+Hämtar dagen i månaden som representeras av den här instansen.
+
+**Returns:**
+int - Dagkomponenten, uttryckt som ett värde mellan 1 och 31.
+### getDayOfWeek() {#getDayOfWeek--}
+```
+public int getDayOfWeek()
+```
+
+
+Hämtar veckodagen som representeras av den här instansen.
+
+**Returns:**
+int - veckodagen för detta DateTime‑värde.
+### getDayOfYear() {#getDayOfYear--}
+```
+public int getDayOfYear()
+```
+
+
+Hämtar dagen på året som representeras av detta objekt.
+
+**Returns:**
+int - Dagen på året, uttryckt som ett värde mellan 1 och 366.
+### getHour() {#getHour--}
+```
+public int getHour()
+```
+
+
+Hämtar timkomponenten i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Timkomponenten, uttryckt som ett värde mellan 0 och 23.
+### getMillisecond() {#getMillisecond--}
+```
+public int getMillisecond()
+```
+
+
+Hämtar millisekundkomponenten i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Millisekundkomponenten, uttryckt som ett värde mellan 0 och 999.
+### getMinute() {#getMinute--}
+```
+public int getMinute()
+```
+
+
+Hämtar minutkomponenten i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Minutkomponenten, uttryckt som ett värde mellan 0 och 59.
+### getMonth() {#getMonth--}
+```
+public int getMonth()
+```
+
+
+Hämtar månadsdelen i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Månadskomponenten, uttryckt som ett värde mellan 1 och 12.
+### getNow() {#getNow--}
+```
+public static DateTime getNow()
+```
+
+
+Hämtar ett DateTime-objekt som är inställt på det aktuella datumet och tiden på den här datorn, uttryckt i lokal tid.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object whose value is the current local date and time.
+### getSecond() {#getSecond--}
+```
+public int getSecond()
+```
+
+
+Hämtar sekundkomponenten i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Sekunderna, mellan 0 och 59.
+### getYear() {#getYear--}
+```
+public int getYear()
+```
+
+
+Hämtar årskomponenten i datumet som representeras av detta objekt.
+
+**Returns:**
+int - Året, mellan 1 och 9999.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Returnerar hashkoden för detta objekt.
+
+**Returns:**
+int - En 32-bitars signerad heltals hashkod.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toCalendar() {#toCalendar--}
+```
+public Calendar toCalendar()
+```
+
+
+Konverterar värdet av det aktuella DateTime-objektet till ett Calendar-objekt.
+
+**Returns:**
+[Calendar](../../java.util/calendar) - Calendar object
+### toDate() {#toDate--}
+```
+public Date toDate()
+```
+
+
+Konverterar värdet av det aktuella DateTime-objektet till ett Date-objekt.
+
+**Returns:**
+java.util.Date - Datumobjekt
+### toLocalTime() {#toLocalTime--}
+```
+public DateTime toLocalTime()
+```
+
+
+Konverterar värdet av det aktuella DateTime-objektet till lokal tid.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of local
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+Konverterar värdet av det aktuella DateTime-objektet till dess motsvarande strängrepresentation.
+
+**Returns:**
+java.lang.String - En strängrepresentation av värdet för det aktuella DateTime-objektet.
+### toUniversalTime() {#toUniversalTime--}
+```
+public DateTime toUniversalTime()
+```
+
+
+Konverterar värdet av det aktuella DateTime-objektet till koordinerad universell tid (UTC).
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - A DateTime object of UTC
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/datevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/datevalue/_index.md
@@ -1,0 +1,180 @@
+---
+title: DateValue
+second_title: Aspose.Diagram för Java API-referens
+description: Datum- och tidsvärde.
+type: docs
+weight: 116
+url: /sv/java/com.aspose.diagram/datevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DateValue
+```
+
+Datum- och tidsvärde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DateValue(DateTime value, int unit)](#DateValue-com.aspose.diagram.DateTime-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Datum- och tidsvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(DateTime value)](#setValue-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/datevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DateValue(DateTime value, int unit) {#DateValue-com.aspose.diagram.DateTime-int-}
+```
+public DateValue(DateTime value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+| enhet | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public DateTime getValue()
+```
+
+
+Datum- och tidsvärde.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(DateTime value) {#setValue-com.aspose.diagram.DateTime-}
+```
+public void setValue(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/datevalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/diagram/_index.md
+++ b/swedish/java/com.aspose.diagram/diagram/_index.md
@@ -1,0 +1,1130 @@
+---
+title: Diagram
+second_title: Aspose.Diagram för Java API-referens
+description: Rot-element för Visio-objekthierarkin.
+type: docs
+weight: 117
+url: /sv/java/com.aspose.diagram/diagram/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Diagram
+```
+
+Rot-element för Visio-objekthierarkin.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Diagram()](#Diagram--) |  |
+| [Diagram(String filename)](#Diagram-java.lang.String-) | Publik klasskonstruktor, laddar diagrammet från filen. |
+| [Diagram(InputStream stream)](#Diagram-java.io.InputStream-) | Publik klasskonstruktor, laddar diagrammet från strömmen. |
+| [Diagram(InputStream stream, int format)](#Diagram-java.io.InputStream-int-) | Publik klasskonstruktor, laddar diagrammet från strömmen med fördefinierat format. |
+| [Diagram(InputStream stream, LoadOptions options)](#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-) | Publik klasskonstruktor, laddar diagrammet från strömmen med fördefinierade alternativ för filinläsning. |
+| [Diagram(String filename, int format)](#Diagram-java.lang.String-int-) | Publik klasskonstruktor, laddar diagrammet från filen med fördefinierat format. |
+| [Diagram(String filename, LoadOptions options)](#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-) | Publik klasskonstruktor, laddar diagrammet från filen med fördefinierade alternativ för filinläsning. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addMaster(Diagram srcDiagram, String masterName)](#addMaster-com.aspose.diagram.Diagram-java.lang.String-) | Lägger till master i diagrammet från källdiagrammet med masterens namn eller NameU. |
+| [addMaster(InputStream templateStream, int masterID)](#addMaster-java.io.InputStream-int-) | Lägger till master i diagrammet från mallströmmen med masterens ID. |
+| [addMaster(InputStream templateStream, String masterName)](#addMaster-java.io.InputStream-java.lang.String-) | Lägger till master i diagrammet från mallströmmen med masterens namn eller NameU. |
+| [addMaster(String templateFilePath, int masterID)](#addMaster-java.lang.String-int-) | Lägger till master i diagrammet från mallfilen med masterens ID. |
+| [addMaster(String templateFilePath, String masterName)](#addMaster-java.lang.String-java.lang.String-) | Lägger till master i diagrammet från mallfilen med masterens namn eller NameU. |
+| [addShape(Shape newShape, String masterName, int pageNumber)](#addShape-com.aspose.diagram.Shape-java.lang.String-int-) | Lägger till en form skapad av master till en specifik sida. |
+| [addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)](#addShape-double-double-double-double-java.lang.String-int-) | Lägger till en form skapad av master på sidan med definierade PinX, PinY, bredd och höjd. |
+| [addShape(double pinX, double pinY, String masterName, int pageNumber)](#addShape-double-double-java.lang.String-int-) | Lägger till en form skapad av master på sidan med definierade PinX och PinY. |
+| [combine(Diagram secondDiagram)](#combine-com.aspose.diagram.Diagram-) | Kombinerar ett annat Diagram-objekt. |
+| [copyTheme(Diagram source)](#copyTheme-com.aspose.diagram.Diagram-) | Kopierar tema från ett källdiagram. |
+| [dispose()](#dispose--) | Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [export(InputStream inputVsd, InputStream outputVdw)](#export-java.io.InputStream-java.io.InputStream-) | Exporterar diagrammet från VSD-ström till VDW-strömformat. |
+| [export(InputStream inputVsd, String outputVdw)](#export-java.io.InputStream-java.lang.String-) | Exporterar diagrammet från VSD-ström till *.vdw-filformat. |
+| [export(String inputVsd, InputStream outputVdw)](#export-java.lang.String-java.io.InputStream-) | Exporterar diagrammet från VSD-fil till VDW-strömformat. |
+| [export(String inputVsd, String outputVdw)](#export-java.lang.String-java.lang.String-) | Exporterar diagrammet från VSD till VDW-format. |
+| [getActivePage()](#getActivePage--) | Anger den aktiva sidan |
+| [getBuildnum()](#getBuildnum--) | Byggnumret för Visio-instansen som användes för att skapa dokumentet. |
+| [getClass()](#getClass--) |  |
+| [getColors()](#getColors--) | Innehåller dokumentets färgtabell. |
+| [getDataConnections()](#getDataConnections--) | Innehåller DataConnection-elementen för dokumentet. |
+| [getDataRecordSets()](#getDataRecordSets--) | Samlingen av DataRecordset-objekt som är associerade med ett Document-objekt. |
+| [getDefaultFontDir()](#getDefaultFontDir--) | Hämta sökvägen till standardteckensnittsmappen |
+| [getDocLangID()](#getDocLangID--) | Det unika ID:t för det användargränssnittsspråk som användaren har angett i Microsoft Office 2010 Språkinställningar. |
+| [getDocumentProps()](#getDocumentProps--) | Innehåller element för dokumentegenskaper såsom dokumentets titel, författare osv. |
+| [getDocumentSettings()](#getDocumentSettings--) | Innehåller element som specificerar dokumentinställningar. |
+| [getDocumentSheet()](#getDocumentSheet--) | Anger ett dokuments ShapeSheet-struktur. |
+| [getEmailRoutingData()](#getEmailRoutingData--) | Innehåller ett MIME (Multipurpose Internet Mail Extensions) kodad MAPI e‑postrouting‑slipp för dokumentet. |
+| [getEventItems()](#getEventItems--) | Innehåller ett EventItem‑element för varje händelse som ett objekt ska svara på. |
+| [getFonts()](#getFonts--) | Innehåller en samling av Font‑element |
+| [getHeaderFooter()](#getHeaderFooter--) | Innehåller element för ett dokuments sidhuvud och sidfot. |
+| [getInterruptMonitor()](#getInterruptMonitor--) | avbrottsmontorn. |
+| [getKey()](#getKey--) | Anger om dokumentet har ändrats utanför Visio. |
+| [getMasters()](#getMasters--) | Samling av Master‑objekt. |
+| [getMetric()](#getMetric--) | Om metriska enheter ska användas i ritningen. |
+| [getPages()](#getPages--) | Samling av Page‑objekt. |
+| [getRibbonX()](#getRibbonX--) | Ribbon‑XML‑strängen som skickas till dokumentet för att anpassa ribbon‑användargränssnittet. |
+| [getSolutionXMLs()](#getSolutionXMLs--) | XML‑värde. |
+| [getStart()](#getStart--) | Anger om dokumentet har ändrats utanför Visio. |
+| [getStyleSheets()](#getStyleSheets--) | Samling av StyleSheet‑objekt. |
+| [getUnusedStyles()](#getUnusedStyles--) | Hämta oanvända stilar |
+| [getUserCustomUI()](#getUserCustomUI--) | Ribbon‑XML‑strängen som skickas till dokumentet för att anpassa snabbåtkomstverktygsfältet eller ribbon. |
+| [getValidation()](#getValidation--) | Lagrar information om diagramvalidering för dokumentet. |
+| [getVbProjectData()](#getVbProjectData--) | Innehåller Microsoft Visual Basic for Applications‑projektdata i MIME (Multipurpose Internet Mail Extensions) kodat format. |
+| [getVbaProject()](#getVbaProject--) | Hämtar VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--). |
+| [getVersion()](#getVersion--) | Versionsnumret för Visio‑instansen. |
+| [getWindows()](#getWindows--) | Innehåller Window‑elementen för ett dokument. |
+| [hasHiddenInfo()](#hasHiddenInfo--) | Anger om detta diagram har dold information. |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Lägger ut formerna och/eller omdirigerar anslutningarna för alla diagram‑sidor. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [print(String printerName)](#print-java.lang.String-) | Skriv ut hela dokumentet till den angivna skrivaren, med den standard (utan användargränssnitt) utskriftskontrollen. |
+| [print(String printerName, PrintSaveOptions options)](#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Skriv ut hela dokumentet till den angivna skrivaren, med den standard (utan användargränssnitt) utskriftskontrollen. |
+| [print(String printerName, String documentName)](#print-java.lang.String-java.lang.String-) | Skriver ut dokumentet, med den standard (utan användargränssnitt) utskriftskontrollen och ett dokumentnamn. |
+| [print(String printerName, String documentName, PrintSaveOptions options)](#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-) | Skriver ut dokumentet, med den standard (utan användargränssnitt) utskriftskontrollen och ett dokumentnamn. |
+| [removeHiddenInformation(int item)](#removeHiddenInformation-int-) | Ta bort oanvänd information |
+| [removeMacro()](#removeMacro--) | Tar bort VBA/makro från detta diagram. |
+| [save(OutputStream stream, SaveOptions saveOptions)](#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-) | Spara diagrammet till strömmen. |
+| [save(OutputStream stream, int format)](#save-java.io.OutputStream-int-) | Spara diagrammet till strömmen. |
+| [save(String filename, SaveOptions options)](#save-java.lang.String-com.aspose.diagram.SaveOptions-) | Sparar dokumentet till en fil med de angivna sparalternativen. |
+| [save(String filename, int format)](#save-java.lang.String-int-) | Sparar diagramdata till filen. |
+| [setBuildnum(long value)](#setBuildnum-long-) | For the description of this property, please see [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--) |
+| [setDocLangID(int value)](#setDocLangID-int-) | For the description of this property, please see [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--) |
+| [setEmailRoutingData(byte[] value)](#setEmailRoutingData-byte---) | For the description of this property, please see [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--) |
+| [setFontDirs(String[] value)](#setFontDirs-java.lang.String---) | Indicates the Fonts folder path |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | For the description of this property, please see [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--) |
+| [setKey(String value)](#setKey-java.lang.String-) | For the description of this property, please see [getKey()](../../com.aspose.diagram/diagram\#getKey--) |
+| [setMetric(int value)](#setMetric-int-) | For the description of this property, please see [getMetric()](../../com.aspose.diagram/diagram\#getMetric--) |
+| [setRibbonX(String value)](#setRibbonX-java.lang.String-) | For the description of this property, please see [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--) |
+| [setStart(long value)](#setStart-long-) | For the description of this property, please see [getStart()](../../com.aspose.diagram/diagram\#getStart--) |
+| [setUserCustomUI(String value)](#setUserCustomUI-java.lang.String-) | For the description of this property, please see [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--) |
+| [setVbProjectData(byte[] value)](#setVbProjectData-byte---) | For the description of this property, please see [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--) |
+| [setVersion(String value)](#setVersion-java.lang.String-) | For the description of this property, please see [getVersion()](../../com.aspose.diagram/diagram\#getVersion--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Diagram() {#Diagram--}
+```
+public Diagram()
+```
+
+
+### Diagram(String filename) {#Diagram-java.lang.String-}
+```
+public Diagram(String filename)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från filen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filename | java.lang.String | The file name. |
+
+### Diagram(InputStream stream) {#Diagram-java.io.InputStream-}
+```
+public Diagram(InputStream stream)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från strömmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | The data stream. |
+
+### Diagram(InputStream stream, int format) {#Diagram-java.io.InputStream-int-}
+```
+public Diagram(InputStream stream, int format)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från strömmen med fördefinierat format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | The data stream. |
+| format | int | The data Aspose.Diagram.LoadFileFormat. |
+
+### Diagram(InputStream stream, LoadOptions options) {#Diagram-java.io.InputStream-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(InputStream stream, LoadOptions options)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från strömmen med fördefinierade alternativ för filinläsning.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | The data stream. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | The data [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### Diagram(String filename, int format) {#Diagram-java.lang.String-int-}
+```
+public Diagram(String filename, int format)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från filen med fördefinierat format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filename | java.lang.String | The file name. |
+| format | int | The file format. |
+
+### Diagram(String filename, LoadOptions options) {#Diagram-java.lang.String-com.aspose.diagram.LoadOptions-}
+```
+public Diagram(String filename, LoadOptions options)
+```
+
+
+Publik klasskonstruktor, laddar diagrammet från filen med fördefinierade alternativ för filinläsning.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filename | java.lang.String | The file name. |
+| options | [LoadOptions](../../com.aspose.diagram/loadoptions) | The data [LoadOptions](../../com.aspose.diagram/loadoptions). |
+
+### addMaster(Diagram srcDiagram, String masterName) {#addMaster-com.aspose.diagram.Diagram-java.lang.String-}
+```
+public int addMaster(Diagram srcDiagram, String masterName)
+```
+
+
+Lägger till master i diagrammet från källdiagrammet med masterens namn eller NameU.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| srcDiagram | [Diagram](../../com.aspose.diagram/diagram) | source diagram. |
+| masterName | java.lang.String | Master's Name or NameU. |
+
+**Returns:**
+int - The unique ID of the master within masters collection in this diagram.
+### addMaster(InputStream templateStream, int masterID) {#addMaster-java.io.InputStream-int-}
+```
+public int addMaster(InputStream templateStream, int masterID)
+```
+
+
+Lägger till master i diagrammet från mallströmmen med masterens ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | template stream. |
+| masterID | int | The unique ID of the master within masters collection in template. |
+
+**Returns:**
+int - The unique ID of the master within masters collection in this diagram.
+### addMaster(InputStream templateStream, String masterName) {#addMaster-java.io.InputStream-java.lang.String-}
+```
+public int addMaster(InputStream templateStream, String masterName)
+```
+
+
+Lägger till master i diagrammet från mallströmmen med masterens namn eller NameU.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| templateStream | java.io.InputStream | template stream. |
+| masterName | java.lang.String | Master's Name or NameU. |
+
+**Returns:**
+int - The unique ID of the master within masters collection in this diagram.
+### addMaster(String templateFilePath, int masterID) {#addMaster-java.lang.String-int-}
+```
+public int addMaster(String templateFilePath, int masterID)
+```
+
+
+Lägger till master i diagrammet från mallfilen med masterens ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Sökväg till mallfil(can vara vdx, vst eller vsd-format). |
+| masterID | int | The unique ID of the master within masters collection in template. |
+
+**Returns:**
+int - The unique ID of the master within masters collection in this diagram.
+### addMaster(String templateFilePath, String masterName) {#addMaster-java.lang.String-java.lang.String-}
+```
+public int addMaster(String templateFilePath, String masterName)
+```
+
+
+Lägger till master i diagrammet från mallfilen med masterens namn eller NameU.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| templateFilePath | java.lang.String | Sökväg till mallfil(can vara vdx, vst eller vsd-format). |
+| masterName | java.lang.String | Master's Name or NameU. |
+
+**Returns:**
+int - The unique ID of the master within masters collection in this diagram.
+### addShape(Shape newShape, String masterName, int pageNumber) {#addShape-com.aspose.diagram.Shape-java.lang.String-int-}
+```
+public long addShape(Shape newShape, String masterName, int pageNumber)
+```
+
+
+Lägger till en form skapad av master till en specifik sida.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nytt figurobjekt[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Mästarens namn. |
+| pageNumber | int | Sidans index. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber) {#addShape-double-double-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName, int pageNumber)
+```
+
+
+Lägger till en form skapad av master på sidan med definierade PinX, PinY, bredd och höjd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger figurens bredd i tum. |
+| höjd | double | Anger figurens höjd i tum. |
+| masterName | java.lang.String | Mästarens namn. |
+| pageNumber | int | Sidans index. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### addShape(double pinX, double pinY, String masterName, int pageNumber) {#addShape-double-double-java.lang.String-int-}
+```
+public long addShape(double pinX, double pinY, String masterName, int pageNumber)
+```
+
+
+Lägger till en form skapad av master på sidan med definierade PinX och PinY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| masterName | java.lang.String | Mästarens namn. |
+| pageNumber | int | Sidans index. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### combine(Diagram secondDiagram) {#combine-com.aspose.diagram.Diagram-}
+```
+public void combine(Diagram secondDiagram)
+```
+
+
+Kombinerar ett annat Diagram-objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| secondDiagram | [Diagram](../../com.aspose.diagram/diagram) | Ett annat Diagram-objekt. |
+
+### copyTheme(Diagram source) {#copyTheme-com.aspose.diagram.Diagram-}
+```
+public void copyTheme(Diagram source)
+```
+
+
+Kopierar tema från ett källdiagram.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [Diagram](../../com.aspose.diagram/diagram) | source diagram. |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### export(InputStream inputVsd, InputStream outputVdw) {#export-java.io.InputStream-java.io.InputStream-}
+```
+public static void export(InputStream inputVsd, InputStream outputVdw)
+```
+
+
+Exporterar diagrammet från vsd-ström till vdw-strömformat. Ej implementerat ännu.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | vsd-ström. |
+| outputVdw | java.io.InputStream | vdw-ström. |
+
+### export(InputStream inputVsd, String outputVdw) {#export-java.io.InputStream-java.lang.String-}
+```
+public static void export(InputStream inputVsd, String outputVdw)
+```
+
+
+Exporterar diagrammet från vsd-ström till \*.vdw-filformat. Ej implementerat ännu.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| inputVsd | java.io.InputStream | \*.vsd filnamn. |
+| outputVdw | java.lang.String | vdw-ström. |
+
+### export(String inputVsd, InputStream outputVdw) {#export-java.lang.String-java.io.InputStream-}
+```
+public static void export(String inputVsd, InputStream outputVdw)
+```
+
+
+Exporterar diagrammet från vsd-fil till vdw-strömformat. Ej implementerat ännu.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd filnamn. |
+| outputVdw | java.io.InputStream | vdw-ström. |
+
+### export(String inputVsd, String outputVdw) {#export-java.lang.String-java.lang.String-}
+```
+public static void export(String inputVsd, String outputVdw)
+```
+
+
+Exporterar diagrammet från vsd till vdw-format. Ej implementerat ännu.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| inputVsd | java.lang.String | \*.vsd filnamn. |
+| outputVdw | java.lang.String | \*.vdw filnamn. |
+
+### getActivePage() {#getActivePage--}
+```
+public Page getActivePage()
+```
+
+
+Anger den aktiva sidan
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBuildnum() {#getBuildnum--}
+```
+public long getBuildnum()
+```
+
+
+Byggnumret för Visio-instansen som användes för att skapa dokumentet.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColors() {#getColors--}
+```
+public ColorEntryCollection getColors()
+```
+
+
+Innehåller dokumentets färgtabell. Varje dokument innehåller en enda färgtabell, som listar de 24 standardfärgerna som är tillgängliga för tillämpning på objekt såsom former, text och lager i dokumentet.
+
+**Returns:**
+[ColorEntryCollection](../../com.aspose.diagram/colorentrycollection)
+### getDataConnections() {#getDataConnections--}
+```
+public DataConnectionCollection getDataConnections()
+```
+
+
+Innehåller DataConnection-elementen för dokumentet.
+
+**Returns:**
+[DataConnectionCollection](../../com.aspose.diagram/dataconnectioncollection)
+### getDataRecordSets() {#getDataRecordSets--}
+```
+public DataRecordSetCollection getDataRecordSets()
+```
+
+
+Samlingen av DataRecordset-objekt som är associerade med ett Document-objekt.
+
+**Returns:**
+[DataRecordSetCollection](../../com.aspose.diagram/datarecordsetcollection)
+### getDefaultFontDir() {#getDefaultFontDir--}
+```
+public String getDefaultFontDir()
+```
+
+
+Hämta sökvägen till standardteckensnittsmappen
+
+**Returns:**
+java.lang.String
+### getDocLangID() {#getDocLangID--}
+```
+public int getDocLangID()
+```
+
+
+Det unika ID:t för det användargränssnittsspråk som användaren har angett i Microsoft Office 2010 Språkinställningar.
+
+**Returns:**
+int
+### getDocumentProps() {#getDocumentProps--}
+```
+public DocumentProperties getDocumentProps()
+```
+
+
+Innehåller element för dokumentegenskaper såsom dokumentets titel, författare osv.
+
+**Returns:**
+[DocumentProperties](../../com.aspose.diagram/documentproperties)
+### getDocumentSettings() {#getDocumentSettings--}
+```
+public DocumentSettings getDocumentSettings()
+```
+
+
+Innehåller element som specificerar dokumentinställningar.
+
+**Returns:**
+[DocumentSettings](../../com.aspose.diagram/documentsettings)
+### getDocumentSheet() {#getDocumentSheet--}
+```
+public DocumentSheet getDocumentSheet()
+```
+
+
+Anger ett dokuments ShapeSheet-struktur.
+
+**Returns:**
+[DocumentSheet](../../com.aspose.diagram/documentsheet)
+### getEmailRoutingData() {#getEmailRoutingData--}
+```
+public byte[] getEmailRoutingData()
+```
+
+
+Innehåller ett MIME (Multipurpose Internet Mail Extensions) kodad MAPI e‑postrouting‑slipp för dokumentet.
+
+**Returns:**
+byte[]
+### getEventItems() {#getEventItems--}
+```
+public EventItemCollection getEventItems()
+```
+
+
+Innehåller ett EventItem‑element för varje händelse som ett objekt ska svara på.
+
+**Returns:**
+[EventItemCollection](../../com.aspose.diagram/eventitemcollection)
+### getFonts() {#getFonts--}
+```
+public FontCollection getFonts()
+```
+
+
+Innehåller en samling av Font‑element
+
+**Returns:**
+[FontCollection](../../com.aspose.diagram/fontcollection)
+### getHeaderFooter() {#getHeaderFooter--}
+```
+public HeaderFooter getHeaderFooter()
+```
+
+
+Innehåller element för ett dokuments sidhuvud och sidfot.
+
+**Returns:**
+[HeaderFooter](../../com.aspose.diagram/headerfooter)
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+avbrottsmontorn.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getKey() {#getKey--}
+```
+public String getKey()
+```
+
+
+Anger om dokumentet har ändrats utanför Visio. Om närvarande kommer Visio att fullt ut testa filens innehåll. Utelämna för filer du skapar utanför Visio.
+
+**Returns:**
+java.lang.String
+### getMasters() {#getMasters--}
+```
+public MasterCollection getMasters()
+```
+
+
+Samling av Master‑objekt.
+
+**Returns:**
+[MasterCollection](../../com.aspose.diagram/mastercollection)
+### getMetric() {#getMetric--}
+```
+public int getMetric()
+```
+
+
+Om metriska enheter ska användas i ritningen. Ställ in detta attribut till True (1) för att använda metriska enheter; ställ in det till False (0) för att använda engelska enheter.
+
+**Returns:**
+int
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Samling av Page‑objekt.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getRibbonX() {#getRibbonX--}
+```
+public String getRibbonX()
+```
+
+
+Ribbon‑XML‑strängen som skickas till dokumentet för att anpassa ribbon‑användargränssnittet.
+
+**Returns:**
+java.lang.String
+### getSolutionXMLs() {#getSolutionXMLs--}
+```
+public SolutionXMLCollection getSolutionXMLs()
+```
+
+
+XML‑värde.
+
+**Returns:**
+[SolutionXMLCollection](../../com.aspose.diagram/solutionxmlcollection)
+### getStart() {#getStart--}
+```
+public long getStart()
+```
+
+
+Anger om dokumentet har ändrats utanför Visio. Om närvarande kommer Visio att fullt ut testa filens innehåll. Utelämna för filer du skapar utanför Visio.
+
+**Returns:**
+long
+### getStyleSheets() {#getStyleSheets--}
+```
+public StyleSheetCollection getStyleSheets()
+```
+
+
+Samling av StyleSheet‑objekt.
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUnusedStyles() {#getUnusedStyles--}
+```
+public StyleSheetCollection getUnusedStyles()
+```
+
+
+Hämta oanvända stilar
+
+**Returns:**
+[StyleSheetCollection](../../com.aspose.diagram/stylesheetcollection)
+### getUserCustomUI() {#getUserCustomUI--}
+```
+public String getUserCustomUI()
+```
+
+
+Ribbon‑XML‑strängen som skickas till dokumentet för att anpassa snabbåtkomstverktygsfältet eller ribbon.
+
+**Returns:**
+java.lang.String
+### getValidation() {#getValidation--}
+```
+public Validation getValidation()
+```
+
+
+Lagrar information om diagramvalidering för dokumentet.
+
+**Returns:**
+[Validation](../../com.aspose.diagram/validation)
+### getVbProjectData() {#getVbProjectData--}
+```
+public byte[] getVbProjectData()
+```
+
+
+Innehåller Microsoft Visual Basic for Applications‑projektdata i MIME (Multipurpose Internet Mail Extensions) kodat format.
+
+**Returns:**
+byte[]
+### getVbaProject() {#getVbaProject--}
+```
+public VbaProject getVbaProject()
+```
+
+
+Hämtar VbaProject[getVbaProject()](../../com.aspose.diagram/diagram\#getVbaProject--).
+
+**Returns:**
+[VbaProject](../../com.aspose.diagram/vbaproject)
+### getVersion() {#getVersion--}
+```
+public String getVersion()
+```
+
+
+Versionsnumret för Visio-instansen. Microsoft Visio 2010 = 14.
+
+**Returns:**
+java.lang.String
+### getWindows() {#getWindows--}
+```
+public WindowCollection getWindows()
+```
+
+
+Innehåller Window‑elementen för ett dokument.
+
+**Returns:**
+[WindowCollection](../../com.aspose.diagram/windowcollection)
+### hasHiddenInfo() {#hasHiddenInfo--}
+```
+public boolean hasHiddenInfo()
+```
+
+
+Anger om detta diagram har dold information.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Lägger ut formerna och/eller omdirigerar anslutningarna för alla diagram‑sidor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Använd [LayoutOptions](../../com.aspose.diagram/layoutoptions) för att konfigurera layoutalternativ. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### print(String printerName) {#print-java.lang.String-}
+```
+public void print(String printerName)
+```
+
+
+Skriv ut hela dokumentet till den angivna skrivaren,med den standard (utan användargränssnitt) utskriftskontrollen. Om printerName är Null eller tom kommer standardskrivaren att användas.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| printerName | java.lang.String | Skrivarnamnet.Can vara Null |
+
+### print(String printerName, PrintSaveOptions options) {#print-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, PrintSaveOptions options)
+```
+
+
+Skriv ut hela dokumentet till den angivna skrivaren,med den standard (utan användargränssnitt) utskriftskontrollen. Om printerName är Null eller tom kommer standardskrivaren att användas.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| printerName | java.lang.String | Skrivarnamnet.Can vara Null |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Utskriftsalternativen. |
+
+### print(String printerName, String documentName) {#print-java.lang.String-java.lang.String-}
+```
+public void print(String printerName, String documentName)
+```
+
+
+Skriver ut dokumentet, med den standard (utan användargränssnitt) utskriftskontrollen och ett dokumentnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| printerName | java.lang.String | Skrivarnamnet.Can vara Null |
+| documentName | java.lang.String | Dokumentnamnet som ska visas (till exempel i en utskriftsstatusdialogruta eller skrivarkö) när dokumentet skrivs ut. |
+
+### print(String printerName, String documentName, PrintSaveOptions options) {#print-java.lang.String-java.lang.String-com.aspose.diagram.PrintSaveOptions-}
+```
+public void print(String printerName, String documentName, PrintSaveOptions options)
+```
+
+
+Skriver ut dokumentet, med den standard (utan användargränssnitt) utskriftskontrollen och ett dokumentnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| printerName | java.lang.String | Skrivarnamnet.Can vara Null |
+| documentName | java.lang.String | Dokumentnamnet som ska visas (till exempel i en utskriftsstatusdialogruta eller skrivarkö) när dokumentet skrivs ut. |
+| options | [PrintSaveOptions](../../com.aspose.diagram/printsaveoptions) | Utskriftsalternativen. |
+
+### removeHiddenInformation(int item) {#removeHiddenInformation-int-}
+```
+public void removeHiddenInformation(int item)
+```
+
+
+Ta bort oanvänd information
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | int | RemoveHiddenInfoItem. |
+
+### removeMacro() {#removeMacro--}
+```
+public void removeMacro()
+```
+
+
+Tar bort VBA/makro från detta diagram.
+
+### save(OutputStream stream, SaveOptions saveOptions) {#save-java.io.OutputStream-com.aspose.diagram.SaveOptions-}
+```
+public void save(OutputStream stream, SaveOptions saveOptions)
+```
+
+
+Spara diagrammet till strömmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Filströmmen. |
+| saveOptions | [SaveOptions](../../com.aspose.diagram/saveoptions) | Sparaalternativen. |
+
+### save(OutputStream stream, int format) {#save-java.io.OutputStream-int-}
+```
+public void save(OutputStream stream, int format)
+```
+
+
+Spara diagrammet till strömmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Filströmmen. |
+| format | int |  |
+
+### save(String filename, SaveOptions options) {#save-java.lang.String-com.aspose.diagram.SaveOptions-}
+```
+public void save(String filename, SaveOptions options)
+```
+
+
+Sparar dokumentet till en fil med de angivna sparalternativen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filename | java.lang.String | The file name. |
+| options | [SaveOptions](../../com.aspose.diagram/saveoptions) | [SaveOptions](../../com.aspose.diagram/saveoptions) spara diagramalternativ. |
+
+### save(String filename, int format) {#save-java.lang.String-int-}
+```
+public void save(String filename, int format)
+```
+
+
+Sparar diagramdata till filen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filename | java.lang.String | The file name. |
+| format | int | Aspose.Diagram.SaveFileFormat spara filformat. |
+
+### setBuildnum(long value) {#setBuildnum-long-}
+```
+public void setBuildnum(long value)
+```
+
+
+For the description of this property, please see [getBuildnum()](../../com.aspose.diagram/diagram\#getBuildnum--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setDocLangID(int value) {#setDocLangID-int-}
+```
+public void setDocLangID(int value)
+```
+
+
+For the description of this property, please see [getDocLangID()](../../com.aspose.diagram/diagram\#getDocLangID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEmailRoutingData(byte[] value) {#setEmailRoutingData-byte---}
+```
+public void setEmailRoutingData(byte[] value)
+```
+
+
+For the description of this property, please see [getEmailRoutingData()](../../com.aspose.diagram/diagram\#getEmailRoutingData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setFontDirs(String[] value) {#setFontDirs-java.lang.String---}
+```
+public void setFontDirs(String[] value)
+```
+
+
+Indicates the Fonts folder path
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String[] |  |
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+For the description of this property, please see [getInterruptMonitor()](../../com.aspose.diagram/diagram\#getInterruptMonitor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setKey(String value) {#setKey-java.lang.String-}
+```
+public void setKey(String value)
+```
+
+
+For the description of this property, please see [getKey()](../../com.aspose.diagram/diagram\#getKey--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setMetric(int value) {#setMetric-int-}
+```
+public void setMetric(int value)
+```
+
+
+For the description of this property, please see [getMetric()](../../com.aspose.diagram/diagram\#getMetric--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setRibbonX(String value) {#setRibbonX-java.lang.String-}
+```
+public void setRibbonX(String value)
+```
+
+
+For the description of this property, please see [getRibbonX()](../../com.aspose.diagram/diagram\#getRibbonX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setStart(long value) {#setStart-long-}
+```
+public void setStart(long value)
+```
+
+
+For the description of this property, please see [getStart()](../../com.aspose.diagram/diagram\#getStart--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setUserCustomUI(String value) {#setUserCustomUI-java.lang.String-}
+```
+public void setUserCustomUI(String value)
+```
+
+
+For the description of this property, please see [getUserCustomUI()](../../com.aspose.diagram/diagram\#getUserCustomUI--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setVbProjectData(byte[] value) {#setVbProjectData-byte---}
+```
+public void setVbProjectData(byte[] value)
+```
+
+
+For the description of this property, please see [getVbProjectData()](../../com.aspose.diagram/diagram\#getVbProjectData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setVersion(String value) {#setVersion-java.lang.String-}
+```
+public void setVersion(String value)
+```
+
+
+For the description of this property, please see [getVersion()](../../com.aspose.diagram/diagram\#getVersion--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/diagramexception/_index.md
+++ b/swedish/java/com.aspose.diagram/diagramexception/_index.md
@@ -1,0 +1,290 @@
+---
+title: DiagramException
+second_title: Aspose.Diagram för Java API-referens
+description: Bas-klass för alla Aspose.Diagram-undantag.
+type: docs
+weight: 118
+url: /sv/java/com.aspose.diagram/diagramexception/
+---
+
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class DiagramException extends Exception
+```
+
+Bas-klass för alla Aspose.Diagram-undantag.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DiagramException(String msg)](#DiagramException-java.lang.String-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramException(String msg) {#DiagramException-java.lang.String-}
+```
+public DiagramException(String msg)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| msg | java.lang.String |  |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/diagramsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/diagramsaveoptions/_index.md
@@ -1,0 +1,268 @@
+---
+title: DiagramSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Kan användas för att ange ytterligare alternativ när ett diagram sparas i Visio VDXVSX-format.
+type: docs
+weight: 119
+url: /sv/java/com.aspose.diagram/diagramsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class DiagramSaveOptions extends SaveOptions
+```
+
+Kan användas för att ange ytterligare alternativ när ett diagram sparas i Visio (VDX\\VSX)-format. För närvarande tillhandahåller den endast egenskapen SaveFormat, men i framtiden kommer fler alternativ att läggas till.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DiagramSaveOptions()](#DiagramSaveOptions--) | Initierar en ny instans av denna klass som kan användas för att spara ett diagram i VDX-format. |
+| [DiagramSaveOptions(int saveFormat)](#DiagramSaveOptions-int-) | Initierar en ny instans av den här klassen som kan användas för att spara ett diagram i VDX- eller VSX-formatet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAutoFitPageToDrawingContent()](#getAutoFitPageToDrawingContent--) | Definierar om sidan behöver förstoras för att passa ritningsinnehållet eller inte. |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Anger det format i vilket det renderade diagrammet kommer att sparas om detta spara-alternativobjekt används. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoFitPageToDrawingContent(boolean value)](#setAutoFitPageToDrawingContent-boolean-) | För beskrivningen av den här egenskapen, se [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DiagramSaveOptions() {#DiagramSaveOptions--}
+```
+public DiagramSaveOptions()
+```
+
+
+Initierar en ny instans av denna klass som kan användas för att spara ett diagram i VDX-format.
+
+### DiagramSaveOptions(int saveFormat) {#DiagramSaveOptions-int-}
+```
+public DiagramSaveOptions(int saveFormat)
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett diagram i VDX- eller VSX-formatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int |  |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAutoFitPageToDrawingContent() {#getAutoFitPageToDrawingContent--}
+```
+public boolean getAutoFitPageToDrawingContent()
+```
+
+
+Definierar om sidan behöver förstoras för att passa ritningsinnehållet eller inte. Standardvärdet är falskt.
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket det renderade diagrammet kommer att sparas om detta spara-alternativobjekt används. Kan vara Aspose.Diagram.SaveFileFormat eller Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoFitPageToDrawingContent(boolean value) {#setAutoFitPageToDrawingContent-boolean-}
+```
+public void setAutoFitPageToDrawingContent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAutoFitPageToDrawingContent()](../../com.aspose.diagram/diagramsaveoptions\#getAutoFitPageToDrawingContent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/diagramsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/displaymode/_index.md
+++ b/swedish/java/com.aspose.diagram/displaymode/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayMode
+second_title: Aspose.Diagram för Java API-referens
+description: När den finns i ett Group-element specificerar DisplayMode-elementet hur en gruppform och dess medlemmar visas.
+type: docs
+weight: 120
+url: /sv/java/com.aspose.diagram/displaymode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayMode
+```
+
+När den finns i ett Group-element specificerar DisplayMode-elementet hur en gruppform och dess medlemmar visas. När den finns i ett SmartTagDef-element bestämmer DisplayMode-elementet om smart-taggen visas när användaren håller musen över taggen, när formen är markerad, eller hela tiden.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DisplayMode(int value)](#DisplayMode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | När den finns i ett Group-element anger DisplayMode-elementet hur en gruppform och dess medlemmar visas. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/displaymode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayMode(int value) {#DisplayMode-int-}
+```
+public DisplayMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+När den finns i ett Group-element specificerar DisplayMode-elementet hur en gruppform och dess medlemmar visas. När den finns i ett SmartTagDef-element bestämmer DisplayMode-elementet om smart-taggen visas när användaren håller musen över taggen, när formen är markerad, eller hela tiden.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/displaymode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
+++ b/swedish/java/com.aspose.diagram/displaymodesmarttagdef/_index.md
@@ -1,0 +1,179 @@
+---
+title: DisplayModeSmartTagDef
+second_title: Aspose.Diagram för Java API-referens
+description: DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen när formen är markerad eller hela tiden.
+type: docs
+weight: 121
+url: /sv/java/com.aspose.diagram/displaymodesmarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DisplayModeSmartTagDef
+```
+
+DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DisplayModeSmartTagDef(int value)](#DisplayModeSmartTagDef-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DisplayModeSmartTagDef(int value) {#DisplayModeSmartTagDef-int-}
+```
+public DisplayModeSmartTagDef(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/displaymodesmarttagdef\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/displaymodesmarttagdefvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeSmartTagDefValue
+second_title: Aspose.Diagram för Java API-referens
+description: DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen när formen är markerad eller hela tiden.
+type: docs
+weight: 122
+url: /sv/java/com.aspose.diagram/displaymodesmarttagdefvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeSmartTagDefValue
+```
+
+DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALL_TIME](#ALL-TIME) | Visar gruppformen framför medlemsformerna. |
+| [MOUSE_IS_PAUSED](#MOUSE-IS-PAUSED) | Döljer gruppformen och texten. |
+| [SHAPE_IS_SELECTED](#SHAPE-IS-SELECTED) | Visar gruppformen bakom medlemsformerna. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_TIME {#ALL-TIME}
+```
+public static final int ALL_TIME
+```
+
+
+Visar gruppformen framför medlemsformerna.
+
+### MOUSE_IS_PAUSED {#MOUSE-IS-PAUSED}
+```
+public static final int MOUSE_IS_PAUSED
+```
+
+
+Döljer gruppformen och texten.
+
+### SHAPE_IS_SELECTED {#SHAPE-IS-SELECTED}
+```
+public static final int SHAPE_IS_SELECTED
+```
+
+
+Visar gruppformen bakom medlemsformerna.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/displaymodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/displaymodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DisplayModeValue
+second_title: Aspose.Diagram för Java API-referens
+description: När den finns i ett Group-element specificerar DisplayMode-elementet hur en gruppform och dess medlemmar visas.
+type: docs
+weight: 123
+url: /sv/java/com.aspose.diagram/displaymodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DisplayModeValue
+```
+
+När den finns i ett Group-element specificerar DisplayMode-elementet hur en gruppform och dess medlemmar visas. När den finns i ett SmartTagDef-element bestämmer DisplayMode-elementet om smart-taggen visas när användaren håller musen över taggen, när formen är markerad, eller hela tiden.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES](#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES) | Visar gruppformen bakom medlemsformerna. |
+| [DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES](#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES) | Visar gruppformen framför medlemsformerna. |
+| [HIDES_SHAPE_TEXT](#HIDES-SHAPE-TEXT) | Döljer gruppformen och texten. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES {#DISPLAYS-SHAPE-BEHIND-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_BEHIND_MEMBER_SHAPES
+```
+
+
+Visar gruppformen bakom medlemsformerna.
+
+### DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES {#DISPLAYS-SHAPE-FRONT-MEMBER-SHAPES}
+```
+public static final int DISPLAYS_SHAPE_FRONT_MEMBER_SHAPES
+```
+
+
+Visar gruppformen framför medlemsformerna.
+
+### HIDES_SHAPE_TEXT {#HIDES-SHAPE-TEXT}
+```
+public static final int HIDES_SHAPE_TEXT
+```
+
+
+Döljer gruppformen och texten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/docprops/_index.md
+++ b/swedish/java/com.aspose.diagram/docprops/_index.md
@@ -1,0 +1,227 @@
+---
+title: DocProps
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr dokumentets förhandsgranskningskvalitet, omfång och utdataformat.
+type: docs
+weight: 124
+url: /sv/java/com.aspose.diagram/docprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocProps
+```
+
+Innehåller element som styr dokumentets förhandsgranskningskvalitet, omfattning och utdataformat.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddMarkup()](#getAddMarkup--) | Anger om dokumentet granskas för markup. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDocLangID()](#getDocLangID--) | Anger standardspråket för dokumentet. |
+| [getLockPreview()](#getLockPreview--) | Specificerar om en förhandsgranskning sparas varje gång du sparar en ritning. |
+| [getOutputFormat()](#getOutputFormat--) | Anger utdataformatet för en ritning. |
+| [getPreviewQuality()](#getPreviewQuality--) | Specificerar om ritningsförhandsgranskningen är i utkastkvalitet eller detaljerad. |
+| [getPreviewScope()](#getPreviewScope--) | Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet. |
+| [getViewMarkup()](#getViewMarkup--) | Bestämmer om markup visas i ritningsfönstret. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/docprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddMarkup() {#getAddMarkup--}
+```
+public BoolValue getAddMarkup()
+```
+
+
+Anger om dokumentet granskas för markup.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDocLangID() {#getDocLangID--}
+```
+public IntValue getDocLangID()
+```
+
+
+Anger standardspråket för dokumentet.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLockPreview() {#getLockPreview--}
+```
+public BoolValue getLockPreview()
+```
+
+
+Specificerar om en förhandsgranskning sparas varje gång du sparar en ritning.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getOutputFormat() {#getOutputFormat--}
+```
+public OutputFormat getOutputFormat()
+```
+
+
+Anger utdataformatet för en ritning.
+
+**Returns:**
+[OutputFormat](../../com.aspose.diagram/outputformat)
+### getPreviewQuality() {#getPreviewQuality--}
+```
+public BoolValue getPreviewQuality()
+```
+
+
+Specificerar om ritningsförhandsgranskningen är i utkastkvalitet eller detaljerad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPreviewScope() {#getPreviewScope--}
+```
+public PreviewScope getPreviewScope()
+```
+
+
+Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+
+**Returns:**
+[PreviewScope](../../com.aspose.diagram/previewscope)
+### getViewMarkup() {#getViewMarkup--}
+```
+public BoolValue getViewMarkup()
+```
+
+
+Bestämmer om markup visas i ritningsfönstret.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/docprops\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/documentproperties/_index.md
+++ b/swedish/java/com.aspose.diagram/documentproperties/_index.md
@@ -1,0 +1,616 @@
+---
+title: DocumentProperties
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller dokumentegenskapselement såsom dokumentets titel, författare och så vidare.
+type: docs
+weight: 125
+url: /sv/java/com.aspose.diagram/documentproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentProperties
+```
+
+Innehåller element för dokumentegenskaper såsom dokumentets titel, författare osv.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlternateNames()](#getAlternateNames--) | Anger alternativa namn för ett dokument. |
+| [getBuildNumberCreated()](#getBuildNumberCreated--) | Innehåller det fullständiga byggnumret för den instans som användes för att skapa dokumentet. |
+| [getBuildNumberEdited()](#getBuildNumberEdited--) | Innehåller byggnumret för den instans som senast användes för att redigera dokumentet. |
+| [getCategory()](#getCategory--) | Anger den beskrivande texten för ritningstypen, såsom flödesschema eller kontorslayout. |
+| [getClass()](#getClass--) |  |
+| [getCompany()](#getCompany--) | Innehåller användarinmatad information som identifierar företaget som skapar ritningen eller företaget som ritningen skapas för. |
+| [getCreator()](#getCreator--) | Identifierar vem som skapade eller senast uppdaterade filen. |
+| [getCustomProps()](#getCustomProps--) | Samling av CustomProp. |
+| [getDesc()](#getDesc--) | Innehåller en beskrivande textsträng för ett dokument. |
+| [getHyperlinkBase()](#getHyperlinkBase--) | Innehåller sökvägen som ska användas för relativa hyperlänkar (hyperlänkar där den länkade filens plats beskrivs i förhållande till Microsoft Visio-diagrammet). |
+| [getKeywords()](#getKeywords--) | Innehåller en textsträng som identifierar ämnen eller annan viktig information om filen, såsom projektnamn, kundnamn eller versionsnummer. |
+| [getLanguage()](#getLanguage--) | Anger språket |
+| [getManager()](#getManager--) | Innehåller en användarinskriven textsträng som identifierar den ansvariga för projektet eller avdelningen. |
+| [getPreviewPicture()](#getPreviewPicture--) | Innehåller en metafilström som fungerar som en förhandsgranskning av dokumentet. |
+| [getSubject()](#getSubject--) | Innehåller en användardefinierad textsträng som beskriver dokumentets innehåll. |
+| [getTemplate()](#getTemplate--) | Innehåller ett strängvärde som anger filnamnet på mallen som dokumentet skapades från. |
+| [getTimeCreated()](#getTimeCreated--) | Innehåller datum- och tidsvärde som anger när dokumentet skapades. |
+| [getTimeEdited()](#getTimeEdited--) | Innehåller datum- och tidsvärde som anger när dokumentet senast redigerades. |
+| [getTimePrinted()](#getTimePrinted--) | Innehåller datum- och tidsvärde som anger när dokumentet senast skrevs ut. |
+| [getTimeSaved()](#getTimeSaved--) | Innehåller datum- och tidsvärde som anger när dokumentet senast sparades. |
+| [getTitle()](#getTitle--) | Innehåller en användardefinierad textsträng som fungerar som en beskrivande titel för dokumentet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlternateNames(String value)](#setAlternateNames-java.lang.String-) | För beskrivningen av denna egenskap, se [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--) |
+| [setBuildNumberCreated(String value)](#setBuildNumberCreated-java.lang.String-) | För beskrivningen av denna egenskap, se [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--) |
+| [setBuildNumberEdited(String value)](#setBuildNumberEdited-java.lang.String-) | För beskrivningen av denna egenskap, se [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--) |
+| [setCategory(String value)](#setCategory-java.lang.String-) | För beskrivningen av denna egenskap, se [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--) |
+| [setCompany(String value)](#setCompany-java.lang.String-) | För beskrivningen av denna egenskap, se [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--) |
+| [setCreator(String value)](#setCreator-java.lang.String-) | För beskrivningen av denna egenskap, se [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--) |
+| [setDesc(String value)](#setDesc-java.lang.String-) | För beskrivningen av denna egenskap, se [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--) |
+| [setHyperlinkBase(String value)](#setHyperlinkBase-java.lang.String-) | För beskrivningen av denna egenskap, se [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--) |
+| [setKeywords(String value)](#setKeywords-java.lang.String-) | För beskrivningen av denna egenskap, se [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--) |
+| [setLanguage(String value)](#setLanguage-java.lang.String-) | För beskrivningen av denna egenskap, se [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--) |
+| [setManager(String value)](#setManager-java.lang.String-) | För beskrivningen av denna egenskap, se [getManager()](../../com.aspose.diagram/documentproperties\#getManager--) |
+| [setPreviewPicture(byte[] value)](#setPreviewPicture-byte---) | För beskrivningen av denna egenskap, se [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--) |
+| [setSubject(String value)](#setSubject-java.lang.String-) | För beskrivningen av denna egenskap, se [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--) |
+| [setTemplate(String value)](#setTemplate-java.lang.String-) | För beskrivningen av denna egenskap, se [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--) |
+| [setTimeCreated(DateTime value)](#setTimeCreated-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--) |
+| [setTimeEdited(DateTime value)](#setTimeEdited-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--) |
+| [setTimePrinted(DateTime value)](#setTimePrinted-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--) |
+| [setTimeSaved(DateTime value)](#setTimeSaved-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | För beskrivningen av denna egenskap, se [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlternateNames() {#getAlternateNames--}
+```
+public String getAlternateNames()
+```
+
+
+Anger alternativa namn för ett dokument.
+
+**Returns:**
+java.lang.String
+### getBuildNumberCreated() {#getBuildNumberCreated--}
+```
+public String getBuildNumberCreated()
+```
+
+
+Innehåller det fullständiga byggnumret för den instans som användes för att skapa dokumentet.
+
+**Returns:**
+java.lang.String
+### getBuildNumberEdited() {#getBuildNumberEdited--}
+```
+public String getBuildNumberEdited()
+```
+
+
+Innehåller byggnumret för den instans som senast användes för att redigera dokumentet.
+
+**Returns:**
+java.lang.String
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Anger den beskrivande texten för ritningstypen, t.ex. flödesschema eller kontorslayout. Denna text kan också anges i Microsoft Visio-användargränssnittet i Kategori-rutan i dialogrutan Egenskaper.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompany() {#getCompany--}
+```
+public String getCompany()
+```
+
+
+Innehåller användarinskriven information som identifierar företaget som skapar ritningen eller företaget som ritningen skapas för. Maxlängden är 63 tecken.
+
+**Returns:**
+java.lang.String
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+Identifierar vem som skapade eller senast uppdaterade filen. Maxlängden är 63 tecken.
+
+**Returns:**
+java.lang.String
+### getCustomProps() {#getCustomProps--}
+```
+public CustomPropCollection getCustomProps()
+```
+
+
+Samling av CustomProp.
+
+**Returns:**
+[CustomPropCollection](../../com.aspose.diagram/custompropcollection)
+### getDesc() {#getDesc--}
+```
+public String getDesc()
+```
+
+
+Innehåller en beskrivande textsträng för ett dokument. Använd detta element för att lagra viktig information om dokumentet, såsom dess syfte, senaste ändringar eller pågående ändringar. Maxlängden är 191 tecken.
+
+**Returns:**
+java.lang.String
+### getHyperlinkBase() {#getHyperlinkBase--}
+```
+public String getHyperlinkBase()
+```
+
+
+Innehåller sökvägen som ska användas för relativa hyperlänkar (hyperlänkar där den länkade filens plats beskrivs i förhållande till Microsoft Visio-diagrammet). Som standard är en hyperlänksökväg relativ till det aktuella dokumentet om inte en annan sökväg anges i detta element. Maxlängden är 256 tecken.
+
+**Returns:**
+java.lang.String
+### getKeywords() {#getKeywords--}
+```
+public String getKeywords()
+```
+
+
+Innehåller en textsträng som identifierar ämnen eller annan viktig information om filen, såsom projektnamn, kundnamn eller versionsnummer. Maxlängden på strängen är 63 tecken.
+
+**Returns:**
+java.lang.String
+### getLanguage() {#getLanguage--}
+```
+public String getLanguage()
+```
+
+
+Anger språket
+
+```
+setLanguage("en-GB");
+         setLanguage("en-US");
+```
+
+**Returns:**
+java.lang.String
+### getManager() {#getManager--}
+```
+public String getManager()
+```
+
+
+Innehåller en användarinskriven textsträng som identifierar den ansvariga personen för projektet eller avdelningen. Maxlängden är 63 tecken.
+
+**Returns:**
+java.lang.String
+### getPreviewPicture() {#getPreviewPicture--}
+```
+public byte[] getPreviewPicture()
+```
+
+
+Innehåller en metafilström som fungerar som en förhandsgranskning av dokumentet.
+
+**Returns:**
+byte[]
+### getSubject() {#getSubject--}
+```
+public String getSubject()
+```
+
+
+Innehåller en användardefinierad textsträng som beskriver dokumentets innehåll. Maxlängden är 63 tecken.
+
+**Returns:**
+java.lang.String
+### getTemplate() {#getTemplate--}
+```
+public String getTemplate()
+```
+
+
+Innehåller ett strängvärde som anger filnamnet på mallen som dokumentet skapades från.
+
+**Returns:**
+java.lang.String
+### getTimeCreated() {#getTimeCreated--}
+```
+public DateTime getTimeCreated()
+```
+
+
+Innehåller datum- och tidsvärde som anger när dokumentet skapades.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeEdited() {#getTimeEdited--}
+```
+public DateTime getTimeEdited()
+```
+
+
+Innehåller datum- och tidsvärde som anger när dokumentet senast redigerades.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePrinted() {#getTimePrinted--}
+```
+public DateTime getTimePrinted()
+```
+
+
+Innehåller datum- och tidsvärde som anger när dokumentet senast skrevs ut.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeSaved() {#getTimeSaved--}
+```
+public DateTime getTimeSaved()
+```
+
+
+Innehåller datum- och tidsvärde som anger när dokumentet senast sparades.
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+Innehåller en användardefinierad textsträng som fungerar som en beskrivande titel för dokumentet. Maxlängden är 63 tecken.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlternateNames(String value) {#setAlternateNames-java.lang.String-}
+```
+public void setAlternateNames(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAlternateNames()](../../com.aspose.diagram/documentproperties\#getAlternateNames--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setBuildNumberCreated(String value) {#setBuildNumberCreated-java.lang.String-}
+```
+public void setBuildNumberCreated(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBuildNumberCreated()](../../com.aspose.diagram/documentproperties\#getBuildNumberCreated--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setBuildNumberEdited(String value) {#setBuildNumberEdited-java.lang.String-}
+```
+public void setBuildNumberEdited(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBuildNumberEdited()](../../com.aspose.diagram/documentproperties\#getBuildNumberEdited--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCategory()](../../com.aspose.diagram/documentproperties\#getCategory--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setCompany(String value) {#setCompany-java.lang.String-}
+```
+public void setCompany(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCompany()](../../com.aspose.diagram/documentproperties\#getCompany--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setCreator(String value) {#setCreator-java.lang.String-}
+```
+public void setCreator(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCreator()](../../com.aspose.diagram/documentproperties\#getCreator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDesc(String value) {#setDesc-java.lang.String-}
+```
+public void setDesc(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDesc()](../../com.aspose.diagram/documentproperties\#getDesc--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHyperlinkBase(String value) {#setHyperlinkBase-java.lang.String-}
+```
+public void setHyperlinkBase(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHyperlinkBase()](../../com.aspose.diagram/documentproperties\#getHyperlinkBase--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setKeywords(String value) {#setKeywords-java.lang.String-}
+```
+public void setKeywords(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getKeywords()](../../com.aspose.diagram/documentproperties\#getKeywords--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setLanguage(String value) {#setLanguage-java.lang.String-}
+```
+public void setLanguage(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLanguage()](../../com.aspose.diagram/documentproperties\#getLanguage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setManager(String value) {#setManager-java.lang.String-}
+```
+public void setManager(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getManager()](../../com.aspose.diagram/documentproperties\#getManager--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPreviewPicture(byte[] value) {#setPreviewPicture-byte---}
+```
+public void setPreviewPicture(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPreviewPicture()](../../com.aspose.diagram/documentproperties\#getPreviewPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setSubject(String value) {#setSubject-java.lang.String-}
+```
+public void setSubject(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSubject()](../../com.aspose.diagram/documentproperties\#getSubject--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTemplate(String value) {#setTemplate-java.lang.String-}
+```
+public void setTemplate(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTemplate()](../../com.aspose.diagram/documentproperties\#getTemplate--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTimeCreated(DateTime value) {#setTimeCreated-com.aspose.diagram.DateTime-}
+```
+public void setTimeCreated(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimeCreated()](../../com.aspose.diagram/documentproperties\#getTimeCreated--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeEdited(DateTime value) {#setTimeEdited-com.aspose.diagram.DateTime-}
+```
+public void setTimeEdited(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimeEdited()](../../com.aspose.diagram/documentproperties\#getTimeEdited--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePrinted(DateTime value) {#setTimePrinted-com.aspose.diagram.DateTime-}
+```
+public void setTimePrinted(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimePrinted()](../../com.aspose.diagram/documentproperties\#getTimePrinted--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeSaved(DateTime value) {#setTimeSaved-com.aspose.diagram.DateTime-}
+```
+public void setTimeSaved(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTimeSaved()](../../com.aspose.diagram/documentproperties\#getTimeSaved--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTitle()](../../com.aspose.diagram/documentproperties\#getTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/documentsettings/_index.md
+++ b/swedish/java/com.aspose.diagram/documentsettings/_index.md
@@ -1,0 +1,550 @@
+---
+title: DocumentSettings
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar dokumentinställningar.
+type: docs
+weight: 126
+url: /sv/java/com.aspose.diagram/documentsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSettings
+```
+
+Innehåller element som specificerar dokumentinställningar.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAttachedToolbars()](#getAttachedToolbars--) | En MIME (Multipurpose Internet Mail Extensions) kodad Microsoft Visio-användargränssnitt (VSU)-fil som representerar anpassade verktygsfält. |
+| [getClass()](#getClass--) |  |
+| [getCustomMenusFile()](#getCustomMenusFile--) | Innehåller namnet på Microsoft Visio-användargränssnittet (.vsu)-filen som definierar anpassade menyer och acceleratorer för ett dokument. |
+| [getCustomToolbarsFile()](#getCustomToolbarsFile--) | Innehåller namnet på Microsoft Visio-användargränssnittet (.vsu)-filen som definierar anpassade verktygsfält och statusfält för ett dokument. |
+| [getDefaultFillStyle()](#getDefaultFillStyle--) | Anger ID för ett StyleSheet-element. |
+| [getDefaultGuideStyle()](#getDefaultGuideStyle--) | Anger ID för ett StyleSheet-element. |
+| [getDefaultLineStyle()](#getDefaultLineStyle--) | Anger ID för ett StyleSheet-element. |
+| [getDefaultTextStyle()](#getDefaultTextStyle--) | Anger ID för ett StyleSheet-element. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Anger om den dynamiska rutnätsfunktionen är aktiverad för ett dokument eller ett fönster. |
+| [getGlueSettings()](#getGlueSettings--) | Anger de objekt som former limmas till när lim är aktiverat i dokumentet. |
+| [getProtectBkgnds()](#getProtectBkgnds--) | Anger om användaren hindras från att radera eller redigera bakgrundssidor. |
+| [getProtectMasters()](#getProtectMasters--) | Anger om användaren hindras från att skapa, redigera eller radera masterobjekt. |
+| [getProtectShapes()](#getProtectShapes--) | Anger om användaren hindras från att välja former som har sitt LockSelect‑element satt till 1. |
+| [getProtectStyles()](#getProtectStyles--) | Anger om användaren hindras från att skapa eller redigera stilar. |
+| [getSnapAngles()](#getSnapAngles--) | Innehåller en samling av SnapAngle‑element. |
+| [getSnapExtensions()](#getSnapExtensions--) | Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret. |
+| [getSnapSettings()](#getSnapSettings--) | Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret. |
+| [getTopPage()](#getTopPage--) | Anger ID‑t för den sida som ska visas när dokumentet öppnas av Microsoft Visio. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAttachedToolbars(byte[] value)](#setAttachedToolbars-byte---) | För beskrivningen av denna egenskap, se [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--) |
+| [setCustomMenusFile(String value)](#setCustomMenusFile-java.lang.String-) | För beskrivningen av denna egenskap, se [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--) |
+| [setCustomToolbarsFile(String value)](#setCustomToolbarsFile-java.lang.String-) | För beskrivningen av denna egenskap, se [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--) |
+| [setDefaultFillStyle(int value)](#setDefaultFillStyle-int-) | För beskrivningen av denna egenskap, se [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--) |
+| [setDefaultGuideStyle(int value)](#setDefaultGuideStyle-int-) | För beskrivningen av denna egenskap, se [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--) |
+| [setDefaultLineStyle(int value)](#setDefaultLineStyle-int-) | För beskrivningen av denna egenskap, se [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--) |
+| [setDefaultTextStyle(int value)](#setDefaultTextStyle-int-) | För beskrivningen av denna egenskap, se [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | För beskrivningen av denna egenskap, se [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | För beskrivningen av denna egenskap, se [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--) |
+| [setProtectBkgnds(int value)](#setProtectBkgnds-int-) | För beskrivningen av denna egenskap, se [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--) |
+| [setProtectMasters(int value)](#setProtectMasters-int-) | För beskrivningen av denna egenskap, se [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--) |
+| [setProtectShapes(int value)](#setProtectShapes-int-) | För beskrivningen av denna egenskap, se [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--) |
+| [setProtectStyles(int value)](#setProtectStyles-int-) | För beskrivningen av denna egenskap, se [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--) |
+| [setSnapAngles(FloatPointNumCollection value)](#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-) | För beskrivningen av denna egenskap, se [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | För beskrivningen av denna egenskap, se [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | För beskrivningen av denna egenskap, se [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--) |
+| [setTopPage(int value)](#setTopPage-int-) | För beskrivningen av denna egenskap, se [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAttachedToolbars() {#getAttachedToolbars--}
+```
+public byte[] getAttachedToolbars()
+```
+
+
+En MIME (Multipurpose Internet Mail Extensions) kodad Microsoft Visio-användargränssnitt (VSU)-fil som representerar anpassade verktygsfält.
+
+**Returns:**
+byte[]
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomMenusFile() {#getCustomMenusFile--}
+```
+public String getCustomMenusFile()
+```
+
+
+Innehåller namnet på Microsoft Visio-användargränssnittet (.vsu)-filen som definierar anpassade menyer och acceleratorer för ett dokument.
+
+**Returns:**
+java.lang.String
+### getCustomToolbarsFile() {#getCustomToolbarsFile--}
+```
+public String getCustomToolbarsFile()
+```
+
+
+Innehåller namnet på Microsoft Visio-användargränssnittet (.vsu)-filen som definierar anpassade verktygsfält och statusfält för ett dokument.
+
+**Returns:**
+java.lang.String
+### getDefaultFillStyle() {#getDefaultFillStyle--}
+```
+public int getDefaultFillStyle()
+```
+
+
+Anger ID‑t för ett StyleSheet‑element. Nästa gång användaren skapar en form med ett ritverktyg, ärver formen sin fyllningsstil från det angivna StyleSheet‑elementet.
+
+**Returns:**
+int
+### getDefaultGuideStyle() {#getDefaultGuideStyle--}
+```
+public int getDefaultGuideStyle()
+```
+
+
+Anger ID‑t för ett StyleSheet‑element. Nästa gång användaren skapar en guide, ärver guiden sin guidestil från det angivna StyleSheet‑elementet.
+
+**Returns:**
+int
+### getDefaultLineStyle() {#getDefaultLineStyle--}
+```
+public int getDefaultLineStyle()
+```
+
+
+Anger ID‑t för ett StyleSheet‑element. Nästa gång användaren skapar en form med ett ritverktyg, ärver formen sin linjestil från det angivna StyleSheet‑elementet.
+
+**Returns:**
+int
+### getDefaultTextStyle() {#getDefaultTextStyle--}
+```
+public int getDefaultTextStyle()
+```
+
+
+Anger ID‑t för ett StyleSheet‑element. Nästa gång användaren skapar en form med ett ritverktyg, ärver formen sin textstil från det angivna StyleSheet‑elementet.
+
+**Returns:**
+int
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Anger om den dynamiska rutnätsfunktionen är aktiverad för ett dokument eller ett fönster.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Anger de objekt som former limmas till när lim är aktiverat i dokumentet.
+
+**Returns:**
+int
+### getProtectBkgnds() {#getProtectBkgnds--}
+```
+public int getProtectBkgnds()
+```
+
+
+Anger om användaren hindras från att radera eller redigera bakgrundssidor.
+
+**Returns:**
+int
+### getProtectMasters() {#getProtectMasters--}
+```
+public int getProtectMasters()
+```
+
+
+Anger om användaren hindras från att skapa, redigera eller ta bort masters. Oavsett denna inställning kan användaren fortfarande skapa instanser av masters.
+
+**Returns:**
+int
+### getProtectShapes() {#getProtectShapes--}
+```
+public int getProtectShapes()
+```
+
+
+Anger om användaren hindras från att välja former som har sitt LockSelect‑element satt till 1.
+
+**Returns:**
+int
+### getProtectStyles() {#getProtectStyles--}
+```
+public int getProtectStyles()
+```
+
+
+Anger om användaren hindras från att skapa eller redigera stilar. Dock, oavsett denna inställning, kan användaren fortfarande tillämpa stilar.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Innehåller en samling av SnapAngle‑element.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret.
+
+**Returns:**
+int
+### getTopPage() {#getTopPage--}
+```
+public int getTopPage()
+```
+
+
+Anger ID‑t för den sida som ska visas när dokumentet öppnas av Microsoft Visio.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAttachedToolbars(byte[] value) {#setAttachedToolbars-byte---}
+```
+public void setAttachedToolbars(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAttachedToolbars()](../../com.aspose.diagram/documentsettings\#getAttachedToolbars--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setCustomMenusFile(String value) {#setCustomMenusFile-java.lang.String-}
+```
+public void setCustomMenusFile(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCustomMenusFile()](../../com.aspose.diagram/documentsettings\#getCustomMenusFile--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setCustomToolbarsFile(String value) {#setCustomToolbarsFile-java.lang.String-}
+```
+public void setCustomToolbarsFile(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCustomToolbarsFile()](../../com.aspose.diagram/documentsettings\#getCustomToolbarsFile--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDefaultFillStyle(int value) {#setDefaultFillStyle-int-}
+```
+public void setDefaultFillStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFillStyle()](../../com.aspose.diagram/documentsettings\#getDefaultFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDefaultGuideStyle(int value) {#setDefaultGuideStyle-int-}
+```
+public void setDefaultGuideStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultGuideStyle()](../../com.aspose.diagram/documentsettings\#getDefaultGuideStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDefaultLineStyle(int value) {#setDefaultLineStyle-int-}
+```
+public void setDefaultLineStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultLineStyle()](../../com.aspose.diagram/documentsettings\#getDefaultLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDefaultTextStyle(int value) {#setDefaultTextStyle-int-}
+```
+public void setDefaultTextStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultTextStyle()](../../com.aspose.diagram/documentsettings\#getDefaultTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDynamicGridEnabled()](../../com.aspose.diagram/documentsettings\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getGlueSettings()](../../com.aspose.diagram/documentsettings\#getGlueSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setProtectBkgnds(int value) {#setProtectBkgnds-int-}
+```
+public void setProtectBkgnds(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getProtectBkgnds()](../../com.aspose.diagram/documentsettings\#getProtectBkgnds--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setProtectMasters(int value) {#setProtectMasters-int-}
+```
+public void setProtectMasters(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getProtectMasters()](../../com.aspose.diagram/documentsettings\#getProtectMasters--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setProtectShapes(int value) {#setProtectShapes-int-}
+```
+public void setProtectShapes(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getProtectShapes()](../../com.aspose.diagram/documentsettings\#getProtectShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setProtectStyles(int value) {#setProtectStyles-int-}
+```
+public void setProtectStyles(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getProtectStyles()](../../com.aspose.diagram/documentsettings\#getProtectStyles--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSnapAngles(FloatPointNumCollection value) {#setSnapAngles-com.aspose.diagram.FloatPointNumCollection-}
+```
+public void setSnapAngles(FloatPointNumCollection value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSnapAngles()](../../com.aspose.diagram/documentsettings\#getSnapAngles--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection) |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSnapExtensions()](../../com.aspose.diagram/documentsettings\#getSnapExtensions--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSnapSettings()](../../com.aspose.diagram/documentsettings\#getSnapSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTopPage(int value) {#setTopPage-int-}
+```
+public void setTopPage(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTopPage()](../../com.aspose.diagram/documentsettings\#getTopPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/documentsheet/_index.md
+++ b/swedish/java/com.aspose.diagram/documentsheet/_index.md
@@ -1,0 +1,396 @@
+---
+title: DocumentSheet
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar ett dokuments ShapeSheet-struktur.
+type: docs
+weight: 127
+url: /sv/java/com.aspose.diagram/documentsheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentSheet
+```
+
+Anger ett dokuments ShapeSheet-struktur.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAnnotations()](#getAnnotations--) | Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Innehåller en samling av ConnectionABCD-element. |
+| [getConnections()](#getConnections--) | Innehåller en samling av Connection-element. |
+| [getDocProps()](#getDocProps--) | Innehåller element som styr dokumentets förhandsgranskningskvalitet, omfattning och utdataformat. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-element från vilket detta stil ärver fyllningsformatering. |
+| [getForeign()](#getForeign--) | Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. |
+| [getForeignData()](#getForeignData--) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [getHyperlinks()](#getHyperlinks--) | Innehåller en samling Hyperlink-element. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-element från vilket detta stil ärver linjeformatering. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getProps()](#getProps--) | Innehåller en samling Prop-element. |
+| [getReviewers()](#getReviewers--) | Innehåller element som innehåller identifierande information om en dokumentgranskare. |
+| [getScratchs()](#getScratchs--) | Innehåller en samling Scratch-element. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-element från vilket detta stil ärver textformatering. |
+| [getUniqueID()](#getUniqueID--) | En GUID (globalt unik identifierare) som identifierar formen. |
+| [getUsers()](#getUsers--) | Innehåller en samling User-element. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/documentsheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Innehåller en samling av ConnectionABCD-element.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Innehåller en samling av Connection-element.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getDocProps() {#getDocProps--}
+```
+public DocProps getDocProps()
+```
+
+
+Innehåller element som styr dokumentets förhandsgranskningskvalitet, omfattning och utdataformat.
+
+**Returns:**
+[DocProps](../../com.aspose.diagram/docprops)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver fyllningsformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. Inkluderar också element som specificerar avståndet som objektets bild förskjuts inom dess kanter.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Innehåller en samling Hyperlink-element.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver linjeformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Innehåller en samling Prop-element.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getReviewers() {#getReviewers--}
+```
+public ReviewerCollection getReviewers()
+```
+
+
+Innehåller element som innehåller identifierande information om en dokumentgranskare.
+
+**Returns:**
+[ReviewerCollection](../../com.aspose.diagram/reviewercollection)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Innehåller en samling Scratch-element.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver textformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+En GUID (globalt unik identifierare) som identifierar formen.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Innehåller en samling User-element.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/documentsheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/documentsheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/documentsheet\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/documentsheet\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/documentsheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/documentsheet\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/doublevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/doublevalue/_index.md
@@ -1,0 +1,239 @@
+---
+title: DoubleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Dubbelvärde
+type: docs
+weight: 128
+url: /sv/java/com.aspose.diagram/doublevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DoubleValue
+```
+
+Dubbelvärde
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DoubleValue(double value, int unit)](#DoubleValue-double-int-) | Konstruktor. |
+| [DoubleValue()](#DoubleValue--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Dubbelvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | För beskrivningen av denna egenskap, se [isThemed()](../../com.aspose.diagram/doublevalue\\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/doublevalue\\#getUfe--) |
+| [setValue(double value)](#setValue-double-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/doublevalue\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DoubleValue(double value, int unit) {#DoubleValue-double-int-}
+```
+public DoubleValue(double value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+| enhet | int |  |
+
+### DoubleValue() {#DoubleValue--}
+```
+public DoubleValue()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Dubbelvärde.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isThemed()](../../com.aspose.diagram/doublevalue\\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/doublevalue\\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/doublevalue\\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingresizetype/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingresizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingResizeType
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+type: docs
+weight: 129
+url: /sv/java/com.aspose.diagram/drawingresizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingResizeType
+```
+
+Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DrawingResizeType(int value)](#DrawingResizeType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingResizeType(int value) {#DrawingResizeType-int-}
+```
+public DrawingResizeType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/drawingresizetype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingresizetypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingresizetypevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DrawingResizeTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+type: docs
+weight: 130
+url: /sv/java/com.aspose.diagram/drawingresizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingResizeTypeValue
+```
+
+Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [AUTOMATICALLY](#AUTOMATICALLY) | Ritningssidan ändrar storlek automatiskt. |
+| [DEPENDS_ON_DRAWING_SIZE_TYPE](#DEPENDS-ON-DRAWING-SIZE-TYPE) | Om sidan ändrar storlek automatiskt beror på värdet i cellen DrawingSizeType. |
+| [NOT_AUTOMATICALLY](#NOT-AUTOMATICALLY) | Ritningssidan ändrar inte storlek automatiskt. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATICALLY {#AUTOMATICALLY}
+```
+public static final int AUTOMATICALLY
+```
+
+
+Ritningssidan ändrar storlek automatiskt.
+
+### DEPENDS_ON_DRAWING_SIZE_TYPE {#DEPENDS-ON-DRAWING-SIZE-TYPE}
+```
+public static final int DEPENDS_ON_DRAWING_SIZE_TYPE
+```
+
+
+Om sidan ändrar storlek automatiskt beror på värdet i cellen DrawingSizeType. Om DrawingSizeType = 0 (ritningssidans storlek är densamma som den utskrivna sidans storlek) ändras sidan automatiskt. Om värdet i DrawingSizeType är något annat än noll (0) ändras sidan inte automatiskt.
+
+### NOT_AUTOMATICALLY {#NOT-AUTOMATICALLY}
+```
+public static final int NOT_AUTOMATICALLY
+```
+
+
+Ritningssidan ändrar inte storlek automatiskt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingscaletype/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingscaletype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingScaleType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av ritningsskala som ska användas för en sida.
+type: docs
+weight: 131
+url: /sv/java/com.aspose.diagram/drawingscaletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingScaleType
+```
+
+Anger vilken typ av ritningsskala som ska användas för en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DrawingScaleType(int value)](#DrawingScaleType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger vilken typ av ritningsskala som ska användas för en sida. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/drawingscaletype\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingScaleType(int value) {#DrawingScaleType-int-}
+```
+public DrawingScaleType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger vilken typ av ritningsskala som ska användas för en sida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/drawingscaletype\\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingscaletypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingscaletypevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: DrawingScaleTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av ritningsskala som ska användas för en sida.
+type: docs
+weight: 132
+url: /sv/java/com.aspose.diagram/drawingscaletypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingScaleTypeValue
+```
+
+Anger vilken typ av ritningsskala som ska användas för en sida.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ARCHITECTURAL_SCALE](#ARCHITECTURAL-SCALE) | Arkitektonisk skala. |
+| [CIVIL_ENGINEERING_SCALE](#CIVIL-ENGINEERING-SCALE) | Skala för byggnadsteknik. |
+| [CUSTOM_SCALE](#CUSTOM-SCALE) | Anpassad skala. |
+| [MECHANICAL_ENGINEERING_SCALE](#MECHANICAL-ENGINEERING-SCALE) | Skala för maskinteknik. |
+| [METRIC_SCALE](#METRIC-SCALE) | Metrisk skala. |
+| [NO_SCALE](#NO-SCALE) | Ingen skala. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARCHITECTURAL_SCALE {#ARCHITECTURAL-SCALE}
+```
+public static final int ARCHITECTURAL_SCALE
+```
+
+
+Arkitektonisk skala.
+
+### CIVIL_ENGINEERING_SCALE {#CIVIL-ENGINEERING-SCALE}
+```
+public static final int CIVIL_ENGINEERING_SCALE
+```
+
+
+Skala för byggnadsteknik.
+
+### CUSTOM_SCALE {#CUSTOM-SCALE}
+```
+public static final int CUSTOM_SCALE
+```
+
+
+Anpassad skala.
+
+### MECHANICAL_ENGINEERING_SCALE {#MECHANICAL-ENGINEERING-SCALE}
+```
+public static final int MECHANICAL_ENGINEERING_SCALE
+```
+
+
+Skala för maskinteknik.
+
+### METRIC_SCALE {#METRIC-SCALE}
+```
+public static final int METRIC_SCALE
+```
+
+
+Metrisk skala.
+
+### NO_SCALE {#NO-SCALE}
+```
+public static final int NO_SCALE
+```
+
+
+Ingen skala.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingsizetype/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingsizetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: DrawingSizeType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger ritningsstorleken för en sida.
+type: docs
+weight: 133
+url: /sv/java/com.aspose.diagram/drawingsizetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DrawingSizeType
+```
+
+Anger ritningsstorleken för en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DrawingSizeType(int value)](#DrawingSizeType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger ritningsstorleken för en sida. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DrawingSizeType(int value) {#DrawingSizeType-int-}
+```
+public DrawingSizeType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger ritningsstorleken för en sida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/drawingsizetype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/drawingsizetypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/drawingsizetypevalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: DrawingSizeTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger ritningsstorleken för en sida.
+type: docs
+weight: 134
+url: /sv/java/com.aspose.diagram/drawingsizetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DrawingSizeTypeValue
+```
+
+Anger ritningsstorleken för en sida.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ANSI_ARCHITECTURAL](#ANSI-ARCHITECTURAL) | ANSI arkitektonisk. |
+| [ANSI_ENGINEERING](#ANSI-ENGINEERING) | ANSI ingenjörsmässig. |
+| [CUSTOM_PAGE_SIZE](#CUSTOM-PAGE-SIZE) | Anpassad sidstorlek. |
+| [CUSTOM_SCALED_DRAW_SIZE](#CUSTOM-SCALED-DRAW-SIZE) | Anpassad skalad ritningsstorlek. |
+| [FIT_PAGE_DRAW_CONTENTS](#FIT-PAGE-DRAW-CONTENTS) | Anpassa sidan till ritningsinnehållet. |
+| [METRIC_ISO](#METRIC-ISO) | Metrisk (ISO). |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Samma som skrivaren. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANSI_ARCHITECTURAL {#ANSI-ARCHITECTURAL}
+```
+public static final int ANSI_ARCHITECTURAL
+```
+
+
+ANSI arkitektonisk.
+
+### ANSI_ENGINEERING {#ANSI-ENGINEERING}
+```
+public static final int ANSI_ENGINEERING
+```
+
+
+ANSI ingenjörsmässig.
+
+### CUSTOM_PAGE_SIZE {#CUSTOM-PAGE-SIZE}
+```
+public static final int CUSTOM_PAGE_SIZE
+```
+
+
+Anpassad sidstorlek.
+
+### CUSTOM_SCALED_DRAW_SIZE {#CUSTOM-SCALED-DRAW-SIZE}
+```
+public static final int CUSTOM_SCALED_DRAW_SIZE
+```
+
+
+Anpassad skalad ritningsstorlek.
+
+### FIT_PAGE_DRAW_CONTENTS {#FIT-PAGE-DRAW-CONTENTS}
+```
+public static final int FIT_PAGE_DRAW_CONTENTS
+```
+
+
+Anpassa sidan till ritningsinnehållet.
+
+### METRIC_ISO {#METRIC-ISO}
+```
+public static final int METRIC_ISO
+```
+
+
+Metrisk (ISO).
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Samma som skrivaren.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dropbuttonstyle/_index.md
+++ b/swedish/java/com.aspose.diagram/dropbuttonstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: DropButtonStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar symbolen som visas på nedrullningsknappen.
+type: docs
+weight: 135
+url: /sv/java/com.aspose.diagram/dropbuttonstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DropButtonStyle
+```
+
+Representerar symbolen som visas på nedrullningsknappen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ARROW](#ARROW) | Visar en knapp med en nedåtpil. |
+| [ELLIPSIS](#ELLIPSIS) | Visar en knapp med en ellips (...). |
+| [PLAIN](#PLAIN) | Visar en knapp utan symbol. |
+| [REDUCE](#REDUCE) | Visar en knapp med ett horisontellt streck som ett understreckstecken. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARROW {#ARROW}
+```
+public static final int ARROW
+```
+
+
+Visar en knapp med en nedåtpil.
+
+### ELLIPSIS {#ELLIPSIS}
+```
+public static final int ELLIPSIS
+```
+
+
+Visar en knapp med en ellips (...).
+
+### PLAIN {#PLAIN}
+```
+public static final int PLAIN
+```
+
+
+Visar en knapp utan symbol.
+
+### REDUCE {#REDUCE}
+```
+public static final int REDUCE
+```
+
+
+Visar en knapp med ett horisontellt streck som ett understreckstecken.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dynfeedback/_index.md
+++ b/swedish/java/com.aspose.diagram/dynfeedback/_index.md
@@ -1,0 +1,179 @@
+---
+title: DynFeedback
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutare.
+type: docs
+weight: 136
+url: /sv/java/com.aspose.diagram/dynfeedback/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class DynFeedback
+```
+
+Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutning. När musknappen släpps påverkas den resulterande anslutningsformen inte av denna inställning. Detta element gäller inte för routbara anslutningar.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [DynFeedback(int value)](#DynFeedback-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutare. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DynFeedback(int value) {#DynFeedback-int-}
+```
+public DynFeedback(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutning. När musknappen släpps påverkas den resulterande anslutningsformen inte av denna inställning. Detta element gäller inte för routbara anslutningar.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/dynfeedback\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/dynfeedbackvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/dynfeedbackvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: DynFeedbackValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutare.
+type: docs
+weight: 137
+url: /sv/java/com.aspose.diagram/dynfeedbackvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class DynFeedbackValue
+```
+
+Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutning. När musknappen släpps påverkas den resulterande anslutningsformen inte av denna inställning. Detta element gäller inte för routbara anslutningar.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [REMAIN_STRAIGHT](#REMAIN-STRAIGHT) | Förbli rak (inga ben). |
+| [SHOW_FIVE_LEGS](#SHOW-FIVE-LEGS) | Visa fem ben när den dras. |
+| [SHOW_THREE_LEGS](#SHOW-THREE-LEGS) | Visa tre ben när den dras. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REMAIN_STRAIGHT {#REMAIN-STRAIGHT}
+```
+public static final int REMAIN_STRAIGHT
+```
+
+
+Förbli rak (inga ben).
+
+### SHOW_FIVE_LEGS {#SHOW-FIVE-LEGS}
+```
+public static final int SHOW_FIVE_LEGS
+```
+
+
+Visa fem ben när den dras.
+
+### SHOW_THREE_LEGS {#SHOW-THREE-LEGS}
+```
+public static final int SHOW_THREE_LEGS
+```
+
+
+Visa tre ben när den dras.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ellipse/_index.md
+++ b/swedish/java/com.aspose.diagram/ellipse/_index.md
@@ -1,0 +1,349 @@
+---
+title: Ellips
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar x- och y-koordinaterna för ellipsens mittpunkt samt två punkter på ellipsen.
+type: docs
+weight: 138
+url: /sv/java/com.aspose.diagram/ellipse/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class Ellipse extends Coordinate
+```
+
+Innehåller element som specificerar x- och y-koordinaterna för ellipsens mittpunkt samt två punkter på ellipsen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Ellipse()](#Ellipse--) | Skapar en instans av klassen [Ellipse](../../com.aspose.diagram/ellipse). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | En x-koordinat för en punkt på ellipsen som paras med y-koordinaten representerad av B-elementet. |
+| [getB()](#getB--) | En y-koordinat för en punkt på en ellips som paras med en x-koordinat representerad av A-elementet. |
+| [getC()](#getC--) | En x-koordinat för en punkt på ellipsen som paras med y-koordinaten representerad av D-elementet. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | En y-koordinat för en punkt på ellipsen som paras med x-koordinaten representerad av C-elementet. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för ellipsens centrum. |
+| [getY()](#getY--) | y-koordinaten för ellipsens centrum. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/ellipse\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/ellipse\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/ellipse\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/ellipse\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/ellipse\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/ellipse\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/ellipse\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/ellipse\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Ellipse() {#Ellipse--}
+```
+public Ellipse()
+```
+
+
+Skapar en instans av klassen [Ellipse](../../com.aspose.diagram/ellipse).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+En x-koordinat för en punkt på ellipsen som paras med y-koordinaten representerad av B-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+En y-koordinat för en punkt på en ellips som paras med en x-koordinat representerad av A-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+En x-koordinat för en punkt på ellipsen som paras med y-koordinaten representerad av D-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+En y-koordinat för en punkt på ellipsen som paras med x-koordinaten representerad av C-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för ellipsens centrum.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för ellipsens centrum.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/ellipse\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/ellipse\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/ellipse\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/ellipse\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/ellipse\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/ellipse\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/ellipse\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/ellipse\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ellipsecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/ellipsecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipseCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Ellips-samling.
+type: docs
+weight: 139
+url: /sv/java/com.aspose.diagram/ellipsecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipseCollection extends Collection
+```
+
+Ellips-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Ellipse get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Ellipse](../../com.aspose.diagram/ellipse) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ellipticalarcto/_index.md
+++ b/swedish/java/com.aspose.diagram/ellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: EllipticalArcTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar information om en elliptisk båge.
+type: docs
+weight: 140
+url: /sv/java/com.aspose.diagram/ellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class EllipticalArcTo extends Coordinate
+```
+
+Innehåller element som specificerar information om en elliptisk båge.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [EllipticalArcTo()](#EllipticalArcTo--) | Skapar en instans av klassen [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | x-koordinaten för bågens kontrollpunkt. |
+| [getB()](#getB--) | y-koordinaten för en bågs kontrollpunkt. |
+| [getC()](#getC--) | Vinkeln på en bågs huvudaxel i förhållande till förälderns x‑axel. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Förhållandet mellan en bågs huvudaxel och dess sekundära axel. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för den avslutande hörnet av en elliptisk båge. |
+| [getY()](#getY--) | y-koordinaten för den avslutande hörnet av en elliptisk båge. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EllipticalArcTo() {#EllipticalArcTo--}
+```
+public EllipticalArcTo()
+```
+
+
+Skapar en instans av klassen [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+x-koordinaten för bågens kontrollpunkt. Kontrollpunkten bör placeras ungefär halvvägs mellan bågens start- och slutvertexer. Annars kan bågen växa till en extrem storlek för att passera genom kontrollpunkten, med oförutsägbara resultat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+y-koordinaten för en bågs kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Vinkeln på en bågs huvudaxel i förhållande till förälderns x‑axel.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Förhållandet mellan en bågs huvudaxel och dess sekundära axel. Trots den vanliga betydelsen av dessa ord behöver huvudaxeln inte vara större än den sekundära axeln, så detta förhållande behöver inte vara större än 1. Att sätta detta element till ett värde mindre än eller lika med 0 eller större än 1000 kan leda till oförutsägbara resultat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för den avslutande hörnet av en elliptisk båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för den avslutande hörnet av en elliptisk båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/ellipticalarcto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/ellipticalarcto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/ellipticalarcto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/ellipticalarcto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/ellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/ellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/ellipticalarcto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/ellipticalarcto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ellipticalarctocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/ellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: EllipticalArcToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: EllipticalArcTo  samling.
+type: docs
+weight: 141
+url: /sv/java/com.aspose.diagram/ellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EllipticalArcToCollection extends Collection
+```
+
+EllipticalArcTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EllipticalArcTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/emfrendersetting/_index.md
+++ b/swedish/java/com.aspose.diagram/emfrendersetting/_index.md
@@ -1,0 +1,147 @@
+---
+title: EmfRenderSetting
+second_title: Aspose.Diagram för Java API-referens
+description: Inställning för rendering av Emf-metafil.
+type: docs
+weight: 142
+url: /sv/java/com.aspose.diagram/emfrendersetting/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class EmfRenderSetting
+```
+
+Inställning för rendering av Emf-metafil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [EMF_ONLY](#EMF-ONLY) | Endast renderar Emf-poster. |
+| [EMF_PLUS_PREFER](#EMF-PLUS-PREFER) | Föredrar att rendera EmfPlus-poster. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMF_ONLY {#EMF-ONLY}
+```
+public static final int EMF_ONLY
+```
+
+
+Endast renderar Emf-poster.
+
+### EMF_PLUS_PREFER {#EMF-PLUS-PREFER}
+```
+public static final int EMF_PLUS_PREFER
+```
+
+
+Föredrar att rendera EmfPlus-poster.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/encoding/_index.md
+++ b/swedish/java/com.aspose.diagram/encoding/_index.md
@@ -1,0 +1,277 @@
+---
+title: Encoding
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en teckenkodning.
+type: docs
+weight: 143
+url: /sv/java/com.aspose.diagram/encoding/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Encoding
+```
+
+Representerar en teckenkodning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Encoding()](#Encoding--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Encoding other)](#equals-com.aspose.diagram.Encoding-) | Avgör om det angivna Encoding-objektet är lika med den aktuella instansen. |
+| [equals(Object o)](#equals-java.lang.Object-) | Avgör om det angivna objektet är lika med den aktuella instansen. |
+| [getASCII()](#getASCII--) | Hämtar en kodning för ASCII (7-bitars) teckenuppsättningen. |
+| [getBigEndianUnicode()](#getBigEndianUnicode--) | Hämtar en kodning för UTF-16-formatet med big-endian byteordning. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Hämtar en kodning för operativsystemets aktuella ANSI-kodningssida. |
+| [getEncoding(int codePage)](#getEncoding-int-) | Returnerar kodningen som är associerad med det angivna kodsididentifieraren. |
+| [getEncoding(String charsetName)](#getEncoding-java.lang.String-) | Returnerar en kodning som är associerad med det angivna teckenuppsättningsnamnet. |
+| [getEncoding(Charset charset)](#getEncoding-java.nio.charset.Charset-) | Returnerar en kodning som är associerad med det angivna teckenuppsättningsobjektet. |
+| [getUTF7()](#getUTF7--) | Hämtar en kodning för UTF-7-formatet. |
+| [getUTF8()](#getUTF8--) | Hämtar en kodning för UTF-8-formatet. |
+| [getUTF8NoBOM()](#getUTF8NoBOM--) | Hämtar en kodning för UTF-8-formatet utan UTF-8-identifieraren. |
+| [getUnicode()](#getUnicode--) | Hämtar en kodning för UTF-16-formatet med little-endian byteordning. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Encoding() {#Encoding--}
+```
+public Encoding()
+```
+
+
+### equals(Encoding other) {#equals-com.aspose.diagram.Encoding-}
+```
+public boolean equals(Encoding other)
+```
+
+
+Avgör om det angivna Encoding-objektet är lika med den aktuella instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| other | [Encoding](../../com.aspose.diagram/encoding) | Encoding-objektet att jämföra med den aktuella instansen. |
+
+**Returns:**
+boolean - true om värdet är lika med den aktuella instansen; annars false.
+### equals(Object o) {#equals-java.lang.Object-}
+```
+public boolean equals(Object o)
+```
+
+
+Avgör om det angivna objektet är lika med den aktuella instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Objektet att jämföra med den aktuella instansen. |
+
+**Returns:**
+boolean - sant om värdet är en instans av Encoding och är lika med den aktuella instansen; annars falskt.
+### getASCII() {#getASCII--}
+```
+public static Encoding getASCII()
+```
+
+
+Hämtar en kodning för ASCII (7-bitars) teckenuppsättningen.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the ASCII (7-bit) character set.
+### getBigEndianUnicode() {#getBigEndianUnicode--}
+```
+public static Encoding getBigEndianUnicode()
+```
+
+
+Hämtar en kodning för UTF-16-formatet med big-endian byteordning.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the big endian byte
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public static Encoding getDefault()
+```
+
+
+Hämtar en kodning för operativsystemets aktuella ANSI-kodningssida.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - An encoding for the operating system's current ANSI code page.
+### getEncoding(int codePage) {#getEncoding-int-}
+```
+public static Encoding getEncoding(int codePage)
+```
+
+
+Returnerar kodningen som är associerad med det angivna kodsididentifieraren.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| codePage | int | Kodsidans identifierare för den föredragna kodningen. -eller- 0, för att använda standardkodningen. |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified code page.
+### getEncoding(String charsetName) {#getEncoding-java.lang.String-}
+```
+public static Encoding getEncoding(String charsetName)
+```
+
+
+Returnerar en kodning som är associerad med det angivna teckenuppsättningsnamnet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charsetName | java.lang.String | angivet teckenuppsättningsnamn |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset name.
+### getEncoding(Charset charset) {#getEncoding-java.nio.charset.Charset-}
+```
+public static Encoding getEncoding(Charset charset)
+```
+
+
+Returnerar en kodning som är associerad med det angivna teckenuppsättningsobjektet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| charset | java.nio.charset.Charset | angivet teckenuppsättningsobjekt |
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - The Encoding object associated with the specified charset object.
+### getUTF7() {#getUTF7--}
+```
+public static Encoding getUTF7()
+```
+
+
+Hämtar en kodning för UTF-7-formatet.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-7 format.
+### getUTF8() {#getUTF8--}
+```
+public static Encoding getUTF8()
+```
+
+
+Hämtar en kodning för UTF-8-formatet.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format.
+### getUTF8NoBOM() {#getUTF8NoBOM--}
+```
+public static Encoding getUTF8NoBOM()
+```
+
+
+Hämtar en kodning för UTF-8-formatet utan UTF-8-identifieraren.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-8 format without UTF-8 identifier.
+### getUnicode() {#getUnicode--}
+```
+public static Encoding getUnicode()
+```
+
+
+Hämtar en kodning för UTF-16-formatet med little-endian byteordning.
+
+**Returns:**
+[Encoding](../../com.aspose.diagram/encoding) - A Encoding object for the UTF-16 format using the little endian byte
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/event/_index.md
+++ b/swedish/java/com.aspose.diagram/event/_index.md
@@ -1,0 +1,311 @@
+---
+title: Händelse
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar formler som styr formhändelser.
+type: docs
+weight: 144
+url: /sv/java/com.aspose.diagram/event/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Event
+```
+
+Innehåller element som specificerar formler som styr formhändelser.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getEventDblClick()](#getEventDblClick--) | Ett händelseelement som utvärderas när en form dubbelklickas. |
+| [getEventDrop()](#getEventDrop--) | Ett händelseelement som utvärderas när en form släpps på ritningssidan, antingen som en instans eller när en form dupliceras eller klistras in. |
+| [getEventMultiDrop()](#getEventMultiDrop--) | EventMultiDrop. |
+| [getEventXFMod()](#getEventXFMod--) | Ett händelseelement som utvärderas när en forms position eller orientering på sidan transformeras. |
+| [getTheData()](#getTheData--) | Reserverad för framtida användning. |
+| [getTheText()](#getTheText--) | Ett händelseelement som utvärderas när en forms text eller textkomposition ändras. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/event\#getDel--) |
+| [setEventDblClick(DoubleValue value)](#setEventDblClick-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--) |
+| [setEventDrop(DoubleValue value)](#setEventDrop-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--) |
+| [setEventMultiDrop(DoubleValue value)](#setEventMultiDrop-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--) |
+| [setEventXFMod(DoubleValue value)](#setEventXFMod-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--) |
+| [setTheData(DoubleValue value)](#setTheData-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTheData()](../../com.aspose.diagram/event\#getTheData--) |
+| [setTheText(DoubleValue value)](#setTheText-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTheText()](../../com.aspose.diagram/event\#getTheText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getEventDblClick() {#getEventDblClick--}
+```
+public DoubleValue getEventDblClick()
+```
+
+
+Ett händelseelement som utvärderas när en form dubbelklickas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventDrop() {#getEventDrop--}
+```
+public DoubleValue getEventDrop()
+```
+
+
+Ett händelseelement som utvärderas när en form släpps på ritningssidan, antingen som en instans eller när en form dupliceras eller klistras in.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventMultiDrop() {#getEventMultiDrop--}
+```
+public DoubleValue getEventMultiDrop()
+```
+
+
+EventMultiDrop.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEventXFMod() {#getEventXFMod--}
+```
+public DoubleValue getEventXFMod()
+```
+
+
+Ett händelseelement som utvärderas när en forms position eller orientering på sidan transformeras.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheData() {#getTheData--}
+```
+public DoubleValue getTheData()
+```
+
+
+Reserverad för framtida användning.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTheText() {#getTheText--}
+```
+public DoubleValue getTheText()
+```
+
+
+Ett händelseelement som utvärderas när en forms text eller textkomposition ändras.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/event\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEventDblClick(DoubleValue value) {#setEventDblClick-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDblClick(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEventDblClick()](../../com.aspose.diagram/event\#getEventDblClick--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventDrop(DoubleValue value) {#setEventDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventDrop(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEventDrop()](../../com.aspose.diagram/event\#getEventDrop--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventMultiDrop(DoubleValue value) {#setEventMultiDrop-com.aspose.diagram.DoubleValue-}
+```
+public void setEventMultiDrop(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEventMultiDrop()](../../com.aspose.diagram/event\#getEventMultiDrop--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEventXFMod(DoubleValue value) {#setEventXFMod-com.aspose.diagram.DoubleValue-}
+```
+public void setEventXFMod(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEventXFMod()](../../com.aspose.diagram/event\#getEventXFMod--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheData(DoubleValue value) {#setTheData-com.aspose.diagram.DoubleValue-}
+```
+public void setTheData(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTheData()](../../com.aspose.diagram/event\#getTheData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTheText(DoubleValue value) {#setTheText-com.aspose.diagram.DoubleValue-}
+```
+public void setTheText(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTheText()](../../com.aspose.diagram/event\#getTheText--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/eventitem/_index.md
+++ b/swedish/java/com.aspose.diagram/eventitem/_index.md
@@ -1,0 +1,288 @@
+---
+title: EventItem
+second_title: Aspose.Diagram för Java API-referens
+description: Inkapslar en händelsekod.
+type: docs
+weight: 145
+url: /sv/java/com.aspose.diagram/eventitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class EventItem
+```
+
+Inkapslar en händelsekod. Ett EventItem-element kan utlösa två typer av åtgärder: det kan köra ett add-on, eller det kan skicka en notifikation om händelsen till det anropande programmet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [EventItem()](#EventItem--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAction()](#getAction--) | Anger åtgärdskoden för det överordnade EventItem-elementet. För att ett EventItem-element ska sparas i en DatadiagramML-fil måste det vara beständigt. |
+| [getClass()](#getClass--) |  |
+| [getEnabled()](#getEnabled--) | Representerar en flagga som indikerar om händelsen är aktiverad eller inaktiverad. |
+| [getEventCode()](#getEventCode--) | En kod som indikerar händelsen som utlöser add-on. |
+| [getID()](#getID--) | Händelsens ID. |
+| [getTarget()](#getTarget--) | Anger målet för en händelse. |
+| [getTargetArgs()](#getTargetArgs--) | Anger en sträng som innehåller argument som ska skickas till händelsens mål. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAction(int value)](#setAction-int-) | För beskrivningen av denna egenskap, se [getAction()](../../com.aspose.diagram/eventitem\#getAction--) |
+| [setEnabled(int value)](#setEnabled-int-) | För beskrivningen av denna egenskap, se [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--) |
+| [setEventCode(int value)](#setEventCode-int-) | För beskrivningen av denna egenskap, se [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/eventitem\#getID--) |
+| [setTarget(String value)](#setTarget-java.lang.String-) | För beskrivningen av denna egenskap, se [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--) |
+| [setTargetArgs(String value)](#setTargetArgs-java.lang.String-) | För beskrivningen av denna egenskap, se [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItem() {#EventItem--}
+```
+public EventItem()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAction() {#getAction--}
+```
+public int getAction()
+```
+
+
+Anger åtgärdskoden för det överordnade EventItem-elementet. För att ett EventItem-element ska sparas i en DatadiagramML-fil måste det vara beständigt. För närvarande är den enda giltiga åtgärdskoden som ett beständigt evenemang kan ha 1 (ONEVENT_ACT_RUNADDON).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Representerar en flagga som indikerar om händelsen är aktiverad eller inaktiverad.
+
+**Returns:**
+int
+### getEventCode() {#getEventCode--}
+```
+public int getEventCode()
+```
+
+
+En kod som indikerar händelsen som utlöser add-on. För mer information om händelsekoder, se Event Codes i Microsoft Visio 2007 Automation Reference.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Händelsens ID.
+
+**Returns:**
+int
+### getTarget() {#getTarget--}
+```
+public String getTarget()
+```
+
+
+Anger målet för en händelse.
+
+**Returns:**
+java.lang.String
+### getTargetArgs() {#getTargetArgs--}
+```
+public String getTargetArgs()
+```
+
+
+Anger en sträng som innehåller argument som ska skickas till händelsens mål.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAction(int value) {#setAction-int-}
+```
+public void setAction(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAction()](../../com.aspose.diagram/eventitem\#getAction--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEnabled()](../../com.aspose.diagram/eventitem\#getEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEventCode(int value) {#setEventCode-int-}
+```
+public void setEventCode(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEventCode()](../../com.aspose.diagram/eventitem\#getEventCode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/eventitem\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTarget(String value) {#setTarget-java.lang.String-}
+```
+public void setTarget(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTarget()](../../com.aspose.diagram/eventitem\#getTarget--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTargetArgs(String value) {#setTargetArgs-java.lang.String-}
+```
+public void setTargetArgs(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTargetArgs()](../../com.aspose.diagram/eventitem\#getTargetArgs--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/eventitemcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/eventitemcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: EventItemCollection
+second_title: Aspose.Diagram för Java API-referens
+description: EventItem-samling.
+type: docs
+weight: 146
+url: /sv/java/com.aspose.diagram/eventitemcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class EventItemCollection extends Collection
+```
+
+EventItem-samling.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [EventItemCollection()](#EventItemCollection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(EventItem eventItem)](#add-com.aspose.diagram.EventItem-) | Lägg till eventItem i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(EventItem eventItem)](#remove-com.aspose.diagram.EventItem-) | Ta bort eventItem från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EventItemCollection() {#EventItemCollection--}
+```
+public EventItemCollection()
+```
+
+
+Konstruktor.
+
+### add(EventItem eventItem) {#add-com.aspose.diagram.EventItem-}
+```
+public int add(EventItem eventItem)
+```
+
+
+Lägg till eventItem i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public EventItem get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[EventItem](../../com.aspose.diagram/eventitem) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(EventItem eventItem) {#remove-com.aspose.diagram.EventItem-}
+```
+public void remove(EventItem eventItem)
+```
+
+
+Ta bort eventItem från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| eventItem | [EventItem](../../com.aspose.diagram/eventitem) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/field/_index.md
+++ b/swedish/java/com.aspose.diagram/field/_index.md
@@ -1,0 +1,309 @@
+---
+title: Fält
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar funktioner och formler som infogats i formens text.
+type: docs
+weight: 147
+url: /sv/java/com.aspose.diagram/field/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Field
+```
+
+Innehåller element som specificerar funktioner och formler som infogas i formens text.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Field()](#Field--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDisplayValue()](#getDisplayValue--) | Hämtar det formaterade strängvärdet för detta fält. |
+| [getEditMode()](#getEditMode--) | Reserverad för framtida användning. |
+| [getFormat()](#getFormat--) | Format‑elementet specificerar formateringen för ett textfält som är en sträng, ett tal, datum eller tid, varaktighet eller valuta. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getObjectKind()](#getObjectKind--) | Anger typen av textfält. |
+| [getType()](#getType--) | Typ anger en datatyp för textfältets värde. |
+| [getUICat()](#getUICat--) | Specificerar kategorin för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000. |
+| [getUICod()](#getUICod--) | Specificerar koden för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000. |
+| [getUIFmt()](#getUIFmt--) | Specificerar formatet för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000. |
+| [getValue()](#getValue--) | Den innehåller värdet för ett textfält. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/field\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/field\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Field() {#Field--}
+```
+public Field()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDisplayValue() {#getDisplayValue--}
+```
+public String getDisplayValue()
+```
+
+
+Hämtar det formaterade strängvärdet för detta fält.
+
+**Returns:**
+java.lang.String
+### getEditMode() {#getEditMode--}
+```
+public DoubleValue getEditMode()
+```
+
+
+Reserverad för framtida användning.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFormat() {#getFormat--}
+```
+public Value getFormat()
+```
+
+
+Format‑elementet anger formateringen för ett textfält som är en sträng, ett tal, ett datum eller en tid, en varaktighet eller en valuta. Textfältstypen anges i motsvarande Type‑element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getObjectKind() {#getObjectKind--}
+```
+public ObjectKind getObjectKind()
+```
+
+
+Anger typen av textfält.
+
+**Returns:**
+[ObjectKind](../../com.aspose.diagram/objectkind)
+### getType() {#getType--}
+```
+public TypeField getType()
+```
+
+
+Typ anger en datatyp för textfältets värde.
+
+**Returns:**
+[TypeField](../../com.aspose.diagram/typefield)
+### getUICat() {#getUICat--}
+```
+public DoubleValue getUICat()
+```
+
+
+Specificerar kategorin för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUICod() {#getUICod--}
+```
+public DoubleValue getUICod()
+```
+
+
+Specificerar koden för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getUIFmt() {#getUIFmt--}
+```
+public DoubleValue getUIFmt()
+```
+
+
+Specificerar formatet för ett infogat fält i versioner av Microsoft Visio tidigare än Visio 2000.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Den innehåller värdet för ett textfält.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/field\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/field\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fieldcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/fieldcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: FieldCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Fältkollektion.
+type: docs
+weight: 148
+url: /sv/java/com.aspose.diagram/fieldcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FieldCollection extends Collection
+```
+
+Fältkollektion.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Field item)](#add-com.aspose.diagram.Field-) | Lägg till Field-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Field item)](#remove-com.aspose.diagram.Field-) | Ta bort Field-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Field item) {#add-com.aspose.diagram.Field-}
+```
+public int add(Field item)
+```
+
+
+Lägg till Field-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Field get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Field](../../com.aspose.diagram/field) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Field item) {#remove-com.aspose.diagram.Field-}
+```
+public void remove(Field item)
+```
+
+
+Ta bort Field-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Field](../../com.aspose.diagram/field) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/filefontsource/_index.md
+++ b/swedish/java/com.aspose.diagram/filefontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: FileFontSource
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar den enda TrueType-typsnittsfilen som lagras i filsystemet.
+type: docs
+weight: 149
+url: /sv/java/com.aspose.diagram/filefontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FileFontSource extends FontSourceBase
+```
+
+Representerar den enda TrueType-typsnittsfilen som lagras i filsystemet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FileFontSource(String filePath)](#FileFontSource-java.lang.String-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFilePath()](#getFilePath--) | Sökväg till teckensnittfil. |
+| [getType()](#getType--) | Returnerar typen av teckensnittskälla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFontSource(String filePath) {#FileFontSource-java.lang.String-}
+```
+public FileFontSource(String filePath)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filePath | java.lang.String | sökväg till teckensnittfil |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFilePath() {#getFilePath--}
+```
+public String getFilePath()
+```
+
+
+Sökväg till teckensnittfil.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Returnerar typen av teckensnittskälla.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fileformatinfo/_index.md
+++ b/swedish/java/com.aspose.diagram/fileformatinfo/_index.md
@@ -1,0 +1,158 @@
+---
+title: FileFormatInfo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller data som returneras av metoder för filformatdetektering.
+type: docs
+weight: 150
+url: /sv/java/com.aspose.diagram/fileformatinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatInfo
+```
+
+Innehåller data som returneras av [FileFormatUtil](../../com.aspose.diagram/fileformatutil) metoder för filformatdetektering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FileFormatInfo()](#FileFormatInfo--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFileFormatType()](#getFileFormatType--) | Hämtar det upptäckta filformatet. |
+| [getLoadFormat()](#getLoadFormat--) | Hämtar det upptäckta inläsningsformatet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatInfo() {#FileFormatInfo--}
+```
+public FileFormatInfo()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFileFormatType() {#getFileFormatType--}
+```
+public int getFileFormatType()
+```
+
+
+Hämtar det upptäckta filformatet.
+
+**Returns:**
+int
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Hämtar det upptäckta inläsningsformatet.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fileformattype/_index.md
+++ b/swedish/java/com.aspose.diagram/fileformattype/_index.md
@@ -1,0 +1,570 @@
+---
+title: FileFormatType
+second_title: Aspose.Diagram för Java API-referens
+description: Enumererar filformattyper för kalkylblad
+type: docs
+weight: 151
+url: /sv/java/com.aspose.diagram/fileformattype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FileFormatType
+```
+
+Enumererar filformattyper för kalkylblad
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CSV](#CSV) | Representerar en CSV-fil. |
+| [DIF](#DIF) | Datautbytesformat. |
+| [DOC](#DOC) | Representerar en doc-fil. |
+| [DOCM](#DOCM) | Representerar en docm-fil. |
+| [DOCX](#DOCX) | Representerar en docx-fil. |
+| [DOTM](#DOTM) | Representerar en dotm-fil. |
+| [DOTX](#DOTX) | Representerar en dotx-fil. |
+| [EXCEL_2003_XML](#EXCEL-2003-XML) | Representerar en Excel 2003 xml-fil. |
+| [EXCEL_97_TO_2003](#EXCEL-97-TO-2003) | Representerar en Excel97-2003 xls-fil. |
+| [HTML](#HTML) | Representerar en html-fil. |
+| [MAPI_MESSAGE](#MAPI-MESSAGE) | Representerar en e-postfil. |
+| [MS_EQUATION](#MS-EQUATION) | Representerar MS Equation 3.0-objektet. |
+| [ODS](#ODS) | Representerar en ods-fil. |
+| [OLE_10_NATIVE](#OLE-10-NATIVE) | Representerar det inbäddade inhemska objektet. |
+| [OOXML](#OOXML) | Representerar Office Open XML-fil (såsom xlsx, docx, pptx, etc). |
+| [PDF](#PDF) | Representerar en PDF-fil. |
+| [POTM](#POTM) | Representerar en Potm-fil. |
+| [POTX](#POTX) | Representerar en Potx-fil. |
+| [PPSM](#PPSM) | Representerar en ppsm-fil. |
+| [PPSX](#PPSX) | Representerar en ppsx-fil. |
+| [PPT](#PPT) | Representerar en ppt-fil. |
+| [PPTM](#PPTM) | Representerar en pptm-fil. |
+| [PPTX](#PPTX) | Representerar en pptx-fil. |
+| [SLDX](#SLDX) | Representerar en sldx-fil. |
+| [SVG](#SVG) | Representerar en svg-fil. |
+| [TAB_DELIMITED](#TAB-DELIMITED) | Representerar en tab-avgränsad textfil. |
+| [TIFF](#TIFF) | Representerar en TIFF-fil. |
+| [UNKNOWN](#UNKNOWN) | Representerar ett okänt format, kan inte laddas. |
+| [VDW](#VDW) | MS Visio VDW-webbritningsformat. |
+| [VDX](#VDX) | MS Visio VDX xml-format. |
+| [VSD](#VSD) | MS Visio VSD-binärt format. |
+| [VSDM](#VSDM) | MS Visio 2013 VSDM filformat. |
+| [VSDX](#VSDX) | MS Visio 2013 VSDX filformat. |
+| [VSS](#VSS) | MS Visio VSS binärt stencilformat. |
+| [VSSM](#VSSM) | MS Visio 2013 VSSM filformat. |
+| [VSSX](#VSSX) | MS Visio 2013 VSSX filformat. |
+| [VST](#VST) | MS Visio VST binärt mallformat. |
+| [VSTM](#VSTM) | MS Visio 2013 VSTM filformat. |
+| [VSTX](#VSTX) | MS Visio 2013 VSTX mallfilformat. |
+| [VSX](#VSX) | MS Visio VSX xml stencilformat. |
+| [VTX](#VTX) | MS Visio VTX xml mallformat. |
+| [XLAM](#XLAM) | Representerar en addinMacro-enabled mall xltm-fil. |
+| [XLSB](#XLSB) | Representerar en xlsb-fil. |
+| [XLSM](#XLSM) | Representerar en xlsm-fil som möjliggör makron. |
+| [XLSX](#XLSX) | Representerar en xlsx-fil. |
+| [XLTM](#XLTM) | Representerar en makro-aktiverad mall xltm-fil. |
+| [XLTX](#XLTX) | Representerar en mall xltx-fil. |
+| [XML](#XML) | Representerar en enkel xml-fil. |
+| [XPS](#XPS) | Representerar en XPS-fil. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CSV {#CSV}
+```
+public static final int CSV
+```
+
+
+Representerar en CSV-fil.  Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### DIF {#DIF}
+```
+public static final int DIF
+```
+
+
+Datautbytesformat.
+
+### DOC {#DOC}
+```
+public static final int DOC
+```
+
+
+Representerar en doc-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### DOCM {#DOCM}
+```
+public static final int DOCM
+```
+
+
+Representerar en docm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### DOCX {#DOCX}
+```
+public static final int DOCX
+```
+
+
+Representerar en docx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### DOTM {#DOTM}
+```
+public static final int DOTM
+```
+
+
+Representerar en dotm-fil. Filformatet stöds inte. Endas för att upptäcka filtyp.
+
+### DOTX {#DOTX}
+```
+public static final int DOTX
+```
+
+
+Representerar en dotx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### EXCEL_2003_XML {#EXCEL-2003-XML}
+```
+public static final int EXCEL_2003_XML
+```
+
+
+Representerar en Excel 2003 xml-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### EXCEL_97_TO_2003 {#EXCEL-97-TO-2003}
+```
+public static final int EXCEL_97_TO_2003
+```
+
+
+Representerar en Excel97-2003 xls-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Representerar en html-fil.
+
+### MAPI_MESSAGE {#MAPI-MESSAGE}
+```
+public static final int MAPI_MESSAGE
+```
+
+
+Representerar en e‑postfil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### MS_EQUATION {#MS-EQUATION}
+```
+public static final int MS_EQUATION
+```
+
+
+Representerar MS Equation 3.0-objektet. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### ODS {#ODS}
+```
+public static final int ODS
+```
+
+
+Representerar en ods-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### OLE_10_NATIVE {#OLE-10-NATIVE}
+```
+public static final int OLE_10_NATIVE
+```
+
+
+Representerar det inbäddade inhemska objektet. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### OOXML {#OOXML}
+```
+public static final int OOXML
+```
+
+
+Representerar Office Open XML-fil (såsom xlsx, docx, pptx osv). Filformatet stöds inte. Endast för att upptäcka filtyp. Om Office Open XML-filen är krypterad kan den inte identifieras som xlsx, docx, pptx osv.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Representerar en PDF-fil.
+
+### POTM {#POTM}
+```
+public static final int POTM
+```
+
+
+Representerar en Potm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### POTX {#POTX}
+```
+public static final int POTX
+```
+
+
+Representerar en Potx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### PPSM {#PPSM}
+```
+public static final int PPSM
+```
+
+
+Representerar en ppsm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### PPSX {#PPSX}
+```
+public static final int PPSX
+```
+
+
+Representerar en ppsx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### PPT {#PPT}
+```
+public static final int PPT
+```
+
+
+Representerar en ppt-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### PPTM {#PPTM}
+```
+public static final int PPTM
+```
+
+
+Representerar en pptm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### PPTX {#PPTX}
+```
+public static final int PPTX
+```
+
+
+Representerar en pptx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### SLDX {#SLDX}
+```
+public static final int SLDX
+```
+
+
+Representerar en sldx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Representerar en svg-fil.
+
+### TAB_DELIMITED {#TAB-DELIMITED}
+```
+public static final int TAB_DELIMITED
+```
+
+
+Representerar en flikavgränsad textfil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Representerar en TIFF-fil.
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Representerar ett okänt format, kan inte laddas.
+
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio VDW-webbritningsformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX xml-format.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio VSD-binärt format.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio 2013 VSDM filformat.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 VSDX filformat.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio VSS binärt stencilformat.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio 2013 VSSM filformat.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 VSSX filformat.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio VST binärt mallformat.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio 2013 VSTM filformat.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 VSTX mallfilformat.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio VSX xml stencilformat.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio VTX xml mallformat.
+
+### XLAM {#XLAM}
+```
+public static final int XLAM
+```
+
+
+Representerar en addinMacro-aktiverad mall xltm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XLSB {#XLSB}
+```
+public static final int XLSB
+```
+
+
+Representerar en xlsb-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XLSM {#XLSM}
+```
+public static final int XLSM
+```
+
+
+Representerar en xlsm-fil som möjliggör makron. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XLSX {#XLSX}
+```
+public static final int XLSX
+```
+
+
+Representerar en xlsx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XLTM {#XLTM}
+```
+public static final int XLTM
+```
+
+
+Representerar en makroaktiverad mall xltm-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XLTX {#XLTX}
+```
+public static final int XLTX
+```
+
+
+Representerar en mall xltx-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XML {#XML}
+```
+public static final int XML
+```
+
+
+Representerar en enkel xml-fil. Filformatet stöds inte. Endast för att upptäcka filtyp.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Representerar en XPS-fil.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fileformatutil/_index.md
+++ b/swedish/java/com.aspose.diagram/fileformatutil/_index.md
@@ -1,0 +1,168 @@
+---
+title: FileFormatUtil
+second_title: Aspose.Diagram för Java API-referens
+description: Tillhandahåller hjälpfunktioner för att konvertera filformat‑enum till strängar eller filändelser och tillbaka.
+type: docs
+weight: 152
+url: /sv/java/com.aspose.diagram/fileformatutil/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FileFormatUtil
+```
+
+Tillhandahåller hjälpfunktioner för att konvertera filformat‑enum till strängar eller filändelser och tillbaka.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FileFormatUtil()](#FileFormatUtil--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [detectFileFormat(InputStream stream)](#detectFileFormat-java.io.InputStream-) | Detekterar och returnerar information om ett Visio-format lagrat i en ström. |
+| [detectFileFormat(String filePath)](#detectFileFormat-java.lang.String-) | Detekterar och returnerar information om ett Visio-format lagrat i en fil. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileFormatUtil() {#FileFormatUtil--}
+```
+public FileFormatUtil()
+```
+
+
+### detectFileFormat(InputStream stream) {#detectFileFormat-java.io.InputStream-}
+```
+public static FileFormatInfo detectFileFormat(InputStream stream)
+```
+
+
+Detekterar och returnerar information om ett Visio-format lagrat i en ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | Strömmen |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### detectFileFormat(String filePath) {#detectFileFormat-java.lang.String-}
+```
+public static FileFormatInfo detectFileFormat(String filePath)
+```
+
+
+Detekterar och returnerar information om ett Visio-format lagrat i en fil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| filePath | java.lang.String | Filens sökväg. |
+
+**Returns:**
+[FileFormatInfo](../../com.aspose.diagram/fileformatinfo) - A [FileFormatInfo](../../com.aspose.diagram/fileformatinfo) object that contains the detected information.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fill/_index.md
+++ b/swedish/java/com.aspose.diagram/fill/_index.md
@@ -1,0 +1,597 @@
+---
+title: Fill
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning inklusive mönstrets förgrundsfärg och bakgrundsfärg.
+type: docs
+weight: 153
+url: /sv/java/com.aspose.diagram/fill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Fill
+```
+
+Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getFillBkgnd()](#getFillBkgnd--) | Anger färgen som används för bakgrunden i formens fyllningsmönster. |
+| [getFillBkgndTrans()](#getFillBkgndTrans--) | Anger transparensnivån för bakgrundsfärgen (fyllning) i formens fyllningsmönster, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig). |
+| [getFillForegnd()](#getFillForegnd--) | Anger färgen som används för förgrunden (streck) i formens fyllningsmönster. |
+| [getFillForegndTrans()](#getFillForegndTrans--) | Anger transparensnivån för förgrundsfärgen (fyllning) i formens fyllningsmönster, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig). |
+| [getFillPattern()](#getFillPattern--) | Anger fyllningsmönstret för formen. |
+| [getGradientFill()](#getGradientFill--) | Innehåller de aktuella gradientfyllningsformateringsvärdena för formen |
+| [getShapeShdwBlur()](#getShapeShdwBlur--) | Anger skuggans oskärpa för en form. |
+| [getShapeShdwObliqueAngle()](#getShapeShdwObliqueAngle--) | Anger vinkeln för den sneda riktningen på en forms skugga. |
+| [getShapeShdwOffsetX()](#getShapeShdwOffsetX--) | Bestämmer avståndet i sid-enheter som en forms skugga förskjuts horisontellt från formen. |
+| [getShapeShdwOffsetY()](#getShapeShdwOffsetY--) | Bestämmer avståndet i sid-enheter som en forms skugga förskjuts vertikalt från formen. |
+| [getShapeShdwScaleFactor()](#getShapeShdwScaleFactor--) | Anger den procentandel som en forms skugga kan förstoras eller minskas. |
+| [getShapeShdwShow()](#getShapeShdwShow--) | Anger typen av skugga för en form. |
+| [getShapeShdwType()](#getShapeShdwType--) | Anger typen av skugga för en form. |
+| [getShdwBkgnd()](#getShdwBkgnd--) | Anger färgen som används för bakgrunden (fyllning) i formens skuggfyllningsmönster. |
+| [getShdwBkgndTrans()](#getShdwBkgndTrans--) | Anger transparensnivån för bakgrunden (fyllning) i formens skuggfyllningsmönster, från 0.0 (helt ogenomskinlig) till 1.0 (helt genomskinlig). |
+| [getShdwForegnd()](#getShdwForegnd--) | Anger färgen som används för förgrunden (streck) i formens skuggfyllningsmönster. |
+| [getShdwForegndTrans()](#getShdwForegndTrans--) | Anger transparensnivån för förgrunden (streck) i formens skuggfyllningsmönster, från 0.0 (helt ogenomskinlig) till 1.0 (helt genomskinlig). |
+| [getShdwPattern()](#getShdwPattern--) | Anger fyllningsmönstret för en forms skugga. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/fill\#getDel--) |
+| [setFillBkgnd(ColorValue value)](#setFillBkgnd-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--) |
+| [setFillBkgndTrans(DoubleValue value)](#setFillBkgndTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--) |
+| [setFillForegnd(ColorValue value)](#setFillForegnd-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--) |
+| [setFillForegndTrans(DoubleValue value)](#setFillForegndTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--) |
+| [setFillPattern(IntValue value)](#setFillPattern-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--) |
+| [setShapeShdwBlur(DoubleValue value)](#setShapeShdwBlur-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--) |
+| [setShapeShdwObliqueAngle(DoubleValue value)](#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--) |
+| [setShapeShdwOffsetX(DoubleValue value)](#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--) |
+| [setShapeShdwOffsetY(DoubleValue value)](#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--) |
+| [setShapeShdwScaleFactor(DoubleValue value)](#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--) |
+| [setShapeShdwShow(ShapeShdwShow value)](#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-) | För beskrivningen av denna egenskap, se [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--) |
+| [setShapeShdwType(ShapeShdwType value)](#setShapeShdwType-com.aspose.diagram.ShapeShdwType-) | För beskrivningen av denna egenskap, se [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--) |
+| [setShdwBkgnd(ColorValue value)](#setShdwBkgnd-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--) |
+| [setShdwBkgndTrans(DoubleValue value)](#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--) |
+| [setShdwForegnd(ColorValue value)](#setShdwForegnd-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--) |
+| [setShdwForegndTrans(DoubleValue value)](#setShdwForegndTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--) |
+| [setShdwPattern(IntValue value)](#setShdwPattern-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getFillBkgnd() {#getFillBkgnd--}
+```
+public ColorValue getFillBkgnd()
+```
+
+
+Anger färgen som används för bakgrunden i formens fyllningsmönster.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillBkgndTrans() {#getFillBkgndTrans--}
+```
+public DoubleValue getFillBkgndTrans()
+```
+
+
+Anger transparensnivån för bakgrundsfärgen (fyllning) i formens fyllningsmönster, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillForegnd() {#getFillForegnd--}
+```
+public ColorValue getFillForegnd()
+```
+
+
+Anger färgen som används för förgrunden (streck) i formens fyllningsmönster.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getFillForegndTrans() {#getFillForegndTrans--}
+```
+public DoubleValue getFillForegndTrans()
+```
+
+
+Anger transparensnivån för förgrundsfärgen (fyllning) i formens fyllningsmönster, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getFillPattern() {#getFillPattern--}
+```
+public IntValue getFillPattern()
+```
+
+
+Anger fyllningsmönstret för formen.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientFill() {#getGradientFill--}
+```
+public GradientFill getGradientFill()
+```
+
+
+Innehåller de aktuella gradientfyllningsformateringsvärdena för formen
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getShapeShdwBlur() {#getShapeShdwBlur--}
+```
+public DoubleValue getShapeShdwBlur()
+```
+
+
+Anger skuggans oskärpa för en form. Kan inte rita oskärpa nu, men kan parsas från vsdx nu.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwObliqueAngle() {#getShapeShdwObliqueAngle--}
+```
+public DoubleValue getShapeShdwObliqueAngle()
+```
+
+
+Anger vinkeln för den sneda riktningen på en forms skugga.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetX() {#getShapeShdwOffsetX--}
+```
+public DoubleValue getShapeShdwOffsetX()
+```
+
+
+Bestämmer avståndet i sid-enheter som en forms skugga förskjuts horisontellt från formen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwOffsetY() {#getShapeShdwOffsetY--}
+```
+public DoubleValue getShapeShdwOffsetY()
+```
+
+
+Bestämmer avståndet i sid-enheter som en forms skugga förskjuts vertikalt från formen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwScaleFactor() {#getShapeShdwScaleFactor--}
+```
+public DoubleValue getShapeShdwScaleFactor()
+```
+
+
+Anger den procentandel som en forms skugga kan förstoras eller minskas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShapeShdwShow() {#getShapeShdwShow--}
+```
+public ShapeShdwShow getShapeShdwShow()
+```
+
+
+Anger typen av skugga för en form.
+
+**Returns:**
+[ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow)
+### getShapeShdwType() {#getShapeShdwType--}
+```
+public ShapeShdwType getShapeShdwType()
+```
+
+
+Anger typen av skugga för en form.
+
+**Returns:**
+[ShapeShdwType](../../com.aspose.diagram/shapeshdwtype)
+### getShdwBkgnd() {#getShdwBkgnd--}
+```
+public ColorValue getShdwBkgnd()
+```
+
+
+Anger färgen som används för bakgrunden (fyllning) i formens skuggfyllningsmönster.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwBkgndTrans() {#getShdwBkgndTrans--}
+```
+public DoubleValue getShdwBkgndTrans()
+```
+
+
+Anger transparensnivån för bakgrunden (fyllning) i formens skuggfyllningsmönster, från 0.0 (helt ogenomskinlig) till 1.0 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwForegnd() {#getShdwForegnd--}
+```
+public ColorValue getShdwForegnd()
+```
+
+
+Anger färgen som används för förgrunden (streck) i formens skuggfyllningsmönster.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getShdwForegndTrans() {#getShdwForegndTrans--}
+```
+public DoubleValue getShdwForegndTrans()
+```
+
+
+Anger transparensnivån för förgrunden (streck) i formens skuggfyllningsmönster, från 0.0 (helt ogenomskinlig) till 1.0 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwPattern() {#getShdwPattern--}
+```
+public IntValue getShdwPattern()
+```
+
+
+Anger fyllningsmönstret för en forms skugga.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/fill\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setFillBkgnd(ColorValue value) {#setFillBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillBkgnd(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillBkgnd()](../../com.aspose.diagram/fill\#getFillBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillBkgndTrans(DoubleValue value) {#setFillBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillBkgndTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillBkgndTrans()](../../com.aspose.diagram/fill\#getFillBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillForegnd(ColorValue value) {#setFillForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setFillForegnd(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillForegnd()](../../com.aspose.diagram/fill\#getFillForegnd--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setFillForegndTrans(DoubleValue value) {#setFillForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setFillForegndTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillForegndTrans()](../../com.aspose.diagram/fill\#getFillForegndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setFillPattern(IntValue value) {#setFillPattern-com.aspose.diagram.IntValue-}
+```
+public void setFillPattern(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillPattern()](../../com.aspose.diagram/fill\#getFillPattern--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setShapeShdwBlur(DoubleValue value) {#setShapeShdwBlur-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwBlur(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwBlur()](../../com.aspose.diagram/fill\#getShapeShdwBlur--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwObliqueAngle(DoubleValue value) {#setShapeShdwObliqueAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwObliqueAngle(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwObliqueAngle()](../../com.aspose.diagram/fill\#getShapeShdwObliqueAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetX(DoubleValue value) {#setShapeShdwOffsetX-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwOffsetX()](../../com.aspose.diagram/fill\#getShapeShdwOffsetX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwOffsetY(DoubleValue value) {#setShapeShdwOffsetY-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwOffsetY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwOffsetY()](../../com.aspose.diagram/fill\#getShapeShdwOffsetY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwScaleFactor(DoubleValue value) {#setShapeShdwScaleFactor-com.aspose.diagram.DoubleValue-}
+```
+public void setShapeShdwScaleFactor(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwScaleFactor()](../../com.aspose.diagram/fill\#getShapeShdwScaleFactor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShapeShdwShow(ShapeShdwShow value) {#setShapeShdwShow-com.aspose.diagram.ShapeShdwShow-}
+```
+public void setShapeShdwShow(ShapeShdwShow value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwShow()](../../com.aspose.diagram/fill\#getShapeShdwShow--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeShdwShow](../../com.aspose.diagram/shapeshdwshow) |  |
+
+### setShapeShdwType(ShapeShdwType value) {#setShapeShdwType-com.aspose.diagram.ShapeShdwType-}
+```
+public void setShapeShdwType(ShapeShdwType value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeShdwType()](../../com.aspose.diagram/fill\#getShapeShdwType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeShdwType](../../com.aspose.diagram/shapeshdwtype) |  |
+
+### setShdwBkgnd(ColorValue value) {#setShdwBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwBkgnd(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShdwBkgnd()](../../com.aspose.diagram/fill\#getShdwBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwBkgndTrans(DoubleValue value) {#setShdwBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwBkgndTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShdwBkgndTrans()](../../com.aspose.diagram/fill\#getShdwBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwForegnd(ColorValue value) {#setShdwForegnd-com.aspose.diagram.ColorValue-}
+```
+public void setShdwForegnd(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShdwForegnd()](../../com.aspose.diagram/fill\#getShdwForegnd--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setShdwForegndTrans(DoubleValue value) {#setShdwForegndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setShdwForegndTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShdwForegndTrans()](../../com.aspose.diagram/fill\#getShdwForegndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setShdwPattern(IntValue value) {#setShdwPattern-com.aspose.diagram.IntValue-}
+```
+public void setShdwPattern(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShdwPattern()](../../com.aspose.diagram/fill\#getShdwPattern--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/filltype/_index.md
+++ b/swedish/java/com.aspose.diagram/filltype/_index.md
@@ -1,0 +1,183 @@
+---
+title: FillType
+second_title: Aspose.Diagram för Java API-referens
+description: Fyllningsformattyp.
+type: docs
+weight: 154
+url: /sv/java/com.aspose.diagram/filltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FillType
+```
+
+Fyllningsformattyp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [AUTOMATIC](#AUTOMATIC) | Representerar automatisk formateringstyp. |
+| [GRADIENT](#GRADIENT) | Gradientfyllnadsformat. |
+| [NONE](#NONE) | Representerar ingen formateringstyp. |
+| [PATTERN](#PATTERN) | Mönsterfyllnadsformat. |
+| [SOLID](#SOLID) | Solid fyllnadsformat. |
+| [TEXTURE](#TEXTURE) | Texturfyllnadsformat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AUTOMATIC {#AUTOMATIC}
+```
+public static final int AUTOMATIC
+```
+
+
+Representerar automatisk formateringstyp.
+
+### GRADIENT {#GRADIENT}
+```
+public static final int GRADIENT
+```
+
+
+Gradientfyllnadsformat.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Representerar ingen formateringstyp.
+
+### PATTERN {#PATTERN}
+```
+public static final int PATTERN
+```
+
+
+Mönsterfyllnadsformat.
+
+### SOLID {#SOLID}
+```
+public static final int SOLID
+```
+
+
+Solid fyllnadsformat.
+
+### TEXTURE {#TEXTURE}
+```
+public static final int TEXTURE
+```
+
+
+Texturfyllnadsformat.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fld/_index.md
+++ b/swedish/java/com.aspose.diagram/fld/_index.md
@@ -1,0 +1,155 @@
+---
+title: Fld
+second_title: Aspose.Diagram för Java API-referens
+description: Anger en textfältsinsättningspunkt för motsvarande Field‑element.
+type: docs
+weight: 155
+url: /sv/java/com.aspose.diagram/fld/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Fld extends FormatTxt
+```
+
+Anger en textfältsinsättningspunkt för motsvarande Field‑element.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Fld(int IX, Shape shape)](#Fld-int-com.aspose.diagram.Shape-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fld(int IX, Shape shape) {#Fld-int-com.aspose.diagram.Shape-}
+```
+public Fld(int IX, Shape shape)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int | Det nollbaserade indexet för elementet Field inom dess överordnade element Shape. |
+| shape | [Shape](../../com.aspose.diagram/shape) | Form. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/floatpointnumcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/floatpointnumcollection/_index.md
@@ -1,0 +1,231 @@
+---
+title: FloatPointNumCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en samling av dubbleringspunktsnummer
+type: docs
+weight: 156
+url: /sv/java/com.aspose.diagram/floatpointnumcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FloatPointNumCollection extends Collection
+```
+
+Innehåller en samling av dubbleringspunktsnummer
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FloatPointNumCollection()](#FloatPointNumCollection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(double number)](#add-double-) | Lägg till dubbleringspunktsnumret i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(double number)](#remove-double-) | Ta bort dubbleringspunktsnumret från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FloatPointNumCollection() {#FloatPointNumCollection--}
+```
+public FloatPointNumCollection()
+```
+
+
+Konstruktor.
+
+### add(double number) {#add-double-}
+```
+public int add(double number)
+```
+
+
+Lägg till dubbleringspunktsnumret i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nummer | double |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public double get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+double -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(double number) {#remove-double-}
+```
+public void remove(double number)
+```
+
+
+Ta bort dubbleringspunktsnumret från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| nummer | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/folderfontsource/_index.md
+++ b/swedish/java/com.aspose.diagram/folderfontsource/_index.md
@@ -1,0 +1,177 @@
+---
+title: FolderFontSource
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar mappen som innehåller TrueType-typsnittsfiler.
+type: docs
+weight: 157
+url: /sv/java/com.aspose.diagram/folderfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class FolderFontSource extends FontSourceBase
+```
+
+Representerar mappen som innehåller TrueType-typsnittsfiler.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FolderFontSource(String folderPath, boolean scanSubfolders)](#FolderFontSource-java.lang.String-boolean-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFolderPath()](#getFolderPath--) | Sökväg till teckensnittsmappen. |
+| [getScanSubFolders()](#getScanSubFolders--) | Bestämmer om undermappar ska genomsökas eller inte. |
+| [getType()](#getType--) | Returnerar typen av teckensnittskälla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FolderFontSource(String folderPath, boolean scanSubfolders) {#FolderFontSource-java.lang.String-boolean-}
+```
+public FolderFontSource(String folderPath, boolean scanSubfolders)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| folderPath | java.lang.String | sökväg till teckensnittsmappen |
+| scanSubfolders | boolean | Bestämmer om undermappar ska genomsökas eller inte. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFolderPath() {#getFolderPath--}
+```
+public String getFolderPath()
+```
+
+
+Sökväg till teckensnittsmappen.
+
+**Returns:**
+java.lang.String
+### getScanSubFolders() {#getScanSubFolders--}
+```
+public boolean getScanSubFolders()
+```
+
+
+Bestämmer om undermappar ska genomsökas eller inte.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Returnerar typen av teckensnittskälla.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/font/_index.md
+++ b/swedish/java/com.aspose.diagram/font/_index.md
@@ -1,0 +1,288 @@
+---
+title: Typsnitt
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller information om ett typsnitt.
+type: docs
+weight: 158
+url: /sv/java/com.aspose.diagram/font/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Font
+```
+
+Innehåller information om ett typsnitt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Font()](#Font--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSets()](#getCharSets--) | De stödjade teckenuppsättningarna för typsnittet. |
+| [getClass()](#getClass--) |  |
+| [getFlags()](#getFlags--) | Flaggor som indikerar följande: saknat typsnitt, standardtypsnitt, asiatiskt typsnitt, komplext typsnitt, vertikalt typsnitt och typsnittstyp. |
+| [getID()](#getID--) | ID:t för elementet inom dess överordnade element. |
+| [getName()](#getName--) | Namnet på typsnittet som en UTF-16 Unicode-sträng. |
+| [getPanos()](#getPanos--) | Panose-signaturen för typsnittet. |
+| [getUnicodeRanges()](#getUnicodeRanges--) | De stödjade Unicode-områdena för typsnittet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSets(String value)](#setCharSets-java.lang.String-) | För beskrivningen av denna egenskap, se [getCharSets()](../../com.aspose.diagram/font\#getCharSets--) |
+| [setFlags(int value)](#setFlags-int-) | För beskrivningen av denna egenskap, se [getFlags()](../../com.aspose.diagram/font\#getFlags--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/font\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/font\#getName--) |
+| [setPanos(String value)](#setPanos-java.lang.String-) | För beskrivningen av denna egenskap, se [getPanos()](../../com.aspose.diagram/font\#getPanos--) |
+| [setUnicodeRanges(String value)](#setUnicodeRanges-java.lang.String-) | För beskrivningen av denna egenskap, se [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Font() {#Font--}
+```
+public Font()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSets() {#getCharSets--}
+```
+public String getCharSets()
+```
+
+
+De stödjade teckenuppsättningarna för typsnittet.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFlags() {#getFlags--}
+```
+public int getFlags()
+```
+
+
+Flaggor som indikerar följande: saknat typsnitt, standardtypsnitt, asiatiskt typsnitt, komplext typsnitt, vertikalt typsnitt och typsnittstyp.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Namnet på typsnittet som en UTF-16 Unicode-sträng.
+
+**Returns:**
+java.lang.String
+### getPanos() {#getPanos--}
+```
+public String getPanos()
+```
+
+
+Panose-signaturen för typsnittet. Panose är ett klassificeringssystem för typsnitt som kategoriserar dem baserat på deras visuella egenskaper.
+
+**Returns:**
+java.lang.String
+### getUnicodeRanges() {#getUnicodeRanges--}
+```
+public String getUnicodeRanges()
+```
+
+
+De stödjade Unicode-områdena för typsnittet.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSets(String value) {#setCharSets-java.lang.String-}
+```
+public void setCharSets(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCharSets()](../../com.aspose.diagram/font\#getCharSets--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFlags(int value) {#setFlags-int-}
+```
+public void setFlags(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFlags()](../../com.aspose.diagram/font\#getFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/font\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/font\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPanos(String value) {#setPanos-java.lang.String-}
+```
+public void setPanos(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPanos()](../../com.aspose.diagram/font\#getPanos--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setUnicodeRanges(String value) {#setUnicodeRanges-java.lang.String-}
+```
+public void setUnicodeRanges(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUnicodeRanges()](../../com.aspose.diagram/font\#getUnicodeRanges--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fontcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/fontcollection/_index.md
@@ -1,0 +1,247 @@
+---
+title: FontCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en samling av Font‑element.
+type: docs
+weight: 159
+url: /sv/java/com.aspose.diagram/fontcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FontCollection extends Collection
+```
+
+Innehåller en samling av Font‑element.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontCollection()](#FontCollection--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Font font)](#add-com.aspose.diagram.Font-) | Add the Font object in the collection. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getFont(int ID)](#getFont-int-) | Hämtar elementet med angivet ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Font font)](#remove-com.aspose.diagram.Font-) | Remove the Font object from the collection. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontCollection() {#FontCollection--}
+```
+public FontCollection()
+```
+
+
+Konstruktor.
+
+### add(Font font) {#add-com.aspose.diagram.Font-}
+```
+public int add(Font font)
+```
+
+
+Add the Font object in the collection.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Font get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getFont(int ID) {#getFont-int-}
+```
+public Font getFont(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int | intID för elementet inom dess överordnade element. |
+
+**Returns:**
+[Font](../../com.aspose.diagram/font) - [Font](../../com.aspose.diagram/font)Font.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Font font) {#remove-com.aspose.diagram.Font-}
+```
+public void remove(Font font)
+```
+
+
+Remove the Font object from the collection.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| font | [Font](../../com.aspose.diagram/font) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fontconfigs/_index.md
+++ b/swedish/java/com.aspose.diagram/fontconfigs/_index.md
@@ -1,0 +1,272 @@
+---
+title: FontConfigs
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar typsnittsinställningar
+type: docs
+weight: 160
+url: /sv/java/com.aspose.diagram/fontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class FontConfigs
+```
+
+Specificerar typsnittsinställningar
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontConfigs()](#FontConfigs--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFontName()](#getDefaultFontName--) | det förvalda teckensnittets namn. |
+| [getFontSources()](#getFontSources--) | Hämtar en kopia av arrayen som innehåller listan över källor |
+| [getFontSubstitutes(String originalFontName)](#getFontSubstitutes-java.lang.String-) | Returnerar en array som innehåller teckensnittsbytesnamn att använda om originalteckensnittet inte finns. |
+| [getPreferSystemFontSubstitutes()](#getPreferSystemFontSubstitutes--) | Indikerar om systemets teckensnittsbyten ska användas först eller inte när ett teckensnitt inte finns och bytet för detta teckensnitt inte är angivet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFontName(String value)](#setDefaultFontName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--) |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Ställer in teckensnittsmappen |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Ställer in teckensnittsmapparna |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Ställer in teckensnittskällorna. |
+| [setFontSubstitutes(String originalFontName, String[] substituteFontNames)](#setFontSubstitutes-java.lang.String-java.lang.String---) | Teckensnittsbytesnamn för givet originalteckensnitt. |
+| [setPreferSystemFontSubstitutes(boolean value)](#setPreferSystemFontSubstitutes-boolean-) | För beskrivningen av den här egenskapen, se [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontConfigs() {#FontConfigs--}
+```
+public FontConfigs()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFontName() {#getDefaultFontName--}
+```
+public static String getDefaultFontName()
+```
+
+
+det förvalda teckensnittets namn.
+
+**Returns:**
+java.lang.String
+### getFontSources() {#getFontSources--}
+```
+public static FontSourceBase[] getFontSources()
+```
+
+
+Hämtar en kopia av arrayen som innehåller listan över källor
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### getFontSubstitutes(String originalFontName) {#getFontSubstitutes-java.lang.String-}
+```
+public static String[] getFontSubstitutes(String originalFontName)
+```
+
+
+Returnerar en array som innehåller teckensnittsbytesnamn att använda om originalteckensnittet inte finns.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| originalFontName | java.lang.String | originalFontName |
+
+**Returns:**
+java.lang.String[] - En array som innehåller namn på teckensnittssubstitut som ska användas om originalteckensnittet inte finns.
+### getPreferSystemFontSubstitutes() {#getPreferSystemFontSubstitutes--}
+```
+public static boolean getPreferSystemFontSubstitutes()
+```
+
+
+Ange om systemteckensnittssubstitut ska användas först eller inte när ett teckensnitt inte finns och substitutet för detta teckensnitt inte är angivet. t.ex. På Ubuntu ersätts "Arial"-teckensnittet vanligtvis av "Liberation Sans". Standardvärdet är false.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFontName(String value) {#setDefaultFontName-java.lang.String-}
+```
+public static void setDefaultFontName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDefaultFontName()](../../com.aspose.diagram/fontconfigs\#getDefaultFontName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public static void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Ställer in teckensnittsmappen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontFolder | java.lang.String | Mappen som innehåller TrueType-teckensnitt. |
+| recursive | boolean | Bestämmer om undermappar ska genomsökas eller inte. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public static void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Ställer in teckensnittsmapparna
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Mapparna som innehåller TrueType-teckensnitt. |
+| recursive | boolean | Bestämmer om undermappar ska genomsökas eller inte. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public static void setFontSources(FontSourceBase[] sources)
+```
+
+
+Ställer in teckensnittskällorna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | En array av källor som innehåller TrueType-teckensnitt. |
+
+### setFontSubstitutes(String originalFontName, String[] substituteFontNames) {#setFontSubstitutes-java.lang.String-java.lang.String---}
+```
+public static void setFontSubstitutes(String originalFontName, String[] substituteFontNames)
+```
+
+
+Teckensnittsbytesnamn för givet originalteckensnitt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| originalFontName | java.lang.String | Originalt teckensnittsnamn. |
+| substituteFontNames | java.lang.String[] | Lista över namn på teckensnittssubstitut som ska användas om originalteckensnittet inte finns. |
+
+### setPreferSystemFontSubstitutes(boolean value) {#setPreferSystemFontSubstitutes-boolean-}
+```
+public static void setPreferSystemFontSubstitutes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPreferSystemFontSubstitutes()](../../com.aspose.diagram/fontconfigs\#getPreferSystemFontSubstitutes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fontsourcebase/_index.md
+++ b/swedish/java/com.aspose.diagram/fontsourcebase/_index.md
@@ -1,0 +1,147 @@
+---
+title: FontSourceBase
+second_title: Aspose.Diagram för Java API-referens
+description: Detta är en abstrakt basklass för de klasser som låter användaren ange olika typsnittskällor
+type: docs
+weight: 161
+url: /sv/java/com.aspose.diagram/fontsourcebase/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FontSourceBase
+```
+
+Detta är en abstrakt basklass för de klasser som låter användaren ange olika typsnittskällor
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FontSourceBase()](#FontSourceBase--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getType()](#getType--) | Returnerar typen av teckensnittskälla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FontSourceBase() {#FontSourceBase--}
+```
+public FontSourceBase()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getType() {#getType--}
+```
+public abstract int getType()
+```
+
+
+Returnerar typen av teckensnittskälla.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/fontsourcetype/_index.md
+++ b/swedish/java/com.aspose.diagram/fontsourcetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: FontSourceType
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar typen av en typsnittskälla.
+type: docs
+weight: 162
+url: /sv/java/com.aspose.diagram/fontsourcetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FontSourceType
+```
+
+Specificerar typen av en typsnittskälla.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FONTS_FOLDER](#FONTS-FOLDER) | representerar mapp med teckensnitts-filer. |
+| [FONT_FILE](#FONT-FILE) | representerar en enskild teckensnittsfil. |
+| [MEMORY_FONT](#MEMORY-FONT) | representerar ett enskilt teckensnitt i minnet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONTS_FOLDER {#FONTS-FOLDER}
+```
+public static final int FONTS_FOLDER
+```
+
+
+representerar mapp med teckensnitts-filer.
+
+### FONT_FILE {#FONT-FILE}
+```
+public static final int FONT_FILE
+```
+
+
+representerar en enskild teckensnittsfil.
+
+### MEMORY_FONT {#MEMORY-FONT}
+```
+public static final int MEMORY_FONT
+```
+
+
+representerar ett enskilt teckensnitt i minnet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/foreign/_index.md
+++ b/swedish/java/com.aspose.diagram/foreign/_index.md
@@ -1,0 +1,205 @@
+---
+title: Främmande
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument.
+type: docs
+weight: 163
+url: /sv/java/com.aspose.diagram/foreign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Foreign
+```
+
+Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. Inkluderar också element som specificerar avståndet som objektets bild förskjuts inom dess kanter.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getImgHeight()](#getImgHeight--) | Bestämmer bildens höjd för objektet inom dess ram. |
+| [getImgOffsetX()](#getImgOffsetX--) | Bestämmer avståndet objektet är förskjutet horisontellt från ursprunget för objektets ram. |
+| [getImgOffsetY()](#getImgOffsetY--) | Bestämmer avståndet objektet är förskjutet vertikalt från ursprunget för objektets ram. |
+| [getImgWidth()](#getImgWidth--) | Bestämmer bildens bredd för objektet inom dess ram. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/foreign\\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getImgHeight() {#getImgHeight--}
+```
+public DoubleValue getImgHeight()
+```
+
+
+Bestämmer bildens höjd för objektet inom dess ram. Standardformeln är: F=\"Height\\*1\".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetX() {#getImgOffsetX--}
+```
+public DoubleValue getImgOffsetX()
+```
+
+
+Bestämmer avståndet som objektet förskjuts horisontellt från ursprunget för objektets ram. Standardvärdet är 0; standardformeln är F=\"ImgWidth\\*0\".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgOffsetY() {#getImgOffsetY--}
+```
+public DoubleValue getImgOffsetY()
+```
+
+
+Bestämmer avståndet som objektet förskjuts vertikalt från ursprunget för objektets ram. Standardvärdet är 0; standardformeln är F=\"ImgHeight\\*0\".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getImgWidth() {#getImgWidth--}
+```
+public DoubleValue getImgWidth()
+```
+
+
+Bestämmer bildens bredd för objektet inom dess ram. Standardformeln är: F=\"Width\\*1\".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/foreign\\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/foreigndata/_index.md
+++ b/swedish/java/com.aspose.diagram/foreigndata/_index.md
@@ -1,0 +1,486 @@
+---
+title: ForeignData
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en MIME Multipurpose Internet Mail Extensions-kodad BLOB av bilddata såsom Windows-metafil bitmap eller OLE-data.
+type: docs
+weight: 164
+url: /sv/java/com.aspose.diagram/foreigndata/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ForeignData
+```
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompressionLevel()](#getCompressionLevel--) | Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. |
+| [getCompressionType()](#getCompressionType--) | Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. |
+| [getExtentX()](#getExtentX--) | Detta attribut är endast meningsfullt om den främmande datan är en metafil. |
+| [getExtentY()](#getExtentY--) | Detta attribut är endast meningsfullt om den främmande datan är en metafil. |
+| [getForeignType()](#getForeignType--) | Datatyp. |
+| [getImageData()](#getImageData--) | Representerar bild av ole-objekt som byte-array. |
+| [getMappingMode()](#getMappingMode--) | Detta attribut är endast meningsfullt om den främmande datan är en metafil. |
+| [getObjectData()](#getObjectData--) | Representerar inbäddad ole-objektsdata som byte-array. |
+| [getObjectHeight()](#getObjectHeight--) | Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt. |
+| [getObjectSourceFullName()](#getObjectSourceFullName--) | Returnerar det fullständiga namnet på källfilen för det länkade OLE-objektet. |
+| [getObjectType()](#getObjectType--) | Om attributet ForeignType är "Object" måste ForeignData‑elementet också ha ett ObjectType‑attribut. |
+| [getObjectWidth()](#getObjectWidth--) | Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt. |
+| [getShowAsIcon()](#getShowAsIcon--) | Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt. |
+| [getValue()](#getValue--) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompressionLevel(double value)](#setCompressionLevel-double-) | För beskrivning av denna egenskap, se [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--) |
+| [setCompressionType(int value)](#setCompressionType-int-) | För beskrivning av denna egenskap, se [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--) |
+| [setExtentX(double value)](#setExtentX-double-) | För beskrivning av denna egenskap, se [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--) |
+| [setExtentY(double value)](#setExtentY-double-) | För beskrivning av denna egenskap, se [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--) |
+| [setForeignType(int value)](#setForeignType-int-) | För beskrivning av denna egenskap, se [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--) |
+| [setImageData(byte[] value)](#setImageData-byte---) | För beskrivning av denna egenskap, se [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--) |
+| [setMappingMode(int value)](#setMappingMode-int-) | För beskrivning av denna egenskap, se [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--) |
+| [setObjectData(byte[] value)](#setObjectData-byte---) | För beskrivning av denna egenskap, se [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--) |
+| [setObjectHeight(double value)](#setObjectHeight-double-) | För beskrivning av denna egenskap, se [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--) |
+| [setObjectSourceFullName(String value)](#setObjectSourceFullName-java.lang.String-) | För beskrivning av denna egenskap, se [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--) |
+| [setObjectType(int value)](#setObjectType-int-) | För beskrivning av denna egenskap, se [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--) |
+| [setObjectWidth(double value)](#setObjectWidth-double-) | För beskrivning av denna egenskap, se [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--) |
+| [setShowAsIcon(int value)](#setShowAsIcon-int-) | För beskrivning av denna egenskap, se [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--) |
+| [setValue(byte[] value)](#setValue-byte---) | För beskrivning av denna egenskap, se [getValue()](../../com.aspose.diagram/foreigndata\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompressionLevel() {#getCompressionLevel--}
+```
+public double getCompressionLevel()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. Värdet anger komprimeringsnivån som tillämpas på filen. Komprimeringsnivån mäts i hundradelar av en procent.
+
+**Returns:**
+double
+### getCompressionType() {#getCompressionType--}
+```
+public int getCompressionType()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är ett rasterbaserat främmande objekt, såsom en DIB-, JPG-, PNG-, TIFF- eller GIF-fil. Värdet anger typen av kompression som tillämpas på filen.
+
+**Returns:**
+int
+### getExtentX() {#getExtentX--}
+```
+public double getExtentX()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är en metafil. Värdet anger den horisontella omfattningen av metafilen.
+
+**Returns:**
+double
+### getExtentY() {#getExtentY--}
+```
+public double getExtentY()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är en metafil. Värdet anger den vertikala omfattningen av metafilen.
+
+**Returns:**
+double
+### getForeignType() {#getForeignType--}
+```
+public int getForeignType()
+```
+
+
+Datatyp.
+
+**Returns:**
+int
+### getImageData() {#getImageData--}
+```
+public byte[] getImageData()
+```
+
+
+Representerar bild av ole-objekt som byte-array.
+
+**Returns:**
+byte[]
+### getMappingMode() {#getMappingMode--}
+```
+public int getMappingMode()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är en metafil. Värdet anger metafilens kartläggningsläge.
+
+**Returns:**
+int
+### getObjectData() {#getObjectData--}
+```
+public byte[] getObjectData()
+```
+
+
+Representerar inbäddad ole-objektsdata som byte-array.
+
+**Returns:**
+byte[]
+### getObjectHeight() {#getObjectHeight--}
+```
+public double getObjectHeight()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt. Värdet uttrycker objektets höjd i sid-enheter.
+
+**Returns:**
+double
+### getObjectSourceFullName() {#getObjectSourceFullName--}
+```
+public String getObjectSourceFullName()
+```
+
+
+Returnerar det fullständiga namnet på källfilen för det länkade OLE-objektet. Stöder endast att ange det fullständiga namnet när filtypen är OleFileType.Unknown. Till exempel wav‑fil, avi‑fil osv..
+
+**Returns:**
+java.lang.String
+### getObjectType() {#getObjectType--}
+```
+public int getObjectType()
+```
+
+
+Om attributet ForeignType är "Object" måste ForeignData‑elementet också ha ett ObjectType‑attribut.
+
+**Returns:**
+int
+### getObjectWidth() {#getObjectWidth--}
+```
+public double getObjectWidth()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt. Värdet uttrycker objektets bredd i sid-enheter.
+
+**Returns:**
+double
+### getShowAsIcon() {#getShowAsIcon--}
+```
+public int getShowAsIcon()
+```
+
+
+Detta attribut är endast meningsfullt om den främmande datan är ett OLE2 inbäddat objekt.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public byte[] getValue()
+```
+
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+
+**Returns:**
+byte[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompressionLevel(double value) {#setCompressionLevel-double-}
+```
+public void setCompressionLevel(double value)
+```
+
+
+För beskrivning av denna egenskap, se [getCompressionLevel()](../../com.aspose.diagram/foreigndata\#getCompressionLevel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setCompressionType(int value) {#setCompressionType-int-}
+```
+public void setCompressionType(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getCompressionType()](../../com.aspose.diagram/foreigndata\#getCompressionType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setExtentX(double value) {#setExtentX-double-}
+```
+public void setExtentX(double value)
+```
+
+
+För beskrivning av denna egenskap, se [getExtentX()](../../com.aspose.diagram/foreigndata\#getExtentX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setExtentY(double value) {#setExtentY-double-}
+```
+public void setExtentY(double value)
+```
+
+
+För beskrivning av denna egenskap, se [getExtentY()](../../com.aspose.diagram/foreigndata\#getExtentY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setForeignType(int value) {#setForeignType-int-}
+```
+public void setForeignType(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getForeignType()](../../com.aspose.diagram/foreigndata\#getForeignType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setImageData(byte[] value) {#setImageData-byte---}
+```
+public void setImageData(byte[] value)
+```
+
+
+För beskrivning av denna egenskap, se [getImageData()](../../com.aspose.diagram/foreigndata\#getImageData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMappingMode(int value) {#setMappingMode-int-}
+```
+public void setMappingMode(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getMappingMode()](../../com.aspose.diagram/foreigndata\#getMappingMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setObjectData(byte[] value) {#setObjectData-byte---}
+```
+public void setObjectData(byte[] value)
+```
+
+
+För beskrivning av denna egenskap, se [getObjectData()](../../com.aspose.diagram/foreigndata\#getObjectData--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setObjectHeight(double value) {#setObjectHeight-double-}
+```
+public void setObjectHeight(double value)
+```
+
+
+För beskrivning av denna egenskap, se [getObjectHeight()](../../com.aspose.diagram/foreigndata\#getObjectHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setObjectSourceFullName(String value) {#setObjectSourceFullName-java.lang.String-}
+```
+public void setObjectSourceFullName(String value)
+```
+
+
+För beskrivning av denna egenskap, se [getObjectSourceFullName()](../../com.aspose.diagram/foreigndata\#getObjectSourceFullName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setObjectType(int value) {#setObjectType-int-}
+```
+public void setObjectType(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getObjectType()](../../com.aspose.diagram/foreigndata\#getObjectType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setObjectWidth(double value) {#setObjectWidth-double-}
+```
+public void setObjectWidth(double value)
+```
+
+
+För beskrivning av denna egenskap, se [getObjectWidth()](../../com.aspose.diagram/foreigndata\#getObjectWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setShowAsIcon(int value) {#setShowAsIcon-int-}
+```
+public void setShowAsIcon(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getShowAsIcon()](../../com.aspose.diagram/foreigndata\#getShowAsIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setValue(byte[] value) {#setValue-byte---}
+```
+public void setValue(byte[] value)
+```
+
+
+För beskrivning av denna egenskap, se [getValue()](../../com.aspose.diagram/foreigndata\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/foreigntype/_index.md
+++ b/swedish/java/com.aspose.diagram/foreigntype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ForeignType
+second_title: Aspose.Diagram för Java API-referens
+description: Datatyp.
+type: docs
+weight: 165
+url: /sv/java/com.aspose.diagram/foreigntype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ForeignType
+```
+
+Datatyp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BITMAP](#BITMAP) | Bitmap. |
+| [ENH_METAFILE](#ENH-METAFILE) | Förbättrad Metafil. |
+| [INK](#INK) | Bläck. |
+| [METAFILE](#METAFILE) | Metafil. |
+| [OBJECT](#OBJECT) | Objekt. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BITMAP {#BITMAP}
+```
+public static final int BITMAP
+```
+
+
+Bitmap.
+
+### ENH_METAFILE {#ENH-METAFILE}
+```
+public static final int ENH_METAFILE
+```
+
+
+Förbättrad Metafil.
+
+### INK {#INK}
+```
+public static final int INK
+```
+
+
+Bläck.
+
+### METAFILE {#METAFILE}
+```
+public static final int METAFILE
+```
+
+
+Metafil.
+
+### OBJECT {#OBJECT}
+```
+public static final int OBJECT
+```
+
+
+Objekt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/formattxt/_index.md
+++ b/swedish/java/com.aspose.diagram/formattxt/_index.md
@@ -1,0 +1,147 @@
+---
+title: FormatTxt
+second_title: Aspose.Diagram för Java API-referens
+description: Abstrakt klass för formatering av text
+type: docs
+weight: 166
+url: /sv/java/com.aspose.diagram/formattxt/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class FormatTxt
+```
+
+Abstrakt klass för formatering av text
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [FormatTxt()](#FormatTxt--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FormatTxt() {#FormatTxt--}
+```
+public FormatTxt()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public abstract String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/formattxtcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/formattxtcollection/_index.md
@@ -1,0 +1,243 @@
+---
+title: FormatTxtCollection
+second_title: Aspose.Diagram för Java API-referens
+description: FormatTxt‑samling som innehåller texten för en form.
+type: docs
+weight: 167
+url: /sv/java/com.aspose.diagram/formattxtcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class FormatTxtCollection extends Collection
+```
+
+FormatTxt‑samling som innehåller texten för en form.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(FormatTxt item)](#add-com.aspose.diagram.FormatTxt-) | Lägg till FormatTxt-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getText()](#getText--) | Innehåller texten för en form med formatering. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(FormatTxt item)](#remove-com.aspose.diagram.FormatTxt-) | Ta bort FormatTxt-objektet från samlingen. |
+| [setWholeText(String text)](#setWholeText-java.lang.String-) | Ange texten för en form utan formatering. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(FormatTxt item) {#add-com.aspose.diagram.FormatTxt-}
+```
+public int add(FormatTxt item)
+```
+
+
+Lägg till FormatTxt-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public FormatTxt get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[FormatTxt](../../com.aspose.diagram/formattxt) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Innehåller texten för en form med formatering.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(FormatTxt item) {#remove-com.aspose.diagram.FormatTxt-}
+```
+public void remove(FormatTxt item)
+```
+
+
+Ta bort FormatTxt-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [FormatTxt](../../com.aspose.diagram/formattxt) |  |
+
+### setWholeText(String text) {#setWholeText-java.lang.String-}
+```
+public void setWholeText(String text)
+```
+
+
+Ange texten för en form utan formatering.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/frompartvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/frompartvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: FromPartValue
+second_title: Aspose.Diagram för Java API-referens
+description: Den del av en form varifrån en anslutning startar.
+type: docs
+weight: 168
+url: /sv/java/com.aspose.diagram/frompartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class FromPartValue
+```
+
+Den del av en form varifrån en anslutning startar.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BEGIN_X_CELL](#BEGIN-X-CELL) | BeginX-cell. |
+| [BEGIN_X_OR_BEGIN_Y_POINT](#BEGIN-X-OR-BEGIN-Y-POINT) | BeginX/BeginY-punkt. |
+| [BEGIN_Y_CELL](#BEGIN-Y-CELL) | BeginY-cell. |
+| [BOTTOM_EDGE](#BOTTOM-EDGE) | Bottenkant. |
+| [CENTER_EDGE](#CENTER-EDGE) | Centrumkant. |
+| [CONTROL_POINT](#CONTROL-POINT) | Kontrollpunkt. |
+| [END_X_CELL](#END-X-CELL) | EndX-cell. |
+| [END_X_OR_END_Y_POINT](#END-X-OR-END-Y-POINT) | EndX/EndY-punkt. |
+| [END_Y_CELL](#END-Y-CELL) | EndY‑cell. |
+| [LEFT_EDGE](#LEFT-EDGE) | Vänster kant. |
+| [MIDDLE_EDGE](#MIDDLE-EDGE) | Mellan kant. |
+| [NONE](#NONE) | Ingen. |
+| [RIGHT_EDGE](#RIGHT-EDGE) | Höger kant. |
+| [TOP_EDGE](#TOP-EDGE) | Övre kant. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BEGIN_X_CELL {#BEGIN-X-CELL}
+```
+public static final int BEGIN_X_CELL
+```
+
+
+BeginX-cell.
+
+### BEGIN_X_OR_BEGIN_Y_POINT {#BEGIN-X-OR-BEGIN-Y-POINT}
+```
+public static final int BEGIN_X_OR_BEGIN_Y_POINT
+```
+
+
+BeginX/BeginY-punkt.
+
+### BEGIN_Y_CELL {#BEGIN-Y-CELL}
+```
+public static final int BEGIN_Y_CELL
+```
+
+
+BeginY-cell.
+
+### BOTTOM_EDGE {#BOTTOM-EDGE}
+```
+public static final int BOTTOM_EDGE
+```
+
+
+Bottenkant.
+
+### CENTER_EDGE {#CENTER-EDGE}
+```
+public static final int CENTER_EDGE
+```
+
+
+Centrumkant.
+
+### CONTROL_POINT {#CONTROL-POINT}
+```
+public static final int CONTROL_POINT
+```
+
+
+Kontrollpunkt.
+
+### END_X_CELL {#END-X-CELL}
+```
+public static final int END_X_CELL
+```
+
+
+EndX-cell.
+
+### END_X_OR_END_Y_POINT {#END-X-OR-END-Y-POINT}
+```
+public static final int END_X_OR_END_Y_POINT
+```
+
+
+EndX/EndY-punkt.
+
+### END_Y_CELL {#END-Y-CELL}
+```
+public static final int END_Y_CELL
+```
+
+
+EndY‑cell.
+
+### LEFT_EDGE {#LEFT-EDGE}
+```
+public static final int LEFT_EDGE
+```
+
+
+Vänster kant.
+
+### MIDDLE_EDGE {#MIDDLE-EDGE}
+```
+public static final int MIDDLE_EDGE
+```
+
+
+Mellan kant.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen.
+
+### RIGHT_EDGE {#RIGHT-EDGE}
+```
+public static final int RIGHT_EDGE
+```
+
+
+Höger kant.
+
+### TOP_EDGE {#TOP-EDGE}
+```
+public static final int TOP_EDGE
+```
+
+
+Övre kant.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/geom/_index.md
+++ b/swedish/java/com.aspose.diagram/geom/_index.md
@@ -1,0 +1,346 @@
+---
+title: Geom
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar koordinaterna för hörnen på linjerna och bågarna som utgör formen.
+type: docs
+weight: 169
+url: /sv/java/com.aspose.diagram/geom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Geom
+```
+
+Innehåller element som specificerar koordinaterna för vertexerna för linjerna och bågarna som utgör formen. Om formen har mer än en bana finns ett Geom-element för varje bana.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Geom()](#Geom--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCoordinateCol()](#getCoordinateCol--) | Samling av koordinater. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getNextCoordinateIX()](#getNextCoordinateIX--) | Returnerar IX-värdet för nästa formes koordinatsamlingsmedlem. |
+| [getNoFill()](#getNoFill--) | Anger om en bana kan fyllas. |
+| [getNoLine()](#getNoLine--) | Anger om en linje ritas runt banans gräns. |
+| [getNoQuickDrag()](#getNoQuickDrag--) | Bestämmer om en form kan väljas eller dras när användaren klickar på det fyllda området som definieras av Geometry‑sektionen. |
+| [getNoShow()](#getNoShow--) | Anger om en bana visas på ritningssidan. |
+| [getNoSnap()](#getNoSnap--) | Anger om andra former fäster sig på en bana. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/geom\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/geom\#getIX--) |
+| [setNoFill(BoolValue value)](#setNoFill-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--) |
+| [setNoLine(BoolValue value)](#setNoLine-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--) |
+| [setNoQuickDrag(BoolValue value)](#setNoQuickDrag-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--) |
+| [setNoShow(BoolValue value)](#setNoShow-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--) |
+| [setNoSnap(BoolValue value)](#setNoSnap-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Geom() {#Geom--}
+```
+public Geom()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCoordinateCol() {#getCoordinateCol--}
+```
+public CoordinateCollection getCoordinateCol()
+```
+
+
+Samling av koordinater. Den visar en sekvens av koordinater.
+
+**Returns:**
+[CoordinateCollection](../../com.aspose.diagram/coordinatecollection)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getNextCoordinateIX() {#getNextCoordinateIX--}
+```
+public int getNextCoordinateIX()
+```
+
+
+Returnerar IX-värdet för nästa formes koordinatsamlingsmedlem.
+
+**Returns:**
+int
+### getNoFill() {#getNoFill--}
+```
+public BoolValue getNoFill()
+```
+
+
+Anger om en bana kan fyllas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLine() {#getNoLine--}
+```
+public BoolValue getNoLine()
+```
+
+
+Anger om en linje ritas runt banans gräns.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoQuickDrag() {#getNoQuickDrag--}
+```
+public BoolValue getNoQuickDrag()
+```
+
+
+Bestämmer om en form kan väljas eller dras när användaren klickar på det fyllda området som definieras av Geometry‑sektionen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoShow() {#getNoShow--}
+```
+public BoolValue getNoShow()
+```
+
+
+Anger om en bana visas på ritningssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoSnap() {#getNoSnap--}
+```
+public BoolValue getNoSnap()
+```
+
+
+Anger om andra former fäster sig på en bana.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/geom\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/geom\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setNoFill(BoolValue value) {#setNoFill-com.aspose.diagram.BoolValue-}
+```
+public void setNoFill(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNoFill()](../../com.aspose.diagram/geom\#getNoFill--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoLine(BoolValue value) {#setNoLine-com.aspose.diagram.BoolValue-}
+```
+public void setNoLine(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNoLine()](../../com.aspose.diagram/geom\#getNoLine--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoQuickDrag(BoolValue value) {#setNoQuickDrag-com.aspose.diagram.BoolValue-}
+```
+public void setNoQuickDrag(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNoQuickDrag()](../../com.aspose.diagram/geom\#getNoQuickDrag--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoShow(BoolValue value) {#setNoShow-com.aspose.diagram.BoolValue-}
+```
+public void setNoShow(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNoShow()](../../com.aspose.diagram/geom\#getNoShow--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setNoSnap(BoolValue value) {#setNoSnap-com.aspose.diagram.BoolValue-}
+```
+public void setNoSnap(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNoSnap()](../../com.aspose.diagram/geom\#getNoSnap--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/geomcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/geomcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GeomCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Geom‑samling.
+type: docs
+weight: 170
+url: /sv/java/com.aspose.diagram/geomcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GeomCollection extends Collection
+```
+
+Geom‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Geom item)](#add-com.aspose.diagram.Geom-) | Lägg till Geom-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Geom item)](#remove-com.aspose.diagram.Geom-) | Ta bort Geom-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Geom item) {#add-com.aspose.diagram.Geom-}
+```
+public int add(Geom item)
+```
+
+
+Lägg till Geom-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Geom get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Geom](../../com.aspose.diagram/geom) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Geom item) {#remove-com.aspose.diagram.Geom-}
+```
+public void remove(Geom item)
+```
+
+
+Ta bort Geom-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Geom](../../com.aspose.diagram/geom) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gloweffect/_index.md
+++ b/swedish/java/com.aspose.diagram/gloweffect/_index.md
@@ -1,0 +1,150 @@
+---
+title: GlowEffect
+second_title: Aspose.Diagram för Java API-referens
+description: Denna klass specificerar en glödeffekt där en färgad, suddig kontur läggs till utanför objektets kanter.
+type: docs
+weight: 171
+url: /sv/java/com.aspose.diagram/gloweffect/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlowEffect
+```
+
+Denna klass specificerar en glödeffekt, där en färgad suddig kontur läggs till utanför objektets kanter.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getSize()](#getSize--) | glödens radie, i enheter av punkter. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double value)](#setSize-double-) | För beskrivningen av den här egenskapen, se [getSize()](../../com.aspose.diagram/gloweffect\#getSize--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSize() {#getSize--}
+```
+public double getSize()
+```
+
+
+glödens radie, i enheter av punkter.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double value) {#setSize-double-}
+```
+public void setSize(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSize()](../../com.aspose.diagram/gloweffect\#getSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gluedshapesflags/_index.md
+++ b/swedish/java/com.aspose.diagram/gluedshapesflags/_index.md
@@ -1,0 +1,183 @@
+---
+title: GluedShapesFlags
+second_title: Aspose.Diagram för Java API-referens
+description: Anger konstanter som identifierar vilka former som ska returneras baserat på dimensionen och riktningen för anslutningspunkterna som är fästa vid en viss form som skickas till metoden Shape.GluedShapes.
+type: docs
+weight: 176
+url: /sv/java/com.aspose.diagram/gluedshapesflags/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GluedShapesFlags
+```
+
+Anger konstanter som identifierar vilka former som ska returneras, baserat på dimensionen och riktningen för anslutningspunkterna som är limmade till en viss form; skickas till metoden Shape.GluedShapes.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [GLUED_SHAPES_ALL_1_D](#GLUED-SHAPES-ALL-1-D) | Returnera ID:n för alla 1‑D‑former som är fästa vid denna form. |
+| [GLUED_SHAPES_ALL_2_D](#GLUED-SHAPES-ALL-2-D) | Returnera alla 2‑D‑former som är fästa vid denna form och alla 2‑D‑former som denna form är fäst vid. |
+| [GLUED_SHAPES_INCOMING_1_D](#GLUED-SHAPES-INCOMING-1-D) | Returnera ID:n för 1‑D‑former vars ändpunkter är fästa vid denna form. |
+| [GLUED_SHAPES_INCOMING_2_D](#GLUED-SHAPES-INCOMING-2-D) | Om källobjektet är en 1‑D‑form, returnera ID:n för 2‑D‑formen som startpunkten är fäst vid. |
+| [GLUED_SHAPES_OUTGOING_1_D](#GLUED-SHAPES-OUTGOING-1-D) | Returnera ID:n för 1‑D‑former vars startpunkter är fästa vid denna form. |
+| [GLUED_SHAPES_OUTGOING_2_D](#GLUED-SHAPES-OUTGOING-2-D) | Om källobjektet är en 1‑D‑form, returnera ID:n för 2‑D‑formen som slutpunkten är fäst vid. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUED_SHAPES_ALL_1_D {#GLUED-SHAPES-ALL-1-D}
+```
+public static final int GLUED_SHAPES_ALL_1_D
+```
+
+
+Returnera ID:n för alla 1‑D‑former som är fästa vid denna form.
+
+### GLUED_SHAPES_ALL_2_D {#GLUED-SHAPES-ALL-2-D}
+```
+public static final int GLUED_SHAPES_ALL_2_D
+```
+
+
+Returnera alla 2‑D‑former som är fästa vid denna form och alla 2‑D‑former som denna form är fäst vid.
+
+### GLUED_SHAPES_INCOMING_1_D {#GLUED-SHAPES-INCOMING-1-D}
+```
+public static final int GLUED_SHAPES_INCOMING_1_D
+```
+
+
+Returnera ID:n för 1‑D‑former vars ändpunkter är fästa vid denna form.
+
+### GLUED_SHAPES_INCOMING_2_D {#GLUED-SHAPES-INCOMING-2-D}
+```
+public static final int GLUED_SHAPES_INCOMING_2_D
+```
+
+
+Om källobjektet är en 1‑D‑form, returnera ID:n för 2‑D‑formen som startpunkten är fäst vid. Om källobjektet är en 2‑D‑form, returnera ID:n för 2‑D‑former som är fästa vid denna form.
+
+### GLUED_SHAPES_OUTGOING_1_D {#GLUED-SHAPES-OUTGOING-1-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_1_D
+```
+
+
+Returnera ID:n för 1‑D‑former vars startpunkter är fästa vid denna form.
+
+### GLUED_SHAPES_OUTGOING_2_D {#GLUED-SHAPES-OUTGOING-2-D}
+```
+public static final int GLUED_SHAPES_OUTGOING_2_D
+```
+
+
+Om källobjektet är en 1‑D‑form, returnera ID:n för 2‑D‑formen som slutpunkten är fäst vid. Om källobjektet är en 2‑D‑form, returnera ID:n för 2‑D‑former som denna form är fäst vid.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gluesettings/_index.md
+++ b/swedish/java/com.aspose.diagram/gluesettings/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettings
+second_title: Aspose.Diagram för Java API-referens
+description: Bitvärdena indikerar att en specifik liminställning är på eller av.
+type: docs
+weight: 172
+url: /sv/java/com.aspose.diagram/gluesettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettings
+```
+
+Bitvärdena indikerar att en specifik liminställning är på eller av. Värdet kan vara en summa av värdena:
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Limma till anslutningspunkter. |
+| [DISABLED](#DISABLED) | Lim är inaktiverat |
+| [GEOMETRY](#GEOMETRY) | Limma till geometri. |
+| [GUIDES](#GUIDES) | Limma till hjälplinjer. |
+| [HANDLES](#HANDLES) | Limma till handtag. |
+| [NONE](#NONE) | Lim är aktiverat, men inga andra liminställningar är aktiverade. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VERTICES](#VERTICES) | Limma till hörn. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Limma till anslutningspunkter.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Lim är inaktiverat
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Limma till geometri.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Limma till hjälplinjer.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Limma till handtag.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Lim är aktiverat, men inga andra liminställningar är aktiverade.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Limma till hörn.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gluesettingsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/gluesettingsvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: GlueSettingsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger de objekt som former limmas till när lim är aktiverat i dokumentet.
+type: docs
+weight: 173
+url: /sv/java/com.aspose.diagram/gluesettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueSettingsValue
+```
+
+Anger de objekt som former limmas till när lim är aktiverat i dokumentet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [GLUE_IS_DISABLED](#GLUE-IS-DISABLED) | Lim är inaktiverat. |
+| [GLUE_IS_ENABLED](#GLUE-IS-ENABLED) | Lim är aktiverat, men inga andra liminställningar är aktiverade. |
+| [GLUE_TO_CONNECTION_POINTS](#GLUE-TO-CONNECTION-POINTS) | Limma till anslutningspunkter. |
+| [GLUE_TO_GEOMETRY](#GLUE-TO-GEOMETRY) | Limma till geometri. |
+| [GLUE_TO_GUIDES](#GLUE-TO-GUIDES) | Limma till hjälplinjer. |
+| [GLUE_TO_HANDLES](#GLUE-TO-HANDLES) | Limma till handtag. |
+| [GLUE_TO_VERTICES](#GLUE-TO-VERTICES) | Limma till hörn. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GLUE_IS_DISABLED {#GLUE-IS-DISABLED}
+```
+public static final int GLUE_IS_DISABLED
+```
+
+
+Lim är inaktiverat.
+
+### GLUE_IS_ENABLED {#GLUE-IS-ENABLED}
+```
+public static final int GLUE_IS_ENABLED
+```
+
+
+Lim är aktiverat, men inga andra liminställningar är aktiverade.
+
+### GLUE_TO_CONNECTION_POINTS {#GLUE-TO-CONNECTION-POINTS}
+```
+public static final int GLUE_TO_CONNECTION_POINTS
+```
+
+
+Limma till anslutningspunkter.
+
+### GLUE_TO_GEOMETRY {#GLUE-TO-GEOMETRY}
+```
+public static final int GLUE_TO_GEOMETRY
+```
+
+
+Limma till geometri.
+
+### GLUE_TO_GUIDES {#GLUE-TO-GUIDES}
+```
+public static final int GLUE_TO_GUIDES
+```
+
+
+Limma till hjälplinjer.
+
+### GLUE_TO_HANDLES {#GLUE-TO-HANDLES}
+```
+public static final int GLUE_TO_HANDLES
+```
+
+
+Limma till handtag.
+
+### GLUE_TO_VERTICES {#GLUE-TO-VERTICES}
+```
+public static final int GLUE_TO_VERTICES
+```
+
+
+Limma till hörn.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gluetype/_index.md
+++ b/swedish/java/com.aspose.diagram/gluetype/_index.md
@@ -1,0 +1,179 @@
+---
+title: GlueType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om dynamisk limning mellan former är tillåten när man ansluter till en form.
+type: docs
+weight: 174
+url: /sv/java/com.aspose.diagram/gluetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GlueType
+```
+
+Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GlueType(int value)](#GlueType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/gluetype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GlueType(int value) {#GlueType-int-}
+```
+public GlueType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/gluetype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gluetypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/gluetypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: GlueTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om dynamisk limning mellan former är tillåten när man ansluter till en form.
+type: docs
+weight: 175
+url: /sv/java/com.aspose.diagram/gluetypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GlueTypeValue
+```
+
+Anger om dynamiskt (form-till-form) lim är tillåtet när man ansluter till en form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALLOW_DYNAMIC_GLUE](#ALLOW-DYNAMIC-GLUE) | Tillåt dynamisk limning. |
+| [ALLOW_DYNAMIC_GLUE_2002](#ALLOW-DYNAMIC-GLUE-2002) | Tillåt dynamisk limning (föråldrad i Microsoft Visio 2002). |
+| [ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR](#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR) | Standard. |
+| [NO_ALLOW_2_D_SHAPE](#NO-ALLOW-2-D-SHAPE) | Tillåt inte att denna 2‑D-form ansluts med dynamisk limning. |
+| [NO_ALLOW_DYNAMIC_GLUE](#NO-ALLOW-DYNAMIC-GLUE) | Tillåt inte dynamisk limning. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_DYNAMIC_GLUE {#ALLOW-DYNAMIC-GLUE}
+```
+public static final int ALLOW_DYNAMIC_GLUE
+```
+
+
+Tillåt dynamisk limning.
+
+### ALLOW_DYNAMIC_GLUE_2002 {#ALLOW-DYNAMIC-GLUE-2002}
+```
+public static final int ALLOW_DYNAMIC_GLUE_2002
+```
+
+
+Tillåt dynamisk limning (föråldrad i Microsoft Visio 2002).
+
+### ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR {#ALLOW-DYNAMIC-GLUE-FOR-DYNAMIC-CONNECTOR}
+```
+public static final int ALLOW_DYNAMIC_GLUE_FOR_DYNAMIC_CONNECTOR
+```
+
+
+Standard. Tillåt dynamisk limning endast för den dynamiska anslutningen; annars, använd statisk limning.
+
+### NO_ALLOW_2_D_SHAPE {#NO-ALLOW-2-D-SHAPE}
+```
+public static final int NO_ALLOW_2_D_SHAPE
+```
+
+
+Tillåt inte att denna 2‑D-form ansluts med dynamisk limning.
+
+### NO_ALLOW_DYNAMIC_GLUE {#NO-ALLOW-DYNAMIC-GLUE}
+```
+public static final int NO_ALLOW_DYNAMIC_GLUE
+```
+
+
+Tillåt inte dynamisk limning.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientdirectiontype/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientdirectiontype/_index.md
@@ -1,0 +1,183 @@
+---
+title: GradientDirectionType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar alla riktningstyper för gradient.
+type: docs
+weight: 177
+url: /sv/java/com.aspose.diagram/gradientdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientDirectionType
+```
+
+Representerar alla riktningstyper för gradient.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FROM_CENTER](#FROM-CENTER) | FromCenter |
+| [FROM_LOWER_LEFT_CORNER](#FROM-LOWER-LEFT-CORNER) | FromLowerLeftCorner |
+| [FROM_LOWER_RIGHT_CORNER](#FROM-LOWER-RIGHT-CORNER) | FromLowerRightCorner |
+| [FROM_UPPER_LEFT_CORNER](#FROM-UPPER-LEFT-CORNER) | FromUpperLeftCorner |
+| [FROM_UPPER_RIGHT_CORNER](#FROM-UPPER-RIGHT-CORNER) | FromUpperRightCorner |
+| [UNKNOWN](#UNKNOWN) | Unknown |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+FromCenter
+
+### FROM_LOWER_LEFT_CORNER {#FROM-LOWER-LEFT-CORNER}
+```
+public static final int FROM_LOWER_LEFT_CORNER
+```
+
+
+FromLowerLeftCorner
+
+### FROM_LOWER_RIGHT_CORNER {#FROM-LOWER-RIGHT-CORNER}
+```
+public static final int FROM_LOWER_RIGHT_CORNER
+```
+
+
+FromLowerRightCorner
+
+### FROM_UPPER_LEFT_CORNER {#FROM-UPPER-LEFT-CORNER}
+```
+public static final int FROM_UPPER_LEFT_CORNER
+```
+
+
+FromUpperLeftCorner
+
+### FROM_UPPER_RIGHT_CORNER {#FROM-UPPER-RIGHT-CORNER}
+```
+public static final int FROM_UPPER_RIGHT_CORNER
+```
+
+
+FromUpperRightCorner
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Unknown
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientfill/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientfill/_index.md
@@ -1,0 +1,211 @@
+---
+title: GradientFill
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar gradientfyllningen.
+type: docs
+weight: 178
+url: /sv/java/com.aspose.diagram/gradientfill/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientFill
+```
+
+Representerar gradientfyllningen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getGradientAngle()](#getGradientAngle--) | Anger orienteringen av färggradienten för fyllning |
+| [getGradientDir()](#getGradientDir--) | Anger typen av färggradienten för fyllning |
+| [getGradientEnabled()](#getGradientEnabled--) | Anger om färggradienten för fyllning är synlig. |
+| [getGradientStops()](#getGradientStops--) | Representerar samlingen av gradientstopp. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setGradientAngle(DoubleValue value)](#setGradientAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--) |
+| [setGradientDir(IntValue value)](#setGradientDir-com.aspose.diagram.IntValue-) | För beskrivningen av den här egenskapen, se [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--) |
+| [setGradientEnabled(BoolValue value)](#setGradientEnabled-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getGradientAngle() {#getGradientAngle--}
+```
+public DoubleValue getGradientAngle()
+```
+
+
+Anger orienteringen av färggradienten för fyllning
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGradientDir() {#getGradientDir--}
+```
+public IntValue getGradientDir()
+```
+
+
+Anger typen av färggradienten för fyllning
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getGradientEnabled() {#getGradientEnabled--}
+```
+public BoolValue getGradientEnabled()
+```
+
+
+Anger om färggradienten för fyllning är synlig.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getGradientStops() {#getGradientStops--}
+```
+public GradientStopCollection getGradientStops()
+```
+
+
+Representerar samlingen av gradientstopp.
+
+**Returns:**
+[GradientStopCollection](../../com.aspose.diagram/gradientstopcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setGradientAngle(DoubleValue value) {#setGradientAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setGradientAngle(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getGradientAngle()](../../com.aspose.diagram/gradientfill\#getGradientAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setGradientDir(IntValue value) {#setGradientDir-com.aspose.diagram.IntValue-}
+```
+public void setGradientDir(IntValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getGradientDir()](../../com.aspose.diagram/gradientfill\#getGradientDir--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setGradientEnabled(BoolValue value) {#setGradientEnabled-com.aspose.diagram.BoolValue-}
+```
+public void setGradientEnabled(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getGradientEnabled()](../../com.aspose.diagram/gradientfill\#getGradientEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientfilldir/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientfilldir/_index.md
@@ -1,0 +1,255 @@
+---
+title: GradientFillDir
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av färggradient för en forms fyllning
+type: docs
+weight: 179
+url: /sv/java/com.aspose.diagram/gradientfilldir/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillDir
+```
+
+Anger typen av färggradient för en forms fyllning
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [LINEAR](#LINEAR) | Anger en linjär färgfyllnadsgradient. |
+| [PATH](#PATH) | Anger att fyllningsfärgens gradient för formen är i path mode |
+| [RADIAL_FROM_BOTTOM_LEFT](#RADIAL-FROM-BOTTOM-LEFT) | Anger att fyllningsfärgens gradient för formen är i radial mode från formens nedre vänstra hörn |
+| [RADIAL_FROM_BOTTOM_RIGHT](#RADIAL-FROM-BOTTOM-RIGHT) | Anger att fyllningsfärgens gradient för formen är i radial mode från formens nedre högra hörn |
+| [RADIAL_FROM_CENTER](#RADIAL-FROM-CENTER) | Anger att fyllningsfärgens gradient för formen är i radial mode från formens centrum |
+| [RADIAL_FROM_CENTER_BOTTOM](#RADIAL-FROM-CENTER-BOTTOM) | Anger att fyllningsfärgens gradient för formen är i radial mode från mitten av formens nedre kant |
+| [RADIAL_FROM_CENTER_TOP](#RADIAL-FROM-CENTER-TOP) | Anger att fyllningsfärgens gradient för formen är i radial mode från mitten av formens övre kant |
+| [RADIAL_FROM_TOP_LEFT](#RADIAL-FROM-TOP-LEFT) | Anger att fyllningsfärgens gradient för formen är i radial mode från formens övre vänstra hörn |
+| [RADIAL_FROM_TOP_RIGHT](#RADIAL-FROM-TOP-RIGHT) | Anger att fyllningsfärgens gradient för formen är i radial mode från formens övre högra hörn |
+| [RECTANGLE_FROM_BOTTOM_LEFT](#RECTANGLE-FROM-BOTTOM-LEFT) | Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens nedre vänstra hörn |
+| [RECTANGLE_FROM_BOTTOM_RIGHT](#RECTANGLE-FROM-BOTTOM-RIGHT) | Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens nedre högra hörn |
+| [RECTANGLE_FROM_CENTER](#RECTANGLE-FROM-CENTER) | Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens centrum |
+| [RECTANGLE_FROM_TOP_LEFT](#RECTANGLE-FROM-TOP-LEFT) | Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens övre vänstra hörn |
+| [RECTANGLE_FROM_TOP_RIGHT](#RECTANGLE-FROM-TOP-RIGHT) | Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens övre högra hörn |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Anger en linjär färgfyllnadsgradient.
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i path mode
+
+### RADIAL_FROM_BOTTOM_LEFT {#RADIAL-FROM-BOTTOM-LEFT}
+```
+public static final int RADIAL_FROM_BOTTOM_LEFT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från formens nedre vänstra hörn
+
+### RADIAL_FROM_BOTTOM_RIGHT {#RADIAL-FROM-BOTTOM-RIGHT}
+```
+public static final int RADIAL_FROM_BOTTOM_RIGHT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från formens nedre högra hörn
+
+### RADIAL_FROM_CENTER {#RADIAL-FROM-CENTER}
+```
+public static final int RADIAL_FROM_CENTER
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från formens centrum
+
+### RADIAL_FROM_CENTER_BOTTOM {#RADIAL-FROM-CENTER-BOTTOM}
+```
+public static final int RADIAL_FROM_CENTER_BOTTOM
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från mitten av formens nedre kant
+
+### RADIAL_FROM_CENTER_TOP {#RADIAL-FROM-CENTER-TOP}
+```
+public static final int RADIAL_FROM_CENTER_TOP
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från mitten av formens övre kant
+
+### RADIAL_FROM_TOP_LEFT {#RADIAL-FROM-TOP-LEFT}
+```
+public static final int RADIAL_FROM_TOP_LEFT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från formens övre vänstra hörn
+
+### RADIAL_FROM_TOP_RIGHT {#RADIAL-FROM-TOP-RIGHT}
+```
+public static final int RADIAL_FROM_TOP_RIGHT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i radial mode från formens övre högra hörn
+
+### RECTANGLE_FROM_BOTTOM_LEFT {#RECTANGLE-FROM-BOTTOM-LEFT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_LEFT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens nedre vänstra hörn
+
+### RECTANGLE_FROM_BOTTOM_RIGHT {#RECTANGLE-FROM-BOTTOM-RIGHT}
+```
+public static final int RECTANGLE_FROM_BOTTOM_RIGHT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens nedre högra hörn
+
+### RECTANGLE_FROM_CENTER {#RECTANGLE-FROM-CENTER}
+```
+public static final int RECTANGLE_FROM_CENTER
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens centrum
+
+### RECTANGLE_FROM_TOP_LEFT {#RECTANGLE-FROM-TOP-LEFT}
+```
+public static final int RECTANGLE_FROM_TOP_LEFT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens övre vänstra hörn
+
+### RECTANGLE_FROM_TOP_RIGHT {#RECTANGLE-FROM-TOP-RIGHT}
+```
+public static final int RECTANGLE_FROM_TOP_RIGHT
+```
+
+
+Anger att fyllningsfärgens gradient för formen är i rectangle mode från formens övre högra hörn
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientfilltype/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientfilltype/_index.md
@@ -1,0 +1,165 @@
+---
+title: GradientFillType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar alla gradientfyllningstyper.
+type: docs
+weight: 180
+url: /sv/java/com.aspose.diagram/gradientfilltype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientFillType
+```
+
+Representerar alla gradientfyllningstyper.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [LINEAR](#LINEAR) | Linear |
+| [PATH](#PATH) | Path |
+| [RADIAL](#RADIAL) | Radial |
+| [RECTANGLE](#RECTANGLE) | Rektangel |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### PATH {#PATH}
+```
+public static final int PATH
+```
+
+
+Path
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial
+
+### RECTANGLE {#RECTANGLE}
+```
+public static final int RECTANGLE
+```
+
+
+Rektangel
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientstop/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientstop/_index.md
@@ -1,0 +1,222 @@
+---
+title: GradientStop
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar gradientstoppet.
+type: docs
+weight: 181
+url: /sv/java/com.aspose.diagram/gradientstop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GradientStop
+```
+
+Representerar gradientstoppet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GradientStop()](#GradientStop--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Hämtar färgen på detta gradientstopp. |
+| [getPosition()](#getPosition--) | Positionen för stoppet. |
+| [getTransparency()](#getTransparency--) | Returnerar eller anger graden av transparens för området som ett värde från 0,0 (opak) till 1,0 (klar). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(ColorValue value)](#setColor-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/gradientstop\#getColor--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--) |
+| [setTransparency(DoubleValue value)](#setTransparency-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GradientStop() {#GradientStop--}
+```
+public GradientStop()
+```
+
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Hämtar färgen på detta gradientstopp.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Positionen för stoppet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Returnerar eller anger graden av transparens för området som ett värde från 0,0 (opak) till 1,0 (klar).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(ColorValue value) {#setColor-com.aspose.diagram.ColorValue-}
+```
+public void setColor(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getColor()](../../com.aspose.diagram/gradientstop\#getColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPosition()](../../com.aspose.diagram/gradientstop\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTransparency(DoubleValue value) {#setTransparency-com.aspose.diagram.DoubleValue-}
+```
+public void setTransparency(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTransparency()](../../com.aspose.diagram/gradientstop\#getTransparency--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientstopcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientstopcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: GradientStopCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar samlingen av gradientstopp.
+type: docs
+weight: 182
+url: /sv/java/com.aspose.diagram/gradientstopcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class GradientStopCollection extends Collection
+```
+
+Representerar samlingen av gradientstopp.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(DoubleValue position, ColorValue color)](#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-) | Lägg till ett gradientstopp. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar gradientstoppet efter index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [set(int index, GradientStop value)](#set-int-com.aspose.diagram.GradientStop-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(DoubleValue position, ColorValue color) {#add-com.aspose.diagram.DoubleValue-com.aspose.diagram.ColorValue-}
+```
+public void add(DoubleValue position, ColorValue color)
+```
+
+
+Lägg till ett gradientstopp.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| position | [DoubleValue](../../com.aspose.diagram/doublevalue) | Positionen för stoppet, i procentenhet. |
+| color | [ColorValue](../../com.aspose.diagram/colorvalue) | Färgen på stoppet. |
+
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public GradientStop get(int index)
+```
+
+
+Hämtar gradientstoppet efter index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Indexet. |
+
+**Returns:**
+[GradientStop](../../com.aspose.diagram/gradientstop) - The gradient stop.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### set(int index, GradientStop value) {#set-int-com.aspose.diagram.GradientStop-}
+```
+public void set(int index, GradientStop value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+| value | [GradientStop](../../com.aspose.diagram/gradientstop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/gradientstyletype/_index.md
+++ b/swedish/java/com.aspose.diagram/gradientstyletype/_index.md
@@ -1,0 +1,192 @@
+---
+title: GradientStyleType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar gradientskuggningsstil.
+type: docs
+weight: 183
+url: /sv/java/com.aspose.diagram/gradientstyletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GradientStyleType
+```
+
+Representerar gradientskuggningsstil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DIAGONAL_DOWN](#DIAGONAL-DOWN) | Diagonal nedåtriktad skuggstil |
+| [DIAGONAL_UP](#DIAGONAL-UP) | Diagonal uppåtriktad skuggstil |
+| [FROM_CENTER](#FROM-CENTER) | Från centrum skuggningsstil |
+| [FROM_CORNER](#FROM-CORNER) | Från hörn skuggningsstil |
+| [HORIZONTAL](#HORIZONTAL) | Horisontell skuggningsstil |
+| [UNKNOWN](#UNKNOWN) | Okänd skuggningsstil. Endast för skuggningsstilen (som inte är någon medlem av GradientStyleType) i mallfilen. |
+| [VERTICAL](#VERTICAL) | Vertikal skuggningsstil |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DIAGONAL_DOWN {#DIAGONAL-DOWN}
+```
+public static final int DIAGONAL_DOWN
+```
+
+
+Diagonal nedåtriktad skuggstil
+
+### DIAGONAL_UP {#DIAGONAL-UP}
+```
+public static final int DIAGONAL_UP
+```
+
+
+Diagonal uppåtriktad skuggstil
+
+### FROM_CENTER {#FROM-CENTER}
+```
+public static final int FROM_CENTER
+```
+
+
+Från centrum skuggningsstil
+
+### FROM_CORNER {#FROM-CORNER}
+```
+public static final int FROM_CORNER
+```
+
+
+Från hörn skuggningsstil
+
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Horisontell skuggningsstil
+
+### UNKNOWN {#UNKNOWN}
+```
+public static final int UNKNOWN
+```
+
+
+Okänd skuggningsstil. Endast för skuggningsstilen (som inte är någon medlem av GradientStyleType) i mallfilen.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Vertikal skuggningsstil
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/griddensity/_index.md
+++ b/swedish/java/com.aspose.diagram/griddensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: GridDensity
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida.
+type: docs
+weight: 184
+url: /sv/java/com.aspose.diagram/griddensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class GridDensity
+```
+
+Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [GridDensity(int value)](#GridDensity-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/griddensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GridDensity(int value) {#GridDensity-int-}
+```
+public GridDensity(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/griddensity\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/griddensityvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/griddensityvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: GridDensityValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida.
+type: docs
+weight: 185
+url: /sv/java/com.aspose.diagram/griddensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class GridDensityValue
+```
+
+Anger vilken typ av horisontellt/vertikalt rutnät som ska användas för en sida.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [COARSE](#COARSE) | Grov. |
+| [FINE](#FINE) | Fin |
+| [FIXED](#FIXED) | Fast. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grov.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fin
+
+### FIXED {#FIXED}
+```
+public static final int FIXED
+```
+
+
+Fast.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal. Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/group/_index.md
+++ b/swedish/java/com.aspose.diagram/group/_index.md
@@ -1,0 +1,216 @@
+---
+title: Grupp
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper.
+type: docs
+weight: 186
+url: /sv/java/com.aspose.diagram/group/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Group
+```
+
+Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDisplayMode()](#getDisplayMode--) | När den finns i ett Group-element anger DisplayMode-elementet hur en gruppform och dess medlemmar visas. |
+| [getDontMoveChildren()](#getDontMoveChildren--) | Anger om du kan dra former i en grupp med musen. |
+| [getSelectMode()](#getSelectMode--) | Specificerar hur användaren väljer en gruppform och dess medlemmar. |
+| [hashCode()](#hashCode--) |  |
+| [isDropTarget()](#isDropTarget--) | Anger om gruppen tillåter att en form läggs till den när formen släpps på gruppen. |
+| [isSnapTarget()](#isSnapTarget--) | Anger om fästning till en grupp eller till former inom gruppen är aktiverad. |
+| [isTextEditTarget()](#isTextEditTarget--) | Anger hur text tilldelas en grupp. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/group\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayMode getDisplayMode()
+```
+
+
+När den finns i ett Group-element anger DisplayMode-elementet hur en gruppform och dess medlemmar visas.
+
+**Returns:**
+[DisplayMode](../../com.aspose.diagram/displaymode)
+### getDontMoveChildren() {#getDontMoveChildren--}
+```
+public BoolValue getDontMoveChildren()
+```
+
+
+Anger om du kan dra former i en grupp med musen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSelectMode() {#getSelectMode--}
+```
+public SelectMode getSelectMode()
+```
+
+
+Specificerar hur användaren väljer en gruppform och dess medlemmar.
+
+**Returns:**
+[SelectMode](../../com.aspose.diagram/selectmode)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropTarget() {#isDropTarget--}
+```
+public BoolValue isDropTarget()
+```
+
+
+Anger om gruppen tillåter att en form läggs till den när formen släpps på gruppen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isSnapTarget() {#isSnapTarget--}
+```
+public BoolValue isSnapTarget()
+```
+
+
+Anger om fästning till en grupp eller till former inom gruppen är aktiverad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isTextEditTarget() {#isTextEditTarget--}
+```
+public BoolValue isTextEditTarget()
+```
+
+
+Anger hur text tilldelas en grupp.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/group\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/headerfooter/_index.md
+++ b/swedish/java/com.aspose.diagram/headerfooter/_index.md
@@ -1,0 +1,361 @@
+---
+title: HeaderFooter
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element för ett dokuments sidhuvud och sidfot.
+type: docs
+weight: 188
+url: /sv/java/com.aspose.diagram/headerfooter/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooter
+```
+
+Innehåller element för ett dokuments sidhuvud och sidfot.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFooterCenter()](#getFooterCenter--) | Innehåller textsträngen som visas i den centrala delen av ett dokuments sidfot. |
+| [getFooterLeft()](#getFooterLeft--) | Innehåller textsträngen som visas i den vänstra delen av ett dokuments sidfot. |
+| [getFooterMargin()](#getFooterMargin--) | Anger marginalen för ett dokuments sidfot. |
+| [getFooterRight()](#getFooterRight--) | Innehåller textsträngen som visas i den högra delen av ett dokuments sidfot. |
+| [getHeaderCenter()](#getHeaderCenter--) | Innehåller textsträngen som visas i den centrala delen av ett dokuments sidhuvud. |
+| [getHeaderFooterColor()](#getHeaderFooterColor--) | RGB‑värdet för textfärgen för sidhuvudet och sidfoten. |
+| [getHeaderFooterFont()](#getHeaderFooterFont--) | Anger teckensnittet som används för sidhuvud- och sidfotstexten. |
+| [getHeaderLeft()](#getHeaderLeft--) | Innehåller textsträngen som visas i den vänstra delen av ett dokuments sidhuvud. |
+| [getHeaderMargin()](#getHeaderMargin--) | Anger marginalen för ett dokuments sidfot. |
+| [getHeaderRight()](#getHeaderRight--) | Innehåller textsträngen som visas i den högra delen av ett dokuments sidhuvud. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFooterCenter(String value)](#setFooterCenter-java.lang.String-) | För beskrivningen av den här egenskapen, se [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--) |
+| [setFooterLeft(String value)](#setFooterLeft-java.lang.String-) | För beskrivningen av den här egenskapen, se [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--) |
+| [setFooterMargin(Margin value)](#setFooterMargin-com.aspose.diagram.Margin-) | För beskrivningen av den här egenskapen, se [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--) |
+| [setFooterRight(String value)](#setFooterRight-java.lang.String-) | För beskrivningen av den här egenskapen, se [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--) |
+| [setHeaderCenter(String value)](#setHeaderCenter-java.lang.String-) | För beskrivningen av den här egenskapen, se [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--) |
+| [setHeaderFooterColor(Color value)](#setHeaderFooterColor-com.aspose.diagram.Color-) | För beskrivningen av den här egenskapen, se [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--) |
+| [setHeaderLeft(String value)](#setHeaderLeft-java.lang.String-) | För beskrivningen av den här egenskapen, se [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--) |
+| [setHeaderMargin(Margin value)](#setHeaderMargin-com.aspose.diagram.Margin-) | För beskrivningen av den här egenskapen, se [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--) |
+| [setHeaderRight(String value)](#setHeaderRight-java.lang.String-) | För beskrivningen av den här egenskapen, se [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFooterCenter() {#getFooterCenter--}
+```
+public String getFooterCenter()
+```
+
+
+Innehåller textsträngen som visas i den centrala delen av ett dokuments sidfot.
+
+**Returns:**
+java.lang.String
+### getFooterLeft() {#getFooterLeft--}
+```
+public String getFooterLeft()
+```
+
+
+Innehåller textsträngen som visas i den vänstra delen av ett dokuments sidfot.
+
+**Returns:**
+java.lang.String
+### getFooterMargin() {#getFooterMargin--}
+```
+public Margin getFooterMargin()
+```
+
+
+Anger marginalen för ett dokuments sidfot.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getFooterRight() {#getFooterRight--}
+```
+public String getFooterRight()
+```
+
+
+Innehåller textsträngen som visas i den högra delen av ett dokuments sidfot.
+
+**Returns:**
+java.lang.String
+### getHeaderCenter() {#getHeaderCenter--}
+```
+public String getHeaderCenter()
+```
+
+
+Innehåller textsträngen som visas i den centrala delen av ett dokuments sidhuvud.
+
+**Returns:**
+java.lang.String
+### getHeaderFooterColor() {#getHeaderFooterColor--}
+```
+public Color getHeaderFooterColor()
+```
+
+
+RGB‑värdet för textfärgen för sidhuvudet och sidfoten.
+
+**Returns:**
+[Color](../../com.aspose.diagram/color)
+### getHeaderFooterFont() {#getHeaderFooterFont--}
+```
+public HeaderFooterFont getHeaderFooterFont()
+```
+
+
+Anger teckensnittet som används för sidhuvud- och sidfotstexten.
+
+**Returns:**
+[HeaderFooterFont](../../com.aspose.diagram/headerfooterfont)
+### getHeaderLeft() {#getHeaderLeft--}
+```
+public String getHeaderLeft()
+```
+
+
+Innehåller textsträngen som visas i den vänstra delen av ett dokuments sidhuvud.
+
+**Returns:**
+java.lang.String
+### getHeaderMargin() {#getHeaderMargin--}
+```
+public Margin getHeaderMargin()
+```
+
+
+Anger marginalen för ett dokuments sidfot.
+
+**Returns:**
+[Margin](../../com.aspose.diagram/margin)
+### getHeaderRight() {#getHeaderRight--}
+```
+public String getHeaderRight()
+```
+
+
+Innehåller textsträngen som visas i den högra delen av ett dokuments sidhuvud.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFooterCenter(String value) {#setFooterCenter-java.lang.String-}
+```
+public void setFooterCenter(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFooterCenter()](../../com.aspose.diagram/headerfooter\#getFooterCenter--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFooterLeft(String value) {#setFooterLeft-java.lang.String-}
+```
+public void setFooterLeft(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFooterLeft()](../../com.aspose.diagram/headerfooter\#getFooterLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setFooterMargin(Margin value) {#setFooterMargin-com.aspose.diagram.Margin-}
+```
+public void setFooterMargin(Margin value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFooterMargin()](../../com.aspose.diagram/headerfooter\#getFooterMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setFooterRight(String value) {#setFooterRight-java.lang.String-}
+```
+public void setFooterRight(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getFooterRight()](../../com.aspose.diagram/headerfooter\#getFooterRight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeaderCenter(String value) {#setHeaderCenter-java.lang.String-}
+```
+public void setHeaderCenter(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeaderCenter()](../../com.aspose.diagram/headerfooter\#getHeaderCenter--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeaderFooterColor(Color value) {#setHeaderFooterColor-com.aspose.diagram.Color-}
+```
+public void setHeaderFooterColor(Color value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeaderFooterColor()](../../com.aspose.diagram/headerfooter\#getHeaderFooterColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Color](../../com.aspose.diagram/color) |  |
+
+### setHeaderLeft(String value) {#setHeaderLeft-java.lang.String-}
+```
+public void setHeaderLeft(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeaderLeft()](../../com.aspose.diagram/headerfooter\#getHeaderLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeaderMargin(Margin value) {#setHeaderMargin-com.aspose.diagram.Margin-}
+```
+public void setHeaderMargin(Margin value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeaderMargin()](../../com.aspose.diagram/headerfooter\#getHeaderMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Margin](../../com.aspose.diagram/margin) |  |
+
+### setHeaderRight(String value) {#setHeaderRight-java.lang.String-}
+```
+public void setHeaderRight(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeaderRight()](../../com.aspose.diagram/headerfooter\#getHeaderRight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/headerfooterfont/_index.md
+++ b/swedish/java/com.aspose.diagram/headerfooterfont/_index.md
@@ -1,0 +1,475 @@
+---
+title: HeaderFooterFont
+second_title: Aspose.Diagram för Java API-referens
+description: Anger teckensnittet som används för sidhuvud- och sidfotstexten.
+type: docs
+weight: 189
+url: /sv/java/com.aspose.diagram/headerfooterfont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HeaderFooterFont
+```
+
+Anger teckensnittet som används för sidhuvud- och sidfotstexten.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCharSet()](#getCharSet--) | Anger teckenuppsättningen för teckensnittet. |
+| [getClass()](#getClass--) |  |
+| [getClipPrecision()](#getClipPrecision--) | Anger beskärningsprecisionen för teckensnittet. |
+| [getEscapement()](#getEscapement--) | Anger escapement‑attributet för teckensnittet. |
+| [getFaceName()](#getFaceName--) | Anger type face name‑attributet för teckensnittet. |
+| [getHeight()](#getHeight--) | Anger teckensnittets höjd. |
+| [getItalic()](#getItalic--) | Anger teckensnittets vikt. |
+| [getOrientation()](#getOrientation--) | Anger teckensnittets orientering. |
+| [getOutPrecision()](#getOutPrecision--) | Anger utdata‑precision‑attributet för teckensnittet. |
+| [getPitchAndFamily()](#getPitchAndFamily--) | Anger teckensnittets pitch och familj. |
+| [getQuality()](#getQuality--) | Anger teckensnittets utdata­kvalitet. |
+| [getStrikeOut()](#getStrikeOut--) | Anger om teckensnittet är genomstruket. |
+| [getUnderline()](#getUnderline--) | Anger om teckensnittet är understruket. |
+| [getWeight()](#getWeight--) | Anger teckensnittets vikt. |
+| [getWidth()](#getWidth--) | Anger teckensnittets bredd. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCharSet(long value)](#setCharSet-long-) | För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\} |
+| [setClipPrecision(long value)](#setClipPrecision-long-) | För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\} |
+| [setEscapement(int value)](#setEscapement-int-) | För beskrivningen av denna egenskap, se [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--) |
+| [setFaceName(String value)](#setFaceName-java.lang.String-) | För beskrivningen av denna egenskap, se [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--) |
+| [setHeight(int value)](#setHeight-int-) | För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--) |
+| [setItalic(int value)](#setItalic-int-) | För beskrivningen av denna egenskap, se [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--) |
+| [setOrientation(int value)](#setOrientation-int-) | För beskrivningen av denna egenskap, se [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--) |
+| [setOutPrecision(long value)](#setOutPrecision-long-) | För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\} |
+| [setPitchAndFamily(long value)](#setPitchAndFamily-long-) | För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\} |
+| [setQuality(long value)](#setQuality-long-) | För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\} |
+| [setStrikeOut(int value)](#setStrikeOut-int-) | För beskrivningen av denna egenskap, se [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--) |
+| [setUnderline(int value)](#setUnderline-int-) | För beskrivningen av denna egenskap, se [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--) |
+| [setWeight(int value)](#setWeight-int-) | För beskrivningen av denna egenskap, se [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--) |
+| [setWidth(int value)](#setWidth-int-) | För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCharSet() {#getCharSet--}
+```
+public long getCharSet()
+```
+
+
+Anger teckenuppsättningen för teckensnittet. Motsvarar GDI LOGFONT lfCharSet-fältet.
+
+**Returns:**
+long
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClipPrecision() {#getClipPrecision--}
+```
+public long getClipPrecision()
+```
+
+
+Anger beskärningsprecisionen för teckensnittet. Motsvarar GDI LOGFONT lfClipPrecision-fältet.
+
+**Returns:**
+long
+### getEscapement() {#getEscapement--}
+```
+public int getEscapement()
+```
+
+
+Anger escapement-attributet för teckensnittet. Motsvarar GDI LOGFONT lfEscapement-fältet.
+
+**Returns:**
+int
+### getFaceName() {#getFaceName--}
+```
+public String getFaceName()
+```
+
+
+Anger attributet för teckensnittets typnamn. Motsvarar GDI LOGFONT lfFaceName-fältet.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public int getHeight()
+```
+
+
+Anger teckensnittets höjd. Motsvarar GDI LOGFONT lfHeight-fältet.
+
+**Returns:**
+int
+### getItalic() {#getItalic--}
+```
+public int getItalic()
+```
+
+
+Anger teckensnittets vikt. Motsvarar GDI LOGFONT lfWeight-fältet.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+Anger teckensnittets orientering. Motsvarar GDI LOGFONT lfOrientation-fältet.
+
+**Returns:**
+int
+### getOutPrecision() {#getOutPrecision--}
+```
+public long getOutPrecision()
+```
+
+
+Anger utdata-precisionattributet för teckensnittet. Motsvarar GDI LOGFONT lfOutPrecision-fältet.
+
+**Returns:**
+long
+### getPitchAndFamily() {#getPitchAndFamily--}
+```
+public long getPitchAndFamily()
+```
+
+
+Anger teckensnittets pitch och familj. Motsvarar GDI LOGFONT lfPitchAndFamily-fältet.
+
+**Returns:**
+long
+### getQuality() {#getQuality--}
+```
+public long getQuality()
+```
+
+
+Anger teckensnittets utdata-kvalitet. Motsvarar GDI LOGFONT lfQuality-fältet.
+
+**Returns:**
+long
+### getStrikeOut() {#getStrikeOut--}
+```
+public int getStrikeOut()
+```
+
+
+Anger om teckensnittet är genomstruket. Motsvarar GDI LOGFONT lfStrikeOut-fältet.
+
+**Returns:**
+int
+### getUnderline() {#getUnderline--}
+```
+public int getUnderline()
+```
+
+
+Anger om teckensnittet är understruket. Motsvarar GDI LOGFONT lfUnderline-fältet.
+
+**Returns:**
+int
+### getWeight() {#getWeight--}
+```
+public int getWeight()
+```
+
+
+Anger teckensnittets vikt. Motsvarar GDI LOGFONT lfWeight-fältet.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public int getWidth()
+```
+
+
+Anger teckensnittets bredd. Motsvarar GDI LOGFONT lfWidth-fältet.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCharSet(long value) {#setCharSet-long-}
+```
+public void setCharSet(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getCharSet() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setClipPrecision(long value) {#setClipPrecision-long-}
+```
+public void setClipPrecision(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getClipPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setEscapement(int value) {#setEscapement-int-}
+```
+public void setEscapement(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEscapement()](../../com.aspose.diagram/headerfooterfont\#getEscapement--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setFaceName(String value) {#setFaceName-java.lang.String-}
+```
+public void setFaceName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFaceName()](../../com.aspose.diagram/headerfooterfont\#getFaceName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeight(int value) {#setHeight-int-}
+```
+public void setHeight(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/headerfooterfont\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setItalic(int value) {#setItalic-int-}
+```
+public void setItalic(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getItalic()](../../com.aspose.diagram/headerfooterfont\#getItalic--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getOrientation()](../../com.aspose.diagram/headerfooterfont\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setOutPrecision(long value) {#setOutPrecision-long-}
+```
+public void setOutPrecision(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getOutPrecision() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setPitchAndFamily(long value) {#setPitchAndFamily-long-}
+```
+public void setPitchAndFamily(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getPitchAndFamily() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setQuality(long value) {#setQuality-long-}
+```
+public void setQuality(long value)
+```
+
+
+För beskrivningen av denna egenskap, se \{@link HeaderFooterFont\#(getQuality() & 0xFFFFFFFFL)\}
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setStrikeOut(int value) {#setStrikeOut-int-}
+```
+public void setStrikeOut(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getStrikeOut()](../../com.aspose.diagram/headerfooterfont\#getStrikeOut--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUnderline(int value) {#setUnderline-int-}
+```
+public void setUnderline(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUnderline()](../../com.aspose.diagram/headerfooterfont\#getUnderline--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWeight(int value) {#setWeight-int-}
+```
+public void setWeight(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getWeight()](../../com.aspose.diagram/headerfooterfont\#getWeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(int value) {#setWidth-int-}
+```
+public void setWidth(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/headerfooterfont\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/help/_index.md
+++ b/swedish/java/com.aspose.diagram/help/_index.md
@@ -1,0 +1,172 @@
+---
+title: Hjälp
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar Shape-elementens hjälpfilsämne och upphovsrättsinformation.
+type: docs
+weight: 190
+url: /sv/java/com.aspose.diagram/help/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Help
+```
+
+Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCopyright()](#getCopyright--) | Innehåller en sträng som representerar ett mänskligt läsbart upphovsrättsmeddelande. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getHelpTopic()](#getHelpTopic--) | Anger Shape-elementets hjälpämnes-ID. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/help\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCopyright() {#getCopyright--}
+```
+public Str2Value getCopyright()
+```
+
+
+Innehåller en sträng som representerar ett mänskligt läsbart upphovsrättsmeddelande.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getHelpTopic() {#getHelpTopic--}
+```
+public Str2Value getHelpTopic()
+```
+
+
+Anger Shape-elementets hjälpämnes-ID.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/help\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/horzalign/_index.md
+++ b/swedish/java/com.aspose.diagram/horzalign/_index.md
@@ -1,0 +1,179 @@
+---
+title: HorzAlign
+second_title: Aspose.Diagram för Java API-referens
+description: Anger den horisontella justeringen av text i figurens textblock.
+type: docs
+weight: 191
+url: /sv/java/com.aspose.diagram/horzalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class HorzAlign
+```
+
+Anger den horisontella justeringen av text i formens textblock.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [HorzAlign(int value)](#HorzAlign-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger den horisontella justeringen av text i formens textblock. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/horzalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HorzAlign(int value) {#HorzAlign-int-}
+```
+public HorzAlign(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger den horisontella justeringen av text i formens textblock.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/horzalign\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/horzalignvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/horzalignvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: HorzAlignValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger den horisontella justeringen av text i figurens textblock.
+type: docs
+weight: 192
+url: /sv/java/com.aspose.diagram/horzalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class HorzAlignValue
+```
+
+Anger den horisontella justeringen av text i formens textblock.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CENTER](#CENTER) | Centrerad. |
+| [FORCE_JUSTIFY](#FORCE-JUSTIFY) | Tvinga justering. |
+| [JUSTIFY](#JUSTIFY) | Justera. |
+| [LEFT_ALIGN](#LEFT-ALIGN) | Vänsterjustera. |
+| [RIGHT_ALIGN](#RIGHT-ALIGN) | Högerjustera. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centrerad.
+
+### FORCE_JUSTIFY {#FORCE-JUSTIFY}
+```
+public static final int FORCE_JUSTIFY
+```
+
+
+Tvinga justering.
+
+### JUSTIFY {#JUSTIFY}
+```
+public static final int JUSTIFY
+```
+
+
+Justera.
+
+### LEFT_ALIGN {#LEFT-ALIGN}
+```
+public static final int LEFT_ALIGN
+```
+
+
+Vänsterjustera.
+
+### RIGHT_ALIGN {#RIGHT-ALIGN}
+```
+public static final int RIGHT_ALIGN
+```
+
+
+Högerjustera.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/htmlsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/htmlsaveoptions/_index.md
@@ -1,0 +1,629 @@
+---
+title: HTMLSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när diagramssidor renderas till HTML.
+type: docs
+weight: 187
+url: /sv/java/com.aspose.diagram/htmlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class HTMLSaveOptions extends RenderingSaveOptions
+```
+
+Tillåter att ange ytterligare alternativ när diagramssidor renderas till HTML.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [HTMLSaveOptions()](#HTMLSaveOptions--) | Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definierar om dolda sidor ska exporteras eller inte. |
+| [getPageCount()](#getPageCount--) | antalet sidor som ska renderas i HTML. |
+| [getPageIndex()](#getPageIndex--) | det nollbaserade indexet för den första sidan som ska renderas. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getResolution()](#getResolution--) | upplösningen för den genererade HTML:n, i punkter per tum. |
+| [getSaveAsSingleFile()](#getSaveAsSingleFile--) | Indikerar om HTML ska sparas som en enda fil. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska sparas som bild eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger formatet som de renderade diagrammetsidorna kommer att sparas i om detta sparaalternativobjekt används. |
+| [getSaveTitle()](#getSaveTitle--) | Definierar om titeln ska exporteras eller inte. |
+| [getSaveToolBar()](#getSaveToolBar--) | Anger om verktygsfältet ska sparas. Standardvärdet är true. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getStreamProvider()](#getStreamProvider--) | IStreamProvider för att exportera objekt. |
+| [getTitle()](#getTitle--) | titeln på diagrammet som ska renderas i HTML. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setResolution(int value)](#setResolution-int-) | För beskrivningen av den här egenskapen, se [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--) |
+| [setSaveAsSingleFile(boolean value)](#setSaveAsSingleFile-boolean-) | För beskrivningen av den här egenskapen, se [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--) |
+| [setSaveTitle(boolean value)](#setSaveTitle-boolean-) | För beskrivningen av den här egenskapen, se [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--) |
+| [setSaveToolBar(boolean value)](#setSaveToolBar-boolean-) | För beskrivningen av den här egenskapen, se [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | För beskrivningen av den här egenskapen, se [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--) |
+| [setTitle(String value)](#setTitle-java.lang.String-) | För beskrivningen av den här egenskapen, se [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HTMLSaveOptions() {#HTMLSaveOptions--}
+```
+public HTMLSaveOptions()
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definierar om dolda sidor ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+antalet sidor som ska renderas i HTML. Standard är MaxValue vilket betyder att alla diagramssidor kommer att renderas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+det 0-baserade indexet för den första sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+upplösningen för den genererade html, i punkter per tum. Denna egenskap har endast effekt vid sparande till html. Standardvärdet är 96.
+
+**Returns:**
+int
+### getSaveAsSingleFile() {#getSaveAsSingleFile--}
+```
+public boolean getSaveAsSingleFile()
+```
+
+
+Anger om html ska sparas som en enda fil. Standardvärdet är false. Om det finns flera sidor, måste dessa sidor och andra resurser sparas i separata filer. I vissa scenarier kan användaren behöva bara en resulterande fil, till exempel för att underlätta överföring. I så fall kan användaren sätta denna egenskap till true.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska sparas i bilden eller bara förgrunden. Om true – renderas endast förgrundssidor (med bakgrund om den finns). Om false – renderas förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket de renderade diagrammenyerna ska sparas om detta spara-alternativobjekt används. Kan endast vara Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getSaveTitle() {#getSaveTitle--}
+```
+public boolean getSaveTitle()
+```
+
+
+Definierar om titeln ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getSaveToolBar() {#getSaveToolBar--}
+```
+public boolean getSaveToolBar()
+```
+
+
+Anger om verktygsfältet ska sparas. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+IStreamProvider för att exportera objekt.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getTitle() {#getTitle--}
+```
+public String getTitle()
+```
+
+
+titeln på diagrammet som ska renderas i HTML. Om Title är null kommer Diagram.DocumentProperties.Title [DocumentProperties](../../com.aspose.diagram/documentproperties) att användas som Title. Om Diagram.DocumentProperties.Title är null eller tomt används diagramfilens namn som Title.
+
+**Returns:**
+java.lang.String
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/htmlsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/htmlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/htmlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setResolution(int value) {#setResolution-int-}
+```
+public void setResolution(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getResolution()](../../com.aspose.diagram/htmlsaveoptions\#getResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSaveAsSingleFile(boolean value) {#setSaveAsSingleFile-boolean-}
+```
+public void setSaveAsSingleFile(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveAsSingleFile()](../../com.aspose.diagram/htmlsaveoptions\#getSaveAsSingleFile--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/htmlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/htmlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSaveTitle(boolean value) {#setSaveTitle-boolean-}
+```
+public void setSaveTitle(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveTitle()](../../com.aspose.diagram/htmlsaveoptions\#getSaveTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveToolBar(boolean value) {#setSaveToolBar-boolean-}
+```
+public void setSaveToolBar(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveToolBar()](../../com.aspose.diagram/htmlsaveoptions\#getSaveToolBar--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStreamProvider()](../../com.aspose.diagram/htmlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setTitle(String value) {#setTitle-java.lang.String-}
+```
+public void setTitle(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTitle()](../../com.aspose.diagram/htmlsaveoptions\#getTitle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/hyperlink/_index.md
+++ b/swedish/java/com.aspose.diagram/hyperlink/_index.md
@@ -1,0 +1,348 @@
+---
+title: Hyperlänk
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element för att skapa flera hopp mellan en form eller ritningssida och en annan ritningssida, en annan fil eller en webbplats.
+type: docs
+weight: 193
+url: /sv/java/com.aspose.diagram/hyperlink/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Hyperlink
+```
+
+Innehåller element för att skapa flera hopp mellan en form eller ritningssida och en annan ritningssida, en annan fil eller en webbplats.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Hyperlink()](#Hyperlink--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAddress()](#getAddress--) | Anger en URL-adress, DOS-filnamn eller UNC-sökväg att hoppa till. |
+| [getClass()](#getClass--) |  |
+| [getDefault()](#getDefault--) | Anger standardhyperlänken för en form eller sida. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDescription()](#getDescription--) | Beskrivningselementet innehåller en textsträng som beskriver hyperlänken. |
+| [getExtraInfo()](#getExtraInfo--) | Innehåller information som ska användas för att lösa en URL, såsom koordinaterna för en bildkarta. |
+| [getFrame()](#getFrame--) | Innehåller namnet på en ram att rikta mot när Microsoft Visio är öppet som ett aktivt dokument i en behållarapplikation. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getInvisible()](#getInvisible--) | Osynligt element indikerar om en hyperlänk visas i snabbmenyn för en form eller sida. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getNewWindow()](#getNewWindow--) | Anger om Microsoft Visio öppnar ett fönster på en ny plats när den följer en hyperlänk för att öppna en webbsida eller ett annat Visio-dokument. |
+| [getSortKey()](#getSortKey--) | Osynligt element indikerar om en hyperlänk visas i snabbmenyn för en form eller sida. |
+| [getSubAddress()](#getSubAddress--) | Anger en plats inom måldokumentet att länka till. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/hyperlink\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/hyperlink\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/hyperlink\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Hyperlink() {#Hyperlink--}
+```
+public Hyperlink()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAddress() {#getAddress--}
+```
+public Str2Value getAddress()
+```
+
+
+Anger en URL-adress, DOS-filnamn eller UNC-sökväg att hoppa till.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefault() {#getDefault--}
+```
+public BoolValue getDefault()
+```
+
+
+Anger standardhyperlänken för en form eller sida.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Beskrivningselementet innehåller en textsträng som beskriver hyperlänken.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getExtraInfo() {#getExtraInfo--}
+```
+public Str2Value getExtraInfo()
+```
+
+
+Innehåller information som ska användas för att lösa en URL, såsom koordinaterna för en bildkarta. Till exempel, x=41 y=7 skulle ange koordinaterna för en bildkarta.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getFrame() {#getFrame--}
+```
+public Str2Value getFrame()
+```
+
+
+Innehåller namnet på en ram att rikta mot när Microsoft Visio är öppet som ett aktivt dokument i en behållarapplikation. Standardvärdet är en tom sträng.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Osynligt element indikerar om en hyperlänk visas i snabbmenyn för en form eller sida.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getNewWindow() {#getNewWindow--}
+```
+public BoolValue getNewWindow()
+```
+
+
+Anger om Microsoft Visio öppnar ett fönster på en ny plats när den följer en hyperlänk för att öppna en webbsida eller ett annat Visio-dokument.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Osynligt element indikerar om en hyperlänk visas i snabbmenyn för en form eller sida.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSubAddress() {#getSubAddress--}
+```
+public Str2Value getSubAddress()
+```
+
+
+Anger en plats inom måldokumentet att länka till.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/hyperlink\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/hyperlink\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/hyperlink\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/hyperlink\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/hyperlinkcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/hyperlinkcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: HyperlinkCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Hyperlänksamling.
+type: docs
+weight: 194
+url: /sv/java/com.aspose.diagram/hyperlinkcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class HyperlinkCollection extends Collection
+```
+
+Hyperlänksamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Hyperlink item)](#add-com.aspose.diagram.Hyperlink-) | Lägg till Hyperlink-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Hyperlink item)](#remove-com.aspose.diagram.Hyperlink-) | Ta bort Hyperlink-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Hyperlink item) {#add-com.aspose.diagram.Hyperlink-}
+```
+public int add(Hyperlink item)
+```
+
+
+Lägg till Hyperlink-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Hyperlink get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Hyperlink](../../com.aspose.diagram/hyperlink) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Hyperlink item) {#remove-com.aspose.diagram.Hyperlink-}
+```
+public void remove(Hyperlink item)
+```
+
+
+Ta bort Hyperlink-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Hyperlink](../../com.aspose.diagram/hyperlink) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/iconsizevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/iconsizevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: IconSizeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Valfri int.
+type: docs
+weight: 195
+url: /sv/java/com.aspose.diagram/iconsizevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class IconSizeValue
+```
+
+Valfri int. Storleken på elementets ikon.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DOUBLE](#DOUBLE) | Double. |
+| [NORMAL](#NORMAL) | Normal. |
+| [TALL](#TALL) | Lång. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [WIDE](#WIDE) | Bred. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DOUBLE {#DOUBLE}
+```
+public static final int DOUBLE
+```
+
+
+Double.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### TALL {#TALL}
+```
+public static final int TALL
+```
+
+
+Lång.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### WIDE {#WIDE}
+```
+public static final int WIDE
+```
+
+
+Bred.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/image/_index.md
+++ b/swedish/java/com.aspose.diagram/image/_index.md
@@ -1,0 +1,227 @@
+---
+title: Bild
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller gamma, ljusstyrka, kontrast, oskärpa, skärpning, brusreducering och transparensvärden för en bitmap.
+type: docs
+weight: 196
+url: /sv/java/com.aspose.diagram/image/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Image
+```
+
+Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBlur()](#getBlur--) | Gör en bitmap‑bild suddig eller mjukare. |
+| [getBrightness()](#getBrightness--) | Justera ljusstyrkan för en bitmap‑bild. |
+| [getClass()](#getClass--) |  |
+| [getContrast()](#getContrast--) | Anger kontrasten för en bitmap‑bild. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDenoise()](#getDenoise--) | Tar bort brus (pixlar som har slumpmässigt fördelade färgnivåer) från en bitmap‑bild. |
+| [getGamma()](#getGamma--) | Justera eller korrigera intensiteten för en bild för en viss utmatningsenhet, såsom en bildskärm eller skanner. |
+| [getSharpen()](#getSharpen--) | Anger mängden skärpning för en bitmap‑bild. |
+| [getTransparency()](#getTransparency--) | Anger transparensnivån för ett lagerfärg, från 0 (opak) till 1 (helt genomskinlig). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/image\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBlur() {#getBlur--}
+```
+public DoubleValue getBlur()
+```
+
+
+Gör en bitmap‑bild suddig eller mjukare. Blur‑elementet innehåller ett värde mellan 0 och 1; standardvärdet är 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBrightness() {#getBrightness--}
+```
+public DoubleValue getBrightness()
+```
+
+
+Justera ljusstyrkan för en bitmap‑bild. Brightness‑elementet innehåller ett värde mellan 0 och 1; standardvärdet är 0.5.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContrast() {#getContrast--}
+```
+public DoubleValue getContrast()
+```
+
+
+Anger kontrasten för en bitmap‑bild. Contrast‑elementet innehåller ett värde mellan 0 och 1.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDenoise() {#getDenoise--}
+```
+public DoubleValue getDenoise()
+```
+
+
+Tar bort brus (pixlar som har slumpmässigt fördelade färgnivåer) från en bitmap‑bild.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGamma() {#getGamma--}
+```
+public DoubleValue getGamma()
+```
+
+
+Justera eller korrigera intensiteten för en bild för en viss utmatningsenhet, såsom en bildskärm eller skanner. Standardvärdet är 1 (ingen korrigering).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSharpen() {#getSharpen--}
+```
+public DoubleValue getSharpen()
+```
+
+
+Anger mängden skärpning för en bitmap‑bild. Skärpning av en bild fokuserar den genom att öka kontrasten mellan intilliggande pixlar.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTransparency() {#getTransparency--}
+```
+public DoubleValue getTransparency()
+```
+
+
+Anger transparensnivån för ett lagerfärg, från 0 (opak) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/image\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/imageactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/imageactivexcontrol/_index.md
@@ -1,0 +1,597 @@
+---
+title: ImageActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar bildkontrollen.
+type: docs
+weight: 197
+url: /sv/java/com.aspose.diagram/imageactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ImageActiveXControl extends ActiveXControl
+```
+
+Representerar bildkontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderOleColor()](#getBorderOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderStyle()](#getBorderStyle--) | typen av ram som används av kontrollen. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPictureAlignment()](#getPictureAlignment--) | justeringen av bilden inuti Form eller Image. |
+| [getPictureSizeMode()](#getPictureSizeMode--) | hur man visar bilden. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTiled()](#isTiled--) | Anger om bilden är kaklad över bakgrunden. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av den här egenskapen, se [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--) |
+| [setPictureAlignment(int value)](#setPictureAlignment-int-) | För beskrivningen av den här egenskapen, se [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--) |
+| [setPictureSizeMode(int value)](#setPictureSizeMode-int-) | För beskrivningen av den här egenskapen, se [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--) |
+| [setTiled(boolean value)](#setTiled-boolean-) | För beskrivningen av den här egenskapen, se [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+typen av ram som används av kontrollen.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPictureAlignment() {#getPictureAlignment--}
+```
+public int getPictureAlignment()
+```
+
+
+justeringen av bilden inuti Form eller Image.
+
+**Returns:**
+int
+### getPictureSizeMode() {#getPictureSizeMode--}
+```
+public int getPictureSizeMode()
+```
+
+
+hur man visar bilden.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTiled() {#isTiled--}
+```
+public boolean isTiled()
+```
+
+
+Anger om bilden är kaklad över bakgrunden.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isAutoSize()](../../com.aspose.diagram/imageactivexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/imageactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/imageactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/imageactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPictureAlignment(int value) {#setPictureAlignment-int-}
+```
+public void setPictureAlignment(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPictureAlignment()](../../com.aspose.diagram/imageactivexcontrol\#getPictureAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPictureSizeMode(int value) {#setPictureSizeMode-int-}
+```
+public void setPictureSizeMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPictureSizeMode()](../../com.aspose.diagram/imageactivexcontrol\#getPictureSizeMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/imageactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTiled(boolean value) {#setTiled-boolean-}
+```
+public void setTiled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTiled()](../../com.aspose.diagram/imageactivexcontrol\#isTiled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/imagecolormode/_index.md
+++ b/swedish/java/com.aspose.diagram/imagecolormode/_index.md
@@ -1,0 +1,156 @@
+---
+title: ImageColorMode
+second_title: Aspose.Diagram för Java API-referens
+description: Anger färgläget för de genererade bilderna av dokumentsidor.
+type: docs
+weight: 198
+url: /sv/java/com.aspose.diagram/imagecolormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ImageColorMode
+```
+
+Anger färgläget för de genererade bilderna av dokumentsidor.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BLACK_AND_WHITE](#BLACK-AND-WHITE) | Dokumentets sidor kommer att renderas som svartvita bilder. |
+| [GRAYSCALE](#GRAYSCALE) | Dokumentets sidor kommer att renderas som gråskalebilder. |
+| [NONE](#NONE) | Dokumentets sidor kommer att renderas som färgbilder. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BLACK_AND_WHITE {#BLACK-AND-WHITE}
+```
+public static final int BLACK_AND_WHITE
+```
+
+
+Dokumentets sidor kommer att renderas som svartvita bilder.
+
+### GRAYSCALE {#GRAYSCALE}
+```
+public static final int GRAYSCALE
+```
+
+
+Dokumentets sidor kommer att renderas som gråskalebilder.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Dokumentets sidor kommer att renderas som färgbilder.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/imageformat/_index.md
+++ b/swedish/java/com.aspose.diagram/imageformat/_index.md
@@ -1,0 +1,273 @@
+---
+title: ImageFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Anger bildens filformat.
+type: docs
+weight: 199
+url: /sv/java/com.aspose.diagram/imageformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ImageFormat
+```
+
+Anger bildens filformat.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ImageFormat()](#ImageFormat--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) | Returnerar ett värde som indikerar om det angivna objektet är ett ImageFormat‑objekt som är ekvivalent med detta ImageFormat‑objekt. |
+| [getBmp()](#getBmp--) | Hämtar bitmap‑ (BMP) bildformatet. |
+| [getClass()](#getClass--) |  |
+| [getEmf()](#getEmf--) | Hämtar det förbättrade metafil‑ (EMF) bildformatet. |
+| [getExif()](#getExif--) | Hämtar Exchangeable Image File (Exif)-formatet. |
+| [getGif()](#getGif--) | Hämtar Graphics Interchange Format (GIF)-bildformatet. |
+| [getIcon()](#getIcon--) | Hämtar Windows‑ikon‑bildformatet. |
+| [getImageFormatFromSuffixName(String name)](#getImageFormatFromSuffixName-java.lang.String-) | Hämta bildformatet enligt suffixnamn. |
+| [getJpeg()](#getJpeg--) | Hämtar Joint Photographic Experts Group (JPEG)-bildformatet. |
+| [getMemoryBmp()](#getMemoryBmp--) | Hämtar ett minnes‑bitmap‑bildformat. |
+| [getName()](#getName--) | Hämta strängnamnet för detta ImageFormat‑instans. |
+| [getPng()](#getPng--) | Hämtar W3C Portable Network Graphics (PNG)-bildformatet. |
+| [getTiff()](#getTiff--) | Hämtar bildformatet Tagged Image File Format (TIFF). |
+| [getWmf()](#getWmf--) | Hämtar Windows-metafilen (WMF) bildformat. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageFormat() {#ImageFormat--}
+```
+public ImageFormat()
+```
+
+
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Returnerar ett värde som indikerar om det angivna objektet är ett ImageFormat‑objekt som är ekvivalent med detta ImageFormat‑objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object | Objektet att testa. |
+
+**Returns:**
+boolean - true om o är ett ImageFormat-objekt som är ekvivalent med detta ImageFormat-objekt; annars false.
+### getBmp() {#getBmp--}
+```
+public static ImageFormat getBmp()
+```
+
+
+Hämtar bitmap‑ (BMP) bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the bitmap image format.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmf() {#getEmf--}
+```
+public static ImageFormat getEmf()
+```
+
+
+Hämtar det förbättrade metafil‑ (EMF) bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the enhanced metafile image format.
+### getExif() {#getExif--}
+```
+public static ImageFormat getExif()
+```
+
+
+Hämtar Exchangeable Image File (Exif)-formatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Exif format.
+### getGif() {#getGif--}
+```
+public static ImageFormat getGif()
+```
+
+
+Hämtar Graphics Interchange Format (GIF)-bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the GIF image format.
+### getIcon() {#getIcon--}
+```
+public static ImageFormat getIcon()
+```
+
+
+Hämtar Windows‑ikon‑bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows icon image format.
+### getImageFormatFromSuffixName(String name) {#getImageFormatFromSuffixName-java.lang.String-}
+```
+public static ImageFormat getImageFormatFromSuffixName(String name)
+```
+
+
+Hämta bildformatet enligt suffixnamn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | suffixnamn |
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - >An ImageFormat object according to the suffix name.
+### getJpeg() {#getJpeg--}
+```
+public static ImageFormat getJpeg()
+```
+
+
+Hämtar Joint Photographic Experts Group (JPEG)-bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the JPEG image format.
+### getMemoryBmp() {#getMemoryBmp--}
+```
+public static ImageFormat getMemoryBmp()
+```
+
+
+Hämtar ett minnes‑bitmap‑bildformat.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the memory bitmap image format.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Hämta strängnamnet för detta ImageFormat‑instans.
+
+**Returns:**
+java.lang.String - Strängnamnet för denna ImageFormat-instans
+### getPng() {#getPng--}
+```
+public static ImageFormat getPng()
+```
+
+
+Hämtar W3C Portable Network Graphics (PNG)-bildformatet.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the PNG image format.
+### getTiff() {#getTiff--}
+```
+public static ImageFormat getTiff()
+```
+
+
+Hämtar bildformatet Tagged Image File Format (TIFF).
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the TIFF image format.
+### getWmf() {#getWmf--}
+```
+public static ImageFormat getWmf()
+```
+
+
+Hämtar Windows-metafilen (WMF) bildformat.
+
+**Returns:**
+[ImageFormat](../../com.aspose.diagram/imageformat) - An ImageFormat object that indicates the Windows metafile image format.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/imagesaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/imagesaveoptions/_index.md
@@ -1,0 +1,809 @@
+---
+title: ImageSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när diagramssidor renderas till bilder.
+type: docs
+weight: 200
+url: /sv/java/com.aspose.diagram/imagesaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class ImageSaveOptions extends RenderingSaveOptions
+```
+
+Tillåter att ange ytterligare alternativ när diagramssidor renderas till bilder.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ImageSaveOptions(int saveFormat)](#ImageSaveOptions-int-) | Initierar en ny instans av denna klass som kan användas för att spara renderade bilder i formatet Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat eller Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompositingQuality()](#getCompositingQuality--) | Anger kvalitetsnivån som ska användas vid sammansättning. |
+| [getContentZoom()](#getContentZoom--) | Denna parameter liknar skala, men påverkar inte den genererade bildens storlek. |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definierar om dolda sidor ska exporteras eller inte. |
+| [getImageBrightness()](#getImageBrightness--) | ljusstyrkan för de genererade bilderna. |
+| [getImageColorMode()](#getImageColorMode--) | färgläget för de genererade bilderna. |
+| [getImageContrast()](#getImageContrast--) | kontrasten för de genererade bilderna. |
+| [getInterpolationMode()](#getInterpolationMode--) | Anger den algoritm som används när bilder skalas eller roteras. |
+| [getJpegQuality()](#getJpegQuality--) | ett värde som bestämmer kvaliteten på de genererade JPEG-bilderna. |
+| [getPageCount()](#getPageCount--) | antalet sidor som ska renderas när du sparar till en flersidig TIFF-fil. |
+| [getPageIndex()](#getPageIndex--) | det nollbaserade indexet för den första sidan som ska renderas. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getPixelOffsetMode()](#getPixelOffsetMode--) | ett värde som specificerar hur pixlar förskjuts under rendering. |
+| [getResolution()](#getResolution--) | upplösningen för de genererade bilderna, i punkter per tum. |
+| [getSameAsPdfConversionArea()](#getSameAsPdfConversionArea--) | Anger om sparningsområdet är samma som PDF. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska sparas som bild eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger formatet som de renderade diagrammetsidorna kommer att sparas i om detta sparaalternativobjekt används. |
+| [getScale()](#getScale--) | zoomfaktorn för de genererade bilderna. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getSmoothingMode()](#getSmoothingMode--) | Specificerar om jämning (antialiasing) tillämpas på linjer och kurvor samt kanterna på fyllda områden. |
+| [getTiffCompression()](#getTiffCompression--) | kompressionstypen som ska tillämpas när genererade bilder sparas i TIFF-format. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompositingQuality(int value)](#setCompositingQuality-int-) | För beskrivning av denna egenskap, se [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--) |
+| [setContentZoom(float value)](#setContentZoom-float-) | För beskrivning av denna egenskap, se [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | För beskrivning av denna egenskap, se [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--) |
+| [setImageBrightness(float value)](#setImageBrightness-float-) | För beskrivning av denna egenskap, se [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--) |
+| [setImageColorMode(int value)](#setImageColorMode-int-) | För beskrivning av denna egenskap, se [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--) |
+| [setImageContrast(float value)](#setImageContrast-float-) | För beskrivning av denna egenskap, se [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--) |
+| [setInterpolationMode(int value)](#setInterpolationMode-int-) | För beskrivning av denna egenskap, se [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | För beskrivning av denna egenskap, se [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivning av denna egenskap, se [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivning av denna egenskap, se [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setPixelOffsetMode(int value)](#setPixelOffsetMode-int-) | För beskrivning av denna egenskap, se [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--) |
+| [setResolution(float value)](#setResolution-float-) | För beskrivning av denna egenskap, se [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--) |
+| [setSameAsPdfConversionArea(boolean value)](#setSameAsPdfConversionArea-boolean-) | För beskrivning av denna egenskap, se [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivning av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivning av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--) |
+| [setScale(float value)](#setScale-float-) | För beskrivning av denna egenskap, se [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSmoothingMode(int value)](#setSmoothingMode-int-) | För beskrivning av denna egenskap, se [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--) |
+| [setTiffCompression(int value)](#setTiffCompression-int-) | För beskrivning av denna egenskap, se [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions(int saveFormat) {#ImageSaveOptions-int-}
+```
+public ImageSaveOptions(int saveFormat)
+```
+
+
+Initierar en ny instans av denna klass som kan användas för att spara renderade bilder i formatet Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat eller Aspose.Diagram.SaveFileFormat.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Kan vara Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat eller Aspose.Diagram.SaveFileFormat. |
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompositingQuality() {#getCompositingQuality--}
+```
+public int getCompositingQuality()
+```
+
+
+Anger kvalitetsnivån som ska användas under sammanslagning. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är Aspose.Diagram.Saving.CompositingQuality.
+
+**Returns:**
+int
+### getContentZoom() {#getContentZoom--}
+```
+public float getContentZoom()
+```
+
+
+Denna parameter liknar skala, men påverkar inte den genererade bildens storlek. Standardvärdet är 1.0. Värdet måste vara större än 0.
+
+**Returns:**
+float
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definierar om dolda sidor ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getImageBrightness() {#getImageBrightness--}
+```
+public float getImageBrightness()
+```
+
+
+Ljusstyrkan för de genererade bilderna. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är 0.5. Värdet måste ligga i intervallet mellan 0 och 1.
+
+**Returns:**
+float
+### getImageColorMode() {#getImageColorMode--}
+```
+public int getImageColorMode()
+```
+
+
+Färgläget för de genererade bilderna. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är Aspose.Diagram.Saving.ImageColorMode.
+
+**Returns:**
+int
+### getImageContrast() {#getImageContrast--}
+```
+public float getImageContrast()
+```
+
+
+Kontrasten för de genererade bilderna. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är 0.5. Värdet måste ligga i intervallet mellan 0 och 1.
+
+**Returns:**
+float
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public int getInterpolationMode()
+```
+
+
+Anger algoritmen som används när bilder skalas eller roteras. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är Aspose.Diagram.Saving.InterpolationMode.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Ett värde som bestämmer kvaliteten på de genererade JPEG-bilderna. Har effekt endast vid sparande till JPEG. Använd denna egenskap för att hämta eller ange kvaliteten på genererade bilder när du sparar i JPEG-format. Värdet kan variera från 0 till 100 där 0 betyder sämst kvalitet men maximal komprimering och 100 betyder bästa kvalitet men minimal komprimering. Standardvärdet är 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Antalet sidor som ska renderas vid sparande till en flersidig TIFF-fil. Standard är MaxValue vilket betyder att alla diagramsidors renderas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+det 0-baserade indexet för den första sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getPixelOffsetMode() {#getPixelOffsetMode--}
+```
+public int getPixelOffsetMode()
+```
+
+
+Ett värde som specificerar hur pixlar förskjuts under rendering. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är Aspose.Diagram.Saving.PixelOffsetMode.
+
+**Returns:**
+int
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+Upplösningen för de genererade bilderna, i punkter per tum. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är 96.
+
+**Returns:**
+float
+### getSameAsPdfConversionArea() {#getSameAsPdfConversionArea--}
+```
+public boolean getSameAsPdfConversionArea()
+```
+
+
+Anger om sparningsområdet ska vara samma som PDF. Om true – renderat område är samma som PDF. Om false – renderat område är standard. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska sparas i bilden eller bara förgrunden. Om true – renderas endast förgrundssidor (med bakgrund om den finns). Om false – renderas förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger formatet som de renderade diagrammen ska sparas i om detta sparaalternativobjekt används. Kan vara Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat, Aspose.Diagram.SaveFileFormat eller Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getScale() {#getScale--}
+```
+public float getScale()
+```
+
+
+Zoomfaktorn för de genererade bilderna. Standardvärdet är 1.0. Värdet måste vara större än 0.
+
+**Returns:**
+float
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public int getSmoothingMode()
+```
+
+
+Anger om jämning (kantutjämning) tillämpas på linjer och kurvor samt kanterna på fyllda områden. Denna egenskap har effekt endast vid sparande till rasterbildformat. Standardvärdet är Aspose.Diagram.Saving.SmoothingMode.
+
+**Returns:**
+int
+### getTiffCompression() {#getTiffCompression--}
+```
+public int getTiffCompression()
+```
+
+
+Kompressionstypen som ska tillämpas när genererade bilder sparas i TIFF-format. Har effekt endast vid sparande till TIFF. Standardvärdet är Aspose.Diagram.Saving.TiffCompression.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompositingQuality(int value) {#setCompositingQuality-int-}
+```
+public void setCompositingQuality(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getCompositingQuality()](../../com.aspose.diagram/imagesaveoptions\#getCompositingQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setContentZoom(float value) {#setContentZoom-float-}
+```
+public void setContentZoom(float value)
+```
+
+
+För beskrivning av denna egenskap, se [getContentZoom()](../../com.aspose.diagram/imagesaveoptions\#getContentZoom--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+För beskrivning av denna egenskap, se [getExportHiddenPage()](../../com.aspose.diagram/imagesaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setImageBrightness(float value) {#setImageBrightness-float-}
+```
+public void setImageBrightness(float value)
+```
+
+
+För beskrivning av denna egenskap, se [getImageBrightness()](../../com.aspose.diagram/imagesaveoptions\#getImageBrightness--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setImageColorMode(int value) {#setImageColorMode-int-}
+```
+public void setImageColorMode(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getImageColorMode()](../../com.aspose.diagram/imagesaveoptions\#getImageColorMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setImageContrast(float value) {#setImageContrast-float-}
+```
+public void setImageContrast(float value)
+```
+
+
+För beskrivning av denna egenskap, se [getImageContrast()](../../com.aspose.diagram/imagesaveoptions\#getImageContrast--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setInterpolationMode(int value) {#setInterpolationMode-int-}
+```
+public void setInterpolationMode(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getInterpolationMode()](../../com.aspose.diagram/imagesaveoptions\#getInterpolationMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getJpegQuality()](../../com.aspose.diagram/imagesaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getPageCount()](../../com.aspose.diagram/imagesaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getPageIndex()](../../com.aspose.diagram/imagesaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setPixelOffsetMode(int value) {#setPixelOffsetMode-int-}
+```
+public void setPixelOffsetMode(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getPixelOffsetMode()](../../com.aspose.diagram/imagesaveoptions\#getPixelOffsetMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+För beskrivning av denna egenskap, se [getResolution()](../../com.aspose.diagram/imagesaveoptions\#getResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setSameAsPdfConversionArea(boolean value) {#setSameAsPdfConversionArea-boolean-}
+```
+public void setSameAsPdfConversionArea(boolean value)
+```
+
+
+För beskrivning av denna egenskap, se [getSameAsPdfConversionArea()](../../com.aspose.diagram/imagesaveoptions\#getSameAsPdfConversionArea--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivning av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/imagesaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/imagesaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setScale(float value) {#setScale-float-}
+```
+public void setScale(float value)
+```
+
+
+För beskrivning av denna egenskap, se [getScale()](../../com.aspose.diagram/imagesaveoptions\#getScale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSmoothingMode(int value) {#setSmoothingMode-int-}
+```
+public void setSmoothingMode(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getSmoothingMode()](../../com.aspose.diagram/imagesaveoptions\#getSmoothingMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTiffCompression(int value) {#setTiffCompression-int-}
+```
+public void setTiffCompression(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getTiffCompression()](../../com.aspose.diagram/imagesaveoptions\#getTiffCompression--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/individualfontconfigs/_index.md
+++ b/swedish/java/com.aspose.diagram/individualfontconfigs/_index.md
@@ -1,0 +1,193 @@
+---
+title: IndividualFontConfigs
+second_title: Aspose.Diagram för Java API-referens
+description: Teckensnittskonfigurationer för varje objekt.
+type: docs
+weight: 201
+url: /sv/java/com.aspose.diagram/individualfontconfigs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IndividualFontConfigs
+```
+
+Teckensnittskonfigurationer för varje [Diagram](../../com.aspose.diagram/diagram) objekt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [IndividualFontConfigs()](#IndividualFontConfigs--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontSources()](#getFontSources--) | Hämtar en kopia av arrayen som innehåller listan över källor |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFontFolder(String fontFolder, boolean recursive)](#setFontFolder-java.lang.String-boolean-) | Ställer in teckensnittsmappen |
+| [setFontFolders(String[] fontFolders, boolean recursive)](#setFontFolders-java.lang.String---boolean-) | Ställer in teckensnittsmapparna |
+| [setFontSources(FontSourceBase[] sources)](#setFontSources-com.aspose.diagram.FontSourceBase---) | Ställer in teckensnittskällorna. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IndividualFontConfigs() {#IndividualFontConfigs--}
+```
+public IndividualFontConfigs()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontSources() {#getFontSources--}
+```
+public FontSourceBase[] getFontSources()
+```
+
+
+Hämtar en kopia av arrayen som innehåller listan över källor
+
+**Returns:**
+com.aspose.diagram.FontSourceBase[] -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFontFolder(String fontFolder, boolean recursive) {#setFontFolder-java.lang.String-boolean-}
+```
+public void setFontFolder(String fontFolder, boolean recursive)
+```
+
+
+Ställer in teckensnittsmappen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontFolder | java.lang.String | Mappen som innehåller TrueType-teckensnitt. |
+| recursive | boolean | Bestämmer om undermappar ska genomsökas eller inte. |
+
+### setFontFolders(String[] fontFolders, boolean recursive) {#setFontFolders-java.lang.String---boolean-}
+```
+public void setFontFolders(String[] fontFolders, boolean recursive)
+```
+
+
+Ställer in teckensnittsmapparna
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontFolders | java.lang.String[] | Mapparna som innehåller TrueType-teckensnitt. |
+| recursive | boolean | Bestämmer om undermappar ska genomsökas eller inte. |
+
+### setFontSources(FontSourceBase[] sources) {#setFontSources-com.aspose.diagram.FontSourceBase---}
+```
+public void setFontSources(FontSourceBase[] sources)
+```
+
+
+Ställer in teckensnittskällorna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| sources | [FontSourceBase\[\]](../../com.aspose.diagram/fontsourcebase) | En array av källor som innehåller TrueType-teckensnitt. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/infiniteline/_index.md
+++ b/swedish/java/com.aspose.diagram/infiniteline/_index.md
@@ -1,0 +1,299 @@
+---
+title: InfiniteLine
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar x- och y-koordinaterna för två punkter på en oändlig linje.
+type: docs
+weight: 202
+url: /sv/java/com.aspose.diagram/infiniteline/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class InfiniteLine extends Coordinate
+```
+
+Innehåller element som specificerar x- och y-koordinaterna för två punkter på en oändlig linje. X- och Y-elementen specificerar x- och y-koordinaterna för den första punkten, och A- och B-elementen specificerar x- och y-koordinaterna för den andra punkten.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [InfiniteLine()](#InfiniteLine--) | Skapar en instans av klassen [InfiniteLine](../../com.aspose.diagram/infiniteline). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | En x-koordinat för en punkt på den oändliga linjen kombinerad med y-koordinaten som representeras av B-elementet. |
+| [getB()](#getB--) | En y-koordinat för en punkt på en oändlig linje kombinerad med en x-koordinat som representeras av A-elementet. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | En x-koordinat för en punkt på den oändliga linjen. |
+| [getY()](#getY--) | En y-koordinat för en punkt på den oändliga linjen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/infiniteline\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/infiniteline\#getB--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/infiniteline\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/infiniteline\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/infiniteline\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/infiniteline\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InfiniteLine() {#InfiniteLine--}
+```
+public InfiniteLine()
+```
+
+
+Skapar en instans av klassen [InfiniteLine](../../com.aspose.diagram/infiniteline).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+En x-koordinat för en punkt på den oändliga linjen kombinerad med y-koordinaten som representeras av B-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+En y-koordinat för en punkt på en oändlig linje kombinerad med en x-koordinat som representeras av A-elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+En x-koordinat för en punkt på den oändliga linjen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+En y-koordinat för en punkt på den oändliga linjen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/infiniteline\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/infiniteline\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/infiniteline\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/infiniteline\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/infiniteline\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/infiniteline\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/infinitelinecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/infinitelinecollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: InfiniteLineCollection
+second_title: Aspose.Diagram för Java API-referens
+description: InfiniteLine-samling.
+type: docs
+weight: 203
+url: /sv/java/com.aspose.diagram/infinitelinecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class InfiniteLineCollection extends Collection
+```
+
+InfiniteLine-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public InfiniteLine get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[InfiniteLine](../../com.aspose.diagram/infiniteline) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/inputmethodeditormode/_index.md
+++ b/swedish/java/com.aspose.diagram/inputmethodeditormode/_index.md
@@ -1,0 +1,246 @@
+---
+title: InputMethodEditorMode
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar standardkörningsläget för Input Method Editor.
+type: docs
+weight: 204
+url: /sv/java/com.aspose.diagram/inputmethodeditormode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InputMethodEditorMode
+```
+
+Representerar standardkörningsläget för Input Method Editor.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALPHA](#ALPHA) | IME på med halvbredd alfanumeriskt läge. |
+| [ALPHA_FULL](#ALPHA-FULL) | IME på med helbredd alfanumeriskt läge. |
+| [DISABLE](#DISABLE) | IME av. Användaren kan inte slå på IME via tangentbordet. |
+| [HANGUL](#HANGUL) | IME på med halvbredd hangul-läge. |
+| [HANGUL_FULL](#HANGUL-FULL) | IME på med helbredd hangul-läge. |
+| [HANZI](#HANZI) | IME på med halvbredd hanzi-läge. |
+| [HANZI_FULL](#HANZI-FULL) | IME på med helbredd hanzi-läge. |
+| [HIRAGANA](#HIRAGANA) | IME på med helbredd hiragana-läge. |
+| [KATAKANA](#KATAKANA) | IME på med helbredd katakana-läge. |
+| [KATAKANA_HALF](#KATAKANA-HALF) | IME på med halvbredd katakana-läge. |
+| [NO_CONTROL](#NO-CONTROL) | Styr inte IME. |
+| [OFF](#OFF) | IME av. |
+| [ON](#ON) | IME på. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALPHA {#ALPHA}
+```
+public static final int ALPHA
+```
+
+
+IME på med halvbredd alfanumeriskt läge.
+
+### ALPHA_FULL {#ALPHA-FULL}
+```
+public static final int ALPHA_FULL
+```
+
+
+IME på med helbredd alfanumeriskt läge.
+
+### DISABLE {#DISABLE}
+```
+public static final int DISABLE
+```
+
+
+IME av. Användaren kan inte slå på IME via tangentbordet.
+
+### HANGUL {#HANGUL}
+```
+public static final int HANGUL
+```
+
+
+IME på med halvbredd hangul-läge.
+
+### HANGUL_FULL {#HANGUL-FULL}
+```
+public static final int HANGUL_FULL
+```
+
+
+IME på med helbredd hangul-läge.
+
+### HANZI {#HANZI}
+```
+public static final int HANZI
+```
+
+
+IME på med halvbredd hanzi-läge.
+
+### HANZI_FULL {#HANZI-FULL}
+```
+public static final int HANZI_FULL
+```
+
+
+IME på med helbredd hanzi-läge.
+
+### HIRAGANA {#HIRAGANA}
+```
+public static final int HIRAGANA
+```
+
+
+IME på med helbredd hiragana-läge.
+
+### KATAKANA {#KATAKANA}
+```
+public static final int KATAKANA
+```
+
+
+IME på med helbredd katakana-läge.
+
+### KATAKANA_HALF {#KATAKANA-HALF}
+```
+public static final int KATAKANA_HALF
+```
+
+
+IME på med halvbredd katakana-läge.
+
+### NO_CONTROL {#NO-CONTROL}
+```
+public static final int NO_CONTROL
+```
+
+
+Styr inte IME.
+
+### OFF {#OFF}
+```
+public static final int OFF
+```
+
+
+IME av. Engelsk läge.
+
+### ON {#ON}
+```
+public static final int ON
+```
+
+
+IME på.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/interpolationmode/_index.md
+++ b/swedish/java/com.aspose.diagram/interpolationmode/_index.md
@@ -1,0 +1,210 @@
+---
+title: InterpolationMode
+second_title: Aspose.Diagram för Java API-referens
+description: InterpolationMode‑enumerationen specificerar den algoritm som används när bilder skalas eller roteras.
+type: docs
+weight: 206
+url: /sv/java/com.aspose.diagram/interpolationmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class InterpolationMode
+```
+
+InterpolationMode‑enumerationen specificerar den algoritm som används när bilder skalas eller roteras.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BICUBIC](#BICUBIC) | Anger bikubisk interpolering. |
+| [BILINEAR](#BILINEAR) | Anger bilinjär interpolering. |
+| [DEFAULT](#DEFAULT) | Anger standardläge. |
+| [HIGH](#HIGH) | Anger högkvalitativ interpolering. |
+| [HIGH_QUALITY_BICUBIC](#HIGH-QUALITY-BICUBIC) | Anger högkvalitativ, bikubisk interpolering. |
+| [HIGH_QUALITY_BILINEAR](#HIGH-QUALITY-BILINEAR) | Anger högkvalitativ, bilinjär interpolering. |
+| [INVALID](#INVALID) | Motsvarar elementet Invalid i QualityMode‑enumerationen. |
+| [LOW](#LOW) | Anger lågkvalitativ interpolering. |
+| [NEAREST_NEIGHBOR](#NEAREST-NEIGHBOR) | Anger närmaste-granne-interpolering. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BICUBIC {#BICUBIC}
+```
+public static final int BICUBIC
+```
+
+
+Anger bikubisk interpolering. Ingen förfiltrering utförs. Detta läge är inte lämpligt för att krympa en bild under 25 procent av dess originalstorlek.
+
+### BILINEAR {#BILINEAR}
+```
+public static final int BILINEAR
+```
+
+
+Anger bilinjär interpolering. Ingen förfiltrering utförs. Detta läge är inte lämpligt för att krympa en bild under 50 procent av dess originalstorlek.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Anger standardläge.
+
+### HIGH {#HIGH}
+```
+public static final int HIGH
+```
+
+
+Anger högkvalitativ interpolering.
+
+### HIGH_QUALITY_BICUBIC {#HIGH-QUALITY-BICUBIC}
+```
+public static final int HIGH_QUALITY_BICUBIC
+```
+
+
+Anger högkvalitativ, bikubisk interpolering. Förfiltrering utförs för att säkerställa högkvalitativ krympning. Detta läge producerar de högsta kvalitetsförändrade bilderna.
+
+### HIGH_QUALITY_BILINEAR {#HIGH-QUALITY-BILINEAR}
+```
+public static final int HIGH_QUALITY_BILINEAR
+```
+
+
+Anger högkvalitativ, bilinjär interpolering. Förfiltrering utförs för att säkerställa högkvalitativ krympning.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Motsvarar elementet Invalid i QualityMode‑enumerationen.
+
+### LOW {#LOW}
+```
+public static final int LOW
+```
+
+
+Anger lågkvalitativ interpolering.
+
+### NEAREST_NEIGHBOR {#NEAREST-NEIGHBOR}
+```
+public static final int NEAREST_NEIGHBOR
+```
+
+
+Anger närmaste-granne-interpolering.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/interruptmonitor/_index.md
+++ b/swedish/java/com.aspose.diagram/interruptmonitor/_index.md
@@ -1,0 +1,156 @@
+---
+title: InterruptMonitor
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar alla operatörer för avbrottet.
+type: docs
+weight: 207
+url: /sv/java/com.aspose.diagram/interruptmonitor/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+```
+public class InterruptMonitor extends AbstractInterruptMonitor
+```
+
+Representerar alla operatörer för avbrottet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [InterruptMonitor()](#InterruptMonitor--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [interrupt()](#interrupt--) | Avbryt den aktuella operatören. |
+| [isInterruptionRequested()](#isInterruptionRequested--) | Markera monitorn som begär avbrott |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InterruptMonitor() {#InterruptMonitor--}
+```
+public InterruptMonitor()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### interrupt() {#interrupt--}
+```
+public void interrupt()
+```
+
+
+Avbryt den aktuella operatören.
+
+### isInterruptionRequested() {#isInterruptionRequested--}
+```
+public boolean isInterruptionRequested()
+```
+
+
+Markera monitorn som begär avbrott
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/intvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/intvalue/_index.md
@@ -1,0 +1,230 @@
+---
+title: IntValue
+second_title: Aspose.Diagram för Java API-referens
+description: Heltalsvärde
+type: docs
+weight: 205
+url: /sv/java/com.aspose.diagram/intvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IntValue
+```
+
+Heltalsvärde
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [IntValue(int value, int unit)](#IntValue-int-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Heltalsvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [isThemed()](#isThemed--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setThemed(boolean value)](#setThemed-boolean-) | För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--) |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/intvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntValue(int value, int unit) {#IntValue-int-int-}
+```
+public IntValue(int value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+| enhet | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Heltalsvärde.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### isThemed() {#isThemed--}
+```
+public boolean isThemed()
+```
+
+
+
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setThemed(boolean value) {#setThemed-boolean-}
+```
+public void setThemed(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isThemed()](../../com.aspose.diagram/intvalue\#isThemed--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/intvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/intvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ipagesavingcallback/_index.md
+++ b/swedish/java/com.aspose.diagram/ipagesavingcallback/_index.md
@@ -1,0 +1,45 @@
+---
+title: IPageSavingCallback
+second_title: Aspose.Diagram för Java API-referens
+description: Styr/indikera framsteg för sidlagringsprocessen.
+type: docs
+weight: 456
+url: /sv/java/com.aspose.diagram/ipagesavingcallback/
+---
+```
+public interface IPageSavingCallback
+```
+
+Styr/indikera framsteg för sidlagringsprocessen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [pageEndSaving(PageEndSavingArgs args)](#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-) | Kontroll/Indikera att en sida avslutas för utskrift. |
+| [pageStartSaving(PageStartSavingArgs args)](#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-) | Kontroll/Indikera att en sida påbörjas för utskrift. |
+### pageEndSaving(PageEndSavingArgs args) {#pageEndSaving-com.aspose.diagram.PageEndSavingArgs-}
+```
+public abstract void pageEndSaving(PageEndSavingArgs args)
+```
+
+
+Kontroll/Indikera att en sida avslutas för utskrift.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| args | [PageEndSavingArgs](../../com.aspose.diagram/pageendsavingargs) | Information för en sida avslutar sparningsprocessen. |
+
+### pageStartSaving(PageStartSavingArgs args) {#pageStartSaving-com.aspose.diagram.PageStartSavingArgs-}
+```
+public abstract void pageStartSaving(PageStartSavingArgs args)
+```
+
+
+Kontroll/Indikera att en sida påbörjas för utskrift.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| args | [PageStartSavingArgs](../../com.aspose.diagram/pagestartsavingargs) | Information för en sida påbörjar sparningsprocessen. |
+

--- a/swedish/java/com.aspose.diagram/issue/_index.md
+++ b/swedish/java/com.aspose.diagram/issue/_index.md
@@ -1,0 +1,210 @@
+---
+title: Issue
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ett enskilt valideringsproblem i dokumentet.
+type: docs
+weight: 208
+url: /sv/java/com.aspose.diagram/issue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Issue
+```
+
+Representerar ett enskilt valideringsproblem i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Issue()](#Issue--) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Anger det unika identifieraren för valideringsproblemet. |
+| [getIgnored()](#getIgnored--) | Anger om valideringsproblemet för närvarande ignoreras. |
+| [getIssueTarget()](#getIssueTarget--) | Beroende på målet för det överordnade valideringsproblemet specificeras antingen sidan, eller både sidan och formen, som det överordnade valideringsproblemet är associerat med. |
+| [getRuleInfo()](#getRuleInfo--) | Anger information om valideringsregeln som det överordnade valideringsproblemet avser. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setID(long value)](#setID-long-) | För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/issue\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | För beskrivningen av den här egenskapen, se [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Issue() {#Issue--}
+```
+public Issue()
+```
+
+
+Konstruktor
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Anger det unika identifieraren för valideringsproblemet.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Anger om valideringsproblemet för närvarande ignoreras. Standardvärdet är False.
+
+**Returns:**
+int
+### getIssueTarget() {#getIssueTarget--}
+```
+public IssueTarget getIssueTarget()
+```
+
+
+Beroende på målet för det överordnade valideringsproblemet, specificerar antingen sidan, eller både sidan och formen, som problemet är associerat med. Om målet för det överordnade valideringsproblemet är ett dokument, specificerar IssueTarget varken en sida eller en form.
+
+**Returns:**
+[IssueTarget](../../com.aspose.diagram/issuetarget)
+### getRuleInfo() {#getRuleInfo--}
+```
+public RuleInfo getRuleInfo()
+```
+
+
+Anger information om valideringsregeln som det överordnade valideringsproblemet avser.
+
+**Returns:**
+[RuleInfo](../../com.aspose.diagram/ruleinfo)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/issue\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIgnored()](../../com.aspose.diagram/issue\#getIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/issuecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/issuecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: IssueCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Issue‑samling.
+type: docs
+weight: 209
+url: /sv/java/com.aspose.diagram/issuecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class IssueCollection extends Collection
+```
+
+Issue‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Issue issue)](#add-com.aspose.diagram.Issue-) | Lägg till problemet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Issue issue)](#remove-com.aspose.diagram.Issue-) | Ta bort problemet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Issue issue) {#add-com.aspose.diagram.Issue-}
+```
+public int add(Issue issue)
+```
+
+
+Lägg till problemet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Issue get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Issue](../../com.aspose.diagram/issue) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Issue issue) {#remove-com.aspose.diagram.Issue-}
+```
+public void remove(Issue issue)
+```
+
+
+Ta bort problemet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| issue | [Issue](../../com.aspose.diagram/issue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/issuetarget/_index.md
+++ b/swedish/java/com.aspose.diagram/issuetarget/_index.md
@@ -1,0 +1,194 @@
+---
+title: IssueTarget
+second_title: Aspose.Diagram för Java API-referens
+description: Beroende på målet för det överordnade valideringsproblemet specificerar antingen sidan eller både sidan och formen som problemet är associerat med.
+type: docs
+weight: 210
+url: /sv/java/com.aspose.diagram/issuetarget/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class IssueTarget
+```
+
+Beroende på målet för det överordnade valideringsproblemet, specificerar antingen sidan, eller både sidan och formen, som problemet är associerat med. Om målet för det överordnade valideringsproblemet är ett dokument, specificerar IssueTarget varken en sida eller en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [IssueTarget(long pageID, long shapeID)](#IssueTarget-long-long-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageId()](#getPageId--) | Specificerar den unika identifieraren för sidan som är associerad med det överordnade valideringsproblemet. |
+| [getShapeId()](#getShapeId--) | Specificerar den unika identifieraren för formen som är associerad med det överordnade valideringsproblemet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageId(long value)](#setPageId-long-) | För beskrivningen av denna egenskap, se [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--) |
+| [setShapeId(long value)](#setShapeId-long-) | För beskrivningen av denna egenskap, se [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IssueTarget(long pageID, long shapeID) {#IssueTarget-long-long-}
+```
+public IssueTarget(long pageID, long shapeID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pageID | long |  |
+| shapeID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageId() {#getPageId--}
+```
+public long getPageId()
+```
+
+
+Specificerar den unika identifieraren för sidan som är associerad med det överordnade valideringsproblemet. Om målet är dokumentet kan PageID‑värdet vara 0xFFFFFFFF.
+
+**Returns:**
+long
+### getShapeId() {#getShapeId--}
+```
+public long getShapeId()
+```
+
+
+Specificerar den unika identifieraren för formen som är associerad med det överordnade valideringsproblemet. Om målet är dokumentet eller en sida kan ShapeID‑värdet vara 0xFFFFFFFF.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageId(long value) {#setPageId-long-}
+```
+public void setPageId(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPageId()](../../com.aspose.diagram/issuetarget\#getPageId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setShapeId(long value) {#setShapeId-long-}
+```
+public void setShapeId(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShapeId()](../../com.aspose.diagram/issuetarget\#getShapeId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/istreamprovider/_index.md
+++ b/swedish/java/com.aspose.diagram/istreamprovider/_index.md
@@ -1,0 +1,45 @@
+---
+title: IStreamProvider
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar den exporterade strömleverantören.
+type: docs
+weight: 457
+url: /sv/java/com.aspose.diagram/istreamprovider/
+---
+```
+public interface IStreamProvider
+```
+
+Representerar den exporterade strömleverantören.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [closeStream(StreamProviderOptions options)](#closeStream-com.aspose.diagram.StreamProviderOptions-) | Stänger strömmen. |
+| [initStream(StreamProviderOptions options)](#initStream-com.aspose.diagram.StreamProviderOptions-) | Hämtar strömmen. |
+### closeStream(StreamProviderOptions options) {#closeStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void closeStream(StreamProviderOptions options)
+```
+
+
+Stänger strömmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+
+### initStream(StreamProviderOptions options) {#initStream-com.aspose.diagram.StreamProviderOptions-}
+```
+public abstract void initStream(StreamProviderOptions options)
+```
+
+
+Hämtar strömmen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| options | [StreamProviderOptions](../../com.aspose.diagram/streamprovideroptions) |  |
+

--- a/swedish/java/com.aspose.diagram/iwarningcallback/_index.md
+++ b/swedish/java/com.aspose.diagram/iwarningcallback/_index.md
@@ -1,0 +1,31 @@
+---
+title: IWarningCallback
+second_title: Aspose.Diagram för Java API-referens
+description: Återuppringningsgränssnitt för varning.
+type: docs
+weight: 458
+url: /sv/java/com.aspose.diagram/iwarningcallback/
+---
+```
+public interface IWarningCallback
+```
+
+Återuppringningsgränssnitt för varning.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [warning(WarningInfo warningInfo)](#warning-com.aspose.diagram.WarningInfo-) | Vår återuppringning behöver bara implementera metoden "Warning". |
+### warning(WarningInfo warningInfo) {#warning-com.aspose.diagram.WarningInfo-}
+```
+public abstract void warning(WarningInfo warningInfo)
+```
+
+
+Vår återuppringning behöver bara implementera metoden "Warning".
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| warningInfo | [WarningInfo](../../com.aspose.diagram/warninginfo) | varningsinformation |
+

--- a/swedish/java/com.aspose.diagram/labelactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/labelactivexcontrol/_index.md
@@ -1,0 +1,622 @@
+---
+title: LabelActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar etikett‑ActiveX‑kontrollen.
+type: docs
+weight: 211
+url: /sv/java/com.aspose.diagram/labelactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class LabelActiveXControl extends ActiveXControl
+```
+
+Representerar etikett‑ActiveX‑kontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Acceleratortangenten för kontrollen. |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderOleColor()](#getBorderOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderStyle()](#getBorderStyle--) | typen av ram som används av kontrollen. |
+| [getCaption()](#getCaption--) | Den beskrivande texten som visas på en kontroll. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPicturePosition()](#getPicturePosition--) | platsen för kontrollens bild relativt dess rubrik. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isWordWrapped()](#isWordWrapped--) | Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | För beskrivningen av den här egenskapen, se [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | För beskrivningen av den här egenskapen, se [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | För beskrivningen av den här egenskapen, se [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | För beskrivningen av den här egenskapen, se [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Acceleratortangenten för kontrollen.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+typen av ram som används av kontrollen.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Den beskrivande texten som visas på en kontroll.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+platsen för kontrollens bild relativt dess rubrik.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAccelerator()](../../com.aspose.diagram/labelactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/labelactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/labelactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getCaption()](../../com.aspose.diagram/labelactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPicture()](../../com.aspose.diagram/labelactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPicturePosition()](../../com.aspose.diagram/labelactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/labelactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isWordWrapped()](../../com.aspose.diagram/labelactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layer/_index.md
+++ b/swedish/java/com.aspose.diagram/layer/_index.md
@@ -1,0 +1,334 @@
+---
+title: Layer
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som definierar ett enskilt lager och dess egenskaper för en sida.
+type: docs
+weight: 212
+url: /sv/java/com.aspose.diagram/layer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layer
+```
+
+Innehåller element som definierar ett enskilt lager och dess egenskaper för en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Layer()](#Layer--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActive()](#getActive--) | Anger om ett lager är aktivt. |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Indexet för färgen i färgtabellen som används för att visa lagret eller ett RGB‑värde som specificerar en anpassad färg som inte finns i färgtabellen (till exempel \#ff9900). |
+| [getColorTrans()](#getColorTrans--) | Bestämmer graden av transparens för ett lager eller en figurs textfärg, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig). |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getGlue()](#getGlue--) | Anger om former som tillhör lagret kan limmas på. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getLock()](#getLock--) | Anger om former som tillhör lagret är låsta för att inte kunna väljas eller redigeras. |
+| [getName()](#getName--) | Name-elementet specificerar namnet på ett lager. |
+| [getNameUniv()](#getNameUniv--) | Anger det universella namnet på ett lager. |
+| [getPrint()](#getPrint--) | Anger om former som tillhör lagret skrivs ut när ritningen skrivs ut. |
+| [getSnap()](#getSnap--) | Anger om andra former kan fästa sig på former som tilldelats lagret. |
+| [getStatus()](#getStatus--) | Anger om lagret är ett giltigt lager för ett dokument. |
+| [getVisible()](#getVisible--) | Anger om former som tillhör lagret är synliga på ritningssidan. |
+| [hashCode()](#hashCode--) |  |
+| [isColorChecked()](#isColorChecked--) | En flagga som indikerar om elementet har kontrollerats lokalt. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorChecked(int value)](#setColorChecked-int-) | För beskrivningen av denna egenskap, se [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/layer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/layer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layer() {#Layer--}
+```
+public Layer()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActive() {#getActive--}
+```
+public BoolValue getActive()
+```
+
+
+Anger om ett lager är aktivt. Former som inte är förhandsassignerade till lager tilldelas det aktiva lagret/lagren när de släpps på ritningssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Indexet för färgen i färgtabellen som används för att visa lagret eller ett RGB‑värde som specificerar en anpassad färg som inte finns i färgtabellen (till exempel \#ff9900).
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getColorTrans() {#getColorTrans--}
+```
+public DoubleValue getColorTrans()
+```
+
+
+Bestämmer graden av transparens för ett lager eller en figurs textfärg, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getGlue() {#getGlue--}
+```
+public BoolValue getGlue()
+```
+
+
+Anger om former som tillhör lagret kan limmas på.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getLock() {#getLock--}
+```
+public BoolValue getLock()
+```
+
+
+Anger om former som tillhör lagret är låsta för att inte kunna väljas eller redigeras.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name-elementet specificerar namnet på ett lager.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getNameUniv() {#getNameUniv--}
+```
+public Str2Value getNameUniv()
+```
+
+
+Anger det universella namnet på ett lager.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getPrint() {#getPrint--}
+```
+public BoolValue getPrint()
+```
+
+
+Anger om former som tillhör lagret skrivs ut när ritningen skrivs ut.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getSnap() {#getSnap--}
+```
+public BoolValue getSnap()
+```
+
+
+Anger om andra former kan fästa sig på former som tilldelats lagret. Former som tilldelats lagret kan fästa sig på andra former, men andra former kan inte fästa sig på dem.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getStatus() {#getStatus--}
+```
+public BoolValue getStatus()
+```
+
+
+Anger om lagret är ett giltigt lager för ett dokument.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getVisible() {#getVisible--}
+```
+public BoolValue getVisible()
+```
+
+
+Anger om former som tillhör lagret är synliga på ritningssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isColorChecked() {#isColorChecked--}
+```
+public int isColorChecked()
+```
+
+
+En flagga som indikerar om elementet har kontrollerats lokalt. Värdet 1 indikerar att elementet kontrollerades lokalt.
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorChecked(int value) {#setColorChecked-int-}
+```
+public void setColorChecked(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [isColorChecked()](../../com.aspose.diagram/layer\#isColorChecked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/layer\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/layer\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layercollection/_index.md
+++ b/swedish/java/com.aspose.diagram/layercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: LayerCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Layer‑samling.
+type: docs
+weight: 213
+url: /sv/java/com.aspose.diagram/layercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LayerCollection extends Collection
+```
+
+Layer‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Layer item)](#add-com.aspose.diagram.Layer-) | Lägg till Layer-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Layer item)](#remove-com.aspose.diagram.Layer-) | Ta bort Layer-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Layer item) {#add-com.aspose.diagram.Layer-}
+```
+public int add(Layer item)
+```
+
+
+Lägg till Layer-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Layer get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Layer](../../com.aspose.diagram/layer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Layer item) {#remove-com.aspose.diagram.Layer-}
+```
+public void remove(Layer item)
+```
+
+
+Ta bort Layer-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Layer](../../com.aspose.diagram/layer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layermem/_index.md
+++ b/swedish/java/com.aspose.diagram/layermem/_index.md
@@ -1,0 +1,161 @@
+---
+title: LayerMem
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller LayerMember-elementet som specificerar varje lager som formen tilldelas.
+type: docs
+weight: 214
+url: /sv/java/com.aspose.diagram/layermem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayerMem
+```
+
+Innehåller LayerMember‑elementet, som specificerar varje lager som formen tilldelas.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getLayerMember()](#getLayerMember--) | Specificerar lagret eller lagren som formen tilldelas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/layermem\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getLayerMember() {#getLayerMember--}
+```
+public Str2Value getLayerMember()
+```
+
+
+Specificerar lagret eller lagren som formen tilldelas. Lagertilldelning specificeras baserat på det nollbaserade indexet för lager på sidan. Om en form tilldelas mer än ett lager, separeras varje lagerindex med ett semikolon.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/layermem\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layout/_index.md
+++ b/swedish/java/com.aspose.diagram/layout/_index.md
@@ -1,0 +1,362 @@
+---
+title: Layout
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr formplacering och inställningar för anslutningsruttning.
+type: docs
+weight: 215
+url: /sv/java/com.aspose.diagram/layout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Layout
+```
+
+Innehåller element som styr formplacering och inställningar för anslutningsruttning.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getConFixedCode()](#getConFixedCode--) | Bestämmer när en anslutning omdirigeras. |
+| [getConLineJumpCode()](#getConLineJumpCode--) | Bestämmer om en anslutning hoppar när två anslutningar korsar, |
+| [getConLineJumpDirX()](#getConLineJumpDirX--) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning. |
+| [getConLineJumpDirY()](#getConLineJumpDirY--) | Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning. |
+| [getConLineJumpStyle()](#getConLineJumpStyle--) | Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning. |
+| [getConLineRouteExt()](#getConLineRouteExt--) | Bestämmer utseendet på en anslutning. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDisplayLevel()](#getDisplayLevel--) | Bestämmer visningsnivåbandet (det relativa intervallet för Z-ordningsgruppering) för formen. |
+| [getRelationships()](#getRelationships--) | Lagrar relationerna mellan behållare, listor, anmärkningar och former. |
+| [getShapeFixedCode()](#getShapeFixedCode--) | Specificerar placeringsbeteende för en placerbar form. |
+| [getShapePermeablePlace()](#getShapePermeablePlace--) | Anger om placerbara former kan placeras ovanpå en form när en användare väljer Lay Out Shapes (Shapes menu). |
+| [getShapePermeableX()](#getShapePermeableX--) | Anger om en anslutning kan routas horisontellt genom en form. |
+| [getShapePermeableY()](#getShapePermeableY--) | Anger om en anslutning kan routas vertikalt genom en form. |
+| [getShapePlaceFlip()](#getShapePlaceFlip--) | Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn). |
+| [getShapePlaceStyle()](#getShapePlaceStyle--) | Bestämmer placeringsstil för underordnade. |
+| [getShapePlowCode()](#getShapePlowCode--) | Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan. |
+| [getShapeRouteStyle()](#getShapeRouteStyle--) | Specificerar routningsstil och riktning för en anslutning på ritningssidan. |
+| [getShapeSplit()](#getShapeSplit--) | Bestämmer om denna form kan dela former som kan delas. |
+| [getShapeSplittable()](#getShapeSplittable--) | Bestämmer om denna 1‑D‑form kan delas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/layout\#getDel--) |
+| [setShapePlaceStyle(ShapePlaceStyle value)](#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-) | För beskrivningen av den här egenskapen, se [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConFixedCode() {#getConFixedCode--}
+```
+public ConFixedCode getConFixedCode()
+```
+
+
+Bestämmer när en anslutning omdirigeras.
+
+**Returns:**
+[ConFixedCode](../../com.aspose.diagram/confixedcode)
+### getConLineJumpCode() {#getConLineJumpCode--}
+```
+public ConLineJumpCode getConLineJumpCode()
+```
+
+
+Bestämmer om en anslutning hoppar när två anslutningar korsar,
+
+**Returns:**
+[ConLineJumpCode](../../com.aspose.diagram/conlinejumpcode)
+### getConLineJumpDirX() {#getConLineJumpDirX--}
+```
+public ConLineJumpDirX getConLineJumpDirX()
+```
+
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett horisontellt segment av en dynamisk anslutning.
+
+**Returns:**
+[ConLineJumpDirX](../../com.aspose.diagram/conlinejumpdirx)
+### getConLineJumpDirY() {#getConLineJumpDirY--}
+```
+public ConLineJumpDirY getConLineJumpDirY()
+```
+
+
+Bestämmer linjesprångens riktning för linjesprång som uppstår på ett vertikalt segment av en dynamisk anslutning.
+
+**Returns:**
+[ConLineJumpDirY](../../com.aspose.diagram/conlinejumpdiry)
+### getConLineJumpStyle() {#getConLineJumpStyle--}
+```
+public ConLineJumpStyle getConLineJumpStyle()
+```
+
+
+Bestämmer linjesprångens stil för linjesprång på en dynamisk anslutning.
+
+**Returns:**
+[ConLineJumpStyle](../../com.aspose.diagram/conlinejumpstyle)
+### getConLineRouteExt() {#getConLineRouteExt--}
+```
+public ConLineRouteExt getConLineRouteExt()
+```
+
+
+Bestämmer utseendet på en anslutning.
+
+**Returns:**
+[ConLineRouteExt](../../com.aspose.diagram/conlinerouteext)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDisplayLevel() {#getDisplayLevel--}
+```
+public IntValue getDisplayLevel()
+```
+
+
+Bestämmer visningsnivåbandet (det relativa intervallet för Z-ordningsgruppering) för formen.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getRelationships() {#getRelationships--}
+```
+public BoolValue getRelationships()
+```
+
+
+Lagrar relationerna mellan behållare, listor, anmärkningar och former.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeFixedCode() {#getShapeFixedCode--}
+```
+public ShapeFixedCode getShapeFixedCode()
+```
+
+
+Specificerar placeringsbeteende för en placerbar form.
+
+**Returns:**
+[ShapeFixedCode](../../com.aspose.diagram/shapefixedcode)
+### getShapePermeablePlace() {#getShapePermeablePlace--}
+```
+public BoolValue getShapePermeablePlace()
+```
+
+
+Anger om placerbara former kan placeras ovanpå en form när en användare väljer Lay Out Shapes (Shapes menu).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableX() {#getShapePermeableX--}
+```
+public BoolValue getShapePermeableX()
+```
+
+
+Anger om en anslutning kan routas horisontellt genom en form.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePermeableY() {#getShapePermeableY--}
+```
+public BoolValue getShapePermeableY()
+```
+
+
+Anger om en anslutning kan routas vertikalt genom en form.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapePlaceFlip() {#getShapePlaceFlip--}
+```
+public ShapePlaceFlip getShapePlaceFlip()
+```
+
+
+Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn).
+
+**Returns:**
+[ShapePlaceFlip](../../com.aspose.diagram/shapeplaceflip)
+### getShapePlaceStyle() {#getShapePlaceStyle--}
+```
+public ShapePlaceStyle getShapePlaceStyle()
+```
+
+
+Bestämmer placeringsstil för underordnade.
+
+**Returns:**
+[ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle)
+### getShapePlowCode() {#getShapePlowCode--}
+```
+public ShapePlowCode getShapePlowCode()
+```
+
+
+Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+
+**Returns:**
+[ShapePlowCode](../../com.aspose.diagram/shapeplowcode)
+### getShapeRouteStyle() {#getShapeRouteStyle--}
+```
+public ShapeRouteStyle getShapeRouteStyle()
+```
+
+
+Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+
+**Returns:**
+[ShapeRouteStyle](../../com.aspose.diagram/shaperoutestyle)
+### getShapeSplit() {#getShapeSplit--}
+```
+public BoolValue getShapeSplit()
+```
+
+
+Bestämmer om denna form kan dela former som kan delas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getShapeSplittable() {#getShapeSplittable--}
+```
+public BoolValue getShapeSplittable()
+```
+
+
+Bestämmer om denna 1‑D‑form kan delas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/layout\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShapePlaceStyle(ShapePlaceStyle value) {#setShapePlaceStyle-com.aspose.diagram.ShapePlaceStyle-}
+```
+public void setShapePlaceStyle(ShapePlaceStyle value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapePlaceStyle()](../../com.aspose.diagram/layout\#getShapePlaceStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapePlaceStyle](../../com.aspose.diagram/shapeplacestyle) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layoutdirection/_index.md
+++ b/swedish/java/com.aspose.diagram/layoutdirection/_index.md
@@ -1,0 +1,201 @@
+---
+title: LayoutDirection
+second_title: Aspose.Diagram för Java API-referens
+description: Används för att ange layoutens riktning.
+type: docs
+weight: 216
+url: /sv/java/com.aspose.diagram/layoutdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutDirection
+```
+
+Används för att ange layoutens riktning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Placera formen från botten till toppen. |
+| [DOWN_THEN_LEFT](#DOWN-THEN-LEFT) | Placera former först nedåt och sedan åt vänster. |
+| [DOWN_THEN_RIGHT](#DOWN-THEN-RIGHT) | Placera former först nedåt och sedan åt höger. |
+| [LEFT_THEN_DOWN](#LEFT-THEN-DOWN) | Placera former först åt vänster och sedan nedåt. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Placera formen från vänster till höger. |
+| [RIGHT_THEN_DOWN](#RIGHT-THEN-DOWN) | Placera former först åt höger och sedan nedåt. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Placera formen från höger till vänster. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Placera formen från toppen till botten. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Placera formen från botten till toppen. Det är bara meningsfullt när Flowchart-stil är vald.
+
+### DOWN_THEN_LEFT {#DOWN-THEN-LEFT}
+```
+public static final int DOWN_THEN_LEFT
+```
+
+
+Placera former först nedåt och sedan åt vänster. Det är bara meningsfullt när CompactTree-stil är vald.
+
+### DOWN_THEN_RIGHT {#DOWN-THEN-RIGHT}
+```
+public static final int DOWN_THEN_RIGHT
+```
+
+
+Placera former först nedåt och sedan åt höger. Det är bara meningsfullt när CompactTree-stil är vald.
+
+### LEFT_THEN_DOWN {#LEFT-THEN-DOWN}
+```
+public static final int LEFT_THEN_DOWN
+```
+
+
+Placera former först åt vänster och sedan nedåt. Det är bara meningsfullt när CompactTree-stil är vald.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Placera formen från vänster till höger. Det är bara meningsfullt när Flowchart‑stilen är vald.
+
+### RIGHT_THEN_DOWN {#RIGHT-THEN-DOWN}
+```
+public static final int RIGHT_THEN_DOWN
+```
+
+
+Placera former först åt höger och sedan nedåt. Det är bara meningsfullt när CompactTree‑stilen är vald.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Placera formen från höger till vänster. Det är bara meningsfullt när Flowchart‑stilen är vald.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Placera formen från toppen till botten. Det är bara meningsfullt när Flowchart‑stilen är vald.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layoutoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/layoutoptions/_index.md
@@ -1,0 +1,238 @@
+---
+title: LayoutOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Används för att ange stil och ytterligare alternativ för layout av former för att utföra Re-Layout av pagepages.
+type: docs
+weight: 217
+url: /sv/java/com.aspose.diagram/layoutoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LayoutOptions
+```
+
+Används för att specificera stil och ytterligare alternativ för layout av former för att utföra om‑layout av sida(sidor).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LayoutOptions()](#LayoutOptions--) | Initierar en ny instans av LayoutOptions. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDirection()](#getDirection--) | Används för att ange riktning för formernas layout. |
+| [getEnlargePage()](#getEnlargePage--) | Definierar om sidan behöver förstoras för att rymma ritningen eller inte. |
+| [getLayoutStyle()](#getLayoutStyle--) | Används för att specificera layoutstil. |
+| [getSpaceShapes()](#getSpaceShapes--) | Definierar avståndet mellan formerna i tum. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDirection(int value)](#setDirection-int-) | För beskrivningen av denna egenskap, se [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av denna egenskap, se [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--) |
+| [setLayoutStyle(int value)](#setLayoutStyle-int-) | För beskrivningen av denna egenskap, se [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--) |
+| [setSpaceShapes(float value)](#setSpaceShapes-float-) | För beskrivningen av denna egenskap, se [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LayoutOptions() {#LayoutOptions--}
+```
+public LayoutOptions()
+```
+
+
+Initierar en ny instans av LayoutOptions.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDirection() {#getDirection--}
+```
+public int getDirection()
+```
+
+
+Används för att ange riktning för formernas layout. Standardvärdet är TopToBottom.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Definierar om sidan behöver förstoras för att rymma ritningen eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getLayoutStyle() {#getLayoutStyle--}
+```
+public int getLayoutStyle()
+```
+
+
+Används för att ange layoutstil. Standardvärdet är FlowChart.
+
+**Returns:**
+int
+### getSpaceShapes() {#getSpaceShapes--}
+```
+public float getSpaceShapes()
+```
+
+
+Definierar avståndet mellan formerna i tum. Standardvärdet 0,3 tum ~ 7,5 mm.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDirection(int value) {#setDirection-int-}
+```
+public void setDirection(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDirection()](../../com.aspose.diagram/layoutoptions\#getDirection--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEnlargePage()](../../com.aspose.diagram/layoutoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setLayoutStyle(int value) {#setLayoutStyle-int-}
+```
+public void setLayoutStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLayoutStyle()](../../com.aspose.diagram/layoutoptions\#getLayoutStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpaceShapes(float value) {#setSpaceShapes-float-}
+```
+public void setSpaceShapes(float value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpaceShapes()](../../com.aspose.diagram/layoutoptions\#getSpaceShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/layoutstyle/_index.md
+++ b/swedish/java/com.aspose.diagram/layoutstyle/_index.md
@@ -1,0 +1,165 @@
+---
+title: LayoutStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Används för att specificera layoutstil.
+type: docs
+weight: 218
+url: /sv/java/com.aspose.diagram/layoutstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LayoutStyle
+```
+
+Används för att specificera layoutstil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CIRCULAR](#CIRCULAR) | Cirkulär stil. |
+| [COMPACT_TREE](#COMPACT-TREE) | Trädstil. |
+| [FLOW_CHART](#FLOW-CHART) | Flödesschema stil. |
+| [RADIAL](#RADIAL) | Radial stil. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Cirkulär stil.
+
+### COMPACT_TREE {#COMPACT-TREE}
+```
+public static final int COMPACT_TREE
+```
+
+
+Trädstil.
+
+### FLOW_CHART {#FLOW-CHART}
+```
+public static final int FLOW_CHART
+```
+
+
+Flödesschema stil.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial stil.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/license/_index.md
+++ b/swedish/java/com.aspose.diagram/license/_index.md
@@ -1,0 +1,188 @@
+---
+title: Licens
+second_title: Aspose.Diagram för Java API-referens
+description: Tillhandahåller metoder för att licensiera komponenten.
+type: docs
+weight: 219
+url: /sv/java/com.aspose.diagram/license/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+Tillhandahåller metoder för att licensiera komponenten.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [License()](#License--) | Initierar en ny instans av den här klassen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | Licensierar komponenten. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | Licensierar komponenten. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+Initierar en ny instans av den här klassen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+Licensierar komponenten.
+
+Använd den här metoden för att läsa in en licens från en ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | En ström som innehåller licensen. |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+Licensierar komponenten.
+
+Försöker hitta licensen på följande platser:
+
+1. Explicit sökväg.
+
+2. Mappen för komponentens assembly.
+
+3. Mappen för klientens anropande assembly.
+
+4. Mappen för startassemblyn.
+
+5. En inbäddad resurs i klientens anropande assembly.
+
+**Note:**On the .NET Compact Framework, tries to find the license only in these locations:
+
+1. Explicit sökväg.
+
+2. En inbäddad resurs i klientens anropande assembly.
+
+2. Mappen för komponentens jar‑fil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| licenseName | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lightrigdirectiontype/_index.md
+++ b/swedish/java/com.aspose.diagram/lightrigdirectiontype/_index.md
@@ -1,0 +1,201 @@
+---
+title: LightRigDirectionType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av ljusrigg‑riktning.
+type: docs
+weight: 220
+url: /sv/java/com.aspose.diagram/lightrigdirectiontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LightRigDirectionType
+```
+
+Representerar typen av ljusrigg‑riktning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Nederst |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Nederst vänster. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Nederst höger. |
+| [LEFT](#LEFT) | Vänster. |
+| [RIGHT](#RIGHT) | Höger. |
+| [TOP](#TOP) | Topp. |
+| [TOP_LEFT](#TOP-LEFT) | Topp vänster. |
+| [TOP_RIGHT](#TOP-RIGHT) | Topp höger. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Nederst
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Nederst vänster.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Nederst höger.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Vänster.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Höger.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Topp.
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Topp vänster.
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Topp höger.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/line/_index.md
+++ b/swedish/java/com.aspose.diagram/line/_index.md
@@ -1,0 +1,447 @@
+---
+title: Line
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar generell placeringsinformation om en form.
+type: docs
+weight: 221
+url: /sv/java/com.aspose.diagram/line/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Line
+```
+
+Innehåller element som specificerar generell placeringsinformation om en form.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginArrow()](#getBeginArrow--) | Anger om en linje har en pilspets eller annat linjeändformat vid dess första hörn. |
+| [getBeginArrowSize()](#getBeginArrowSize--) | Bestämmer storleken på pilspetsen i början av linjen. |
+| [getClass()](#getClass--) |  |
+| [getCompoundType()](#getCompoundType--) | Anger linjens CompoundType för formen. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getEndArrow()](#getEndArrow--) | Anger om en linje har en pilspets eller annat linjeändformat vid dess sista hörn. |
+| [getEndArrowSize()](#getEndArrowSize--) | Anger storleken på pilspetsen i slutet av linjen. |
+| [getGradientLine()](#getGradientLine--) | Innehåller de aktuella gradientlinjeformateringsvärdena för formen |
+| [getLineCap()](#getLineCap--) | Anger om en linje har rundade eller fyrkantiga linjeändar. |
+| [getLineColor()](#getLineColor--) | Anger linjens färg för formen. |
+| [getLineColorTrans()](#getLineColorTrans--) | Anger transparensnivån för en formes linjefärg, från 0 (opak) till 1 (helt transparent). |
+| [getLinePattern()](#getLinePattern--) | Anger linjemönstret för formen |
+| [getLineWeight()](#getLineWeight--) | Anger linjens tjocklek för en form. |
+| [getRounding()](#getRounding--) | Anger radien på den avrundningsbåge som tillämpas där två sammanhängande segment av en bana möts. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginArrow(IntValue value)](#setBeginArrow-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--) |
+| [setBeginArrowSize(ArrowSize value)](#setBeginArrowSize-com.aspose.diagram.ArrowSize-) | För beskrivningen av denna egenskap, se [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--) |
+| [setCompoundType(CompoundType value)](#setCompoundType-com.aspose.diagram.CompoundType-) | För beskrivningen av denna egenskap, se [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/line\#getDel--) |
+| [setEndArrow(IntValue value)](#setEndArrow-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--) |
+| [setEndArrowSize(ArrowSize value)](#setEndArrowSize-com.aspose.diagram.ArrowSize-) | För beskrivningen av denna egenskap, se [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--) |
+| [setLineCap(BoolValue value)](#setLineCap-com.aspose.diagram.BoolValue-) | För beskrivningen av denna egenskap, se [getLineCap()](../../com.aspose.diagram/line\#getLineCap--) |
+| [setLineColor(ColorValue value)](#setLineColor-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getLineColor()](../../com.aspose.diagram/line\#getLineColor--) |
+| [setLineColorTrans(DoubleValue value)](#setLineColorTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--) |
+| [setLinePattern(IntValue value)](#setLinePattern-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--) |
+| [setLineWeight(DoubleValue value)](#setLineWeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--) |
+| [setRounding(DoubleValue value)](#setRounding-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getRounding()](../../com.aspose.diagram/line\#getRounding--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginArrow() {#getBeginArrow--}
+```
+public IntValue getBeginArrow()
+```
+
+
+Anger om en linje har en pilspets eller annat linjeändformat vid dess första hörn. Ange ett tal från 0 till 45 eller USE-funktionen med namnet på en anpassad linjeände.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBeginArrowSize() {#getBeginArrowSize--}
+```
+public ArrowSize getBeginArrowSize()
+```
+
+
+Bestämmer storleken på pilspetsen i början av linjen. Ange ett tal mellan 0 och 6.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompoundType() {#getCompoundType--}
+```
+public CompoundType getCompoundType()
+```
+
+
+Anger linjens CompoundType för formen.
+
+**Returns:**
+[CompoundType](../../com.aspose.diagram/compoundtype)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getEndArrow() {#getEndArrow--}
+```
+public IntValue getEndArrow()
+```
+
+
+Anger om en linje har en pilspets eller annat linjeändformat vid dess sista hörn.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getEndArrowSize() {#getEndArrowSize--}
+```
+public ArrowSize getEndArrowSize()
+```
+
+
+Anger storleken på pilspetsen i slutet av linjen.
+
+**Returns:**
+[ArrowSize](../../com.aspose.diagram/arrowsize)
+### getGradientLine() {#getGradientLine--}
+```
+public GradientFill getGradientLine()
+```
+
+
+Innehåller de aktuella gradientlinjeformateringsvärdena för formen
+
+**Returns:**
+[GradientFill](../../com.aspose.diagram/gradientfill)
+### getLineCap() {#getLineCap--}
+```
+public BoolValue getLineCap()
+```
+
+
+Anger om en linje har rundade eller fyrkantiga linjeändar.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineColor() {#getLineColor--}
+```
+public ColorValue getLineColor()
+```
+
+
+Anger linjens färg för formen.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getLineColorTrans() {#getLineColorTrans--}
+```
+public DoubleValue getLineColorTrans()
+```
+
+
+Anger genomskinlighetsnivån för en formes linjefärg, från 0 (opak) till 1 (helt genomskinlig). Standardvärdet är 0.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLinePattern() {#getLinePattern--}
+```
+public IntValue getLinePattern()
+```
+
+
+Anger linjemönstret för formen
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLineWeight() {#getLineWeight--}
+```
+public DoubleValue getLineWeight()
+```
+
+
+Anger linjebredden för en form. Linjebredden är oberoende av ritningens skala. Om ritningen skalas förblir linjebredden densamma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRounding() {#getRounding--}
+```
+public DoubleValue getRounding()
+```
+
+
+Anger radien på den avrundningsbåge som tillämpas där två sammanhängande segment av en bana möts. Till exempel kan avrundning användas för att ge en rektangel rundade hörn.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginArrow(IntValue value) {#setBeginArrow-com.aspose.diagram.IntValue-}
+```
+public void setBeginArrow(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBeginArrow()](../../com.aspose.diagram/line\#getBeginArrow--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBeginArrowSize(ArrowSize value) {#setBeginArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setBeginArrowSize(ArrowSize value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBeginArrowSize()](../../com.aspose.diagram/line\#getBeginArrowSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setCompoundType(CompoundType value) {#setCompoundType-com.aspose.diagram.CompoundType-}
+```
+public void setCompoundType(CompoundType value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCompoundType()](../../com.aspose.diagram/line\#getCompoundType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [CompoundType](../../com.aspose.diagram/compoundtype) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/line\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEndArrow(IntValue value) {#setEndArrow-com.aspose.diagram.IntValue-}
+```
+public void setEndArrow(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEndArrow()](../../com.aspose.diagram/line\#getEndArrow--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setEndArrowSize(ArrowSize value) {#setEndArrowSize-com.aspose.diagram.ArrowSize-}
+```
+public void setEndArrowSize(ArrowSize value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEndArrowSize()](../../com.aspose.diagram/line\#getEndArrowSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ArrowSize](../../com.aspose.diagram/arrowsize) |  |
+
+### setLineCap(BoolValue value) {#setLineCap-com.aspose.diagram.BoolValue-}
+```
+public void setLineCap(BoolValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineCap()](../../com.aspose.diagram/line\#getLineCap--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setLineColor(ColorValue value) {#setLineColor-com.aspose.diagram.ColorValue-}
+```
+public void setLineColor(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineColor()](../../com.aspose.diagram/line\#getLineColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setLineColorTrans(DoubleValue value) {#setLineColorTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setLineColorTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineColorTrans()](../../com.aspose.diagram/line\#getLineColorTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLinePattern(IntValue value) {#setLinePattern-com.aspose.diagram.IntValue-}
+```
+public void setLinePattern(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLinePattern()](../../com.aspose.diagram/line\#getLinePattern--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setLineWeight(DoubleValue value) {#setLineWeight-com.aspose.diagram.DoubleValue-}
+```
+public void setLineWeight(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineWeight()](../../com.aspose.diagram/line\#getLineWeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRounding(DoubleValue value) {#setRounding-com.aspose.diagram.DoubleValue-}
+```
+public void setRounding(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRounding()](../../com.aspose.diagram/line\#getRounding--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lineadjustfrom/_index.md
+++ b/swedish/java/com.aspose.diagram/lineadjustfrom/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustFrom
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+type: docs
+weight: 222
+url: /sv/java/com.aspose.diagram/lineadjustfrom/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustFrom
+```
+
+Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineAdjustFrom(int value)](#LineAdjustFrom-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustFrom(int value) {#LineAdjustFrom-int-}
+```
+public LineAdjustFrom(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/lineadjustfrom\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lineadjustfromvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/lineadjustfromvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LineAdjustFromValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+type: docs
+weight: 223
+url: /sv/java/com.aspose.diagram/lineadjustfromvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustFromValue
+```
+
+Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALL_LINES](#ALL-LINES) | Alla linjer. |
+| [NO_LINES](#NO-LINES) | Inga linjer. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Standard för routningsstil. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [UNRELATED_LINES](#UNRELATED-LINES) | Orelaterade rader. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES {#ALL-LINES}
+```
+public static final int ALL_LINES
+```
+
+
+Alla linjer.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Inga linjer.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Standard för routningsstil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### UNRELATED_LINES {#UNRELATED-LINES}
+```
+public static final int UNRELATED_LINES
+```
+
+
+Orelaterade rader.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lineadjustto/_index.md
+++ b/swedish/java/com.aspose.diagram/lineadjustto/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineAdjustTo
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+type: docs
+weight: 224
+url: /sv/java/com.aspose.diagram/lineadjustto/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineAdjustTo
+```
+
+Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineAdjustTo(int value)](#LineAdjustTo-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineAdjustTo(int value) {#LineAdjustTo-int-}
+```
+public LineAdjustTo(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/lineadjustto\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lineadjusttovalue/_index.md
+++ b/swedish/java/com.aspose.diagram/lineadjusttovalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: LinjeJusteraTillVärde
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+type: docs
+weight: 225
+url: /sv/java/com.aspose.diagram/lineadjusttovalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineAdjustToValue
+```
+
+Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALL_LINES_CLOSE](#ALL-LINES-CLOSE) | Alla linjer som ligger nära varandra. |
+| [NO_LINES](#NO-LINES) | Inga linjer. |
+| [RELATEDLINES](#RELATEDLINES) | Relaterade linjer. |
+| [ROUTING_STYLE_DEFAULT](#ROUTING-STYLE-DEFAULT) | Standard för routningsstil. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_LINES_CLOSE {#ALL-LINES-CLOSE}
+```
+public static final int ALL_LINES_CLOSE
+```
+
+
+Alla linjer som ligger nära varandra.
+
+### NO_LINES {#NO-LINES}
+```
+public static final int NO_LINES
+```
+
+
+Inga linjer.
+
+### RELATEDLINES {#RELATEDLINES}
+```
+public static final int RELATEDLINES
+```
+
+
+Relaterade linjer.
+
+### ROUTING_STYLE_DEFAULT {#ROUTING-STYLE-DEFAULT}
+```
+public static final int ROUTING_STYLE_DEFAULT
+```
+
+
+Standard för routningsstil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linejumpcode/_index.md
+++ b/swedish/java/com.aspose.diagram/linejumpcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpCode
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+type: docs
+weight: 226
+url: /sv/java/com.aspose.diagram/linejumpcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpCode
+```
+
+Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineJumpCode(int value)](#LineJumpCode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpCode(int value) {#LineJumpCode-int-}
+```
+public LineJumpCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/linejumpcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linejumpcodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/linejumpcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: LineJumpCodeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+type: docs
+weight: 227
+url: /sv/java/com.aspose.diagram/linejumpcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpCodeValue
+```
+
+Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FIRST_DISPLAYED_LINE](#FIRST-DISPLAYED-LINE) | Första visade linjen (nedre formen i visningsordningen). |
+| [HORIZONTAL_LINES](#HORIZONTAL-LINES) | Horisontella linjer. |
+| [LAST_DISPLAYED_LINE](#LAST-DISPLAYED-LINE) | Sista visade linjen (övre formen i visningsordningen). |
+| [LAST_ROUTED_LINE](#LAST-ROUTED-LINE) | Sista ruttade linjen. |
+| [NONE](#NONE) | Ingen. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VERTICAL_LINES](#VERTICAL-LINES) | Vertikala linjer. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FIRST_DISPLAYED_LINE {#FIRST-DISPLAYED-LINE}
+```
+public static final int FIRST_DISPLAYED_LINE
+```
+
+
+Första visade linjen (nedre formen i visningsordningen).
+
+### HORIZONTAL_LINES {#HORIZONTAL-LINES}
+```
+public static final int HORIZONTAL_LINES
+```
+
+
+Horisontella linjer.
+
+### LAST_DISPLAYED_LINE {#LAST-DISPLAYED-LINE}
+```
+public static final int LAST_DISPLAYED_LINE
+```
+
+
+Sista visade linjen (övre formen i visningsordningen).
+
+### LAST_ROUTED_LINE {#LAST-ROUTED-LINE}
+```
+public static final int LAST_ROUTED_LINE
+```
+
+
+Sista ruttade linjen.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VERTICAL_LINES {#VERTICAL-LINES}
+```
+public static final int VERTICAL_LINES
+```
+
+
+Vertikala linjer.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linejumpstyle/_index.md
+++ b/swedish/java/com.aspose.diagram/linejumpstyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineJumpStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Anger linjhoppsstilen för alla anslutningar på ritningssidan som inte har en lokal linjhoppsstil.
+type: docs
+weight: 228
+url: /sv/java/com.aspose.diagram/linejumpstyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineJumpStyle
+```
+
+Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineJumpStyle(int value)](#LineJumpStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineJumpStyle(int value) {#LineJumpStyle-int-}
+```
+public LineJumpStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/linejumpstyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linejumpstylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/linejumpstylevalue/_index.md
@@ -1,0 +1,228 @@
+---
+title: LineJumpStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger linjhoppsstilen för alla anslutningar på ritningssidan som inte har en lokal linjhoppsstil.
+type: docs
+weight: 229
+url: /sv/java/com.aspose.diagram/linejumpstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineJumpStyleValue
+```
+
+Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ARC](#ARC) | Båge. |
+| [DEFAULT](#DEFAULT) | Standard. |
+| [GAP](#GAP) | Mellanrum. |
+| [SIDES_2](#SIDES-2) | 2 sidor. |
+| [SIDES_3](#SIDES-3) | 3 sidor. |
+| [SIDES_4](#SIDES-4) | 4 sidor. |
+| [SIDES_5](#SIDES-5) | 5 sidor. |
+| [SIDES_6](#SIDES-6) | 6 sidor. |
+| [SIDES_7](#SIDES-7) | 7 sidor. |
+| [SQUARE](#SQUARE) | Fyrkant. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ARC {#ARC}
+```
+public static final int ARC
+```
+
+
+Båge.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard.
+
+### GAP {#GAP}
+```
+public static final int GAP
+```
+
+
+Mellanrum.
+
+### SIDES_2 {#SIDES-2}
+```
+public static final int SIDES_2
+```
+
+
+2 sidor.
+
+### SIDES_3 {#SIDES-3}
+```
+public static final int SIDES_3
+```
+
+
+3 sidor.
+
+### SIDES_4 {#SIDES-4}
+```
+public static final int SIDES_4
+```
+
+
+4 sidor.
+
+### SIDES_5 {#SIDES-5}
+```
+public static final int SIDES_5
+```
+
+
+5 sidor.
+
+### SIDES_6 {#SIDES-6}
+```
+public static final int SIDES_6
+```
+
+
+6 sidor.
+
+### SIDES_7 {#SIDES-7}
+```
+public static final int SIDES_7
+```
+
+
+7 sidor.
+
+### SQUARE {#SQUARE}
+```
+public static final int SQUARE
+```
+
+
+Fyrkant.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linerouteext/_index.md
+++ b/swedish/java/com.aspose.diagram/linerouteext/_index.md
@@ -1,0 +1,179 @@
+---
+title: LineRouteExt
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar standardutseendet för alla anslutningar på en sida.
+type: docs
+weight: 230
+url: /sv/java/com.aspose.diagram/linerouteext/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LineRouteExt
+```
+
+Specificerar standardutseendet för alla anslutningar på en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineRouteExt(int value)](#LineRouteExt-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar standardutseendet för alla anslutningar på en sida. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/linerouteext\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineRouteExt(int value) {#LineRouteExt-int-}
+```
+public LineRouteExt(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar standardutseendet för alla anslutningar på en sida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/linerouteext\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linerouteextvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/linerouteextvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LineRouteExtValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar standardutseendet för alla anslutningar på en sida.
+type: docs
+weight: 231
+url: /sv/java/com.aspose.diagram/linerouteextvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LineRouteExtValue
+```
+
+Specificerar standardutseendet för alla anslutningar på en sida.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CURVED](#CURVED) | Kurvig. |
+| [DEFAULT](#DEFAULT) | Standard. |
+| [STRAIGHT](#STRAIGHT) | Rak. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURVED {#CURVED}
+```
+public static final int CURVED
+```
+
+
+Kurvig.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Standard.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Rak.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/lineto/_index.md
+++ b/swedish/java/com.aspose.diagram/lineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: LineTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment.
+type: docs
+weight: 232
+url: /sv/java/com.aspose.diagram/lineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class LineTo extends Coordinate
+```
+
+Innehåller x- och y-koordinater för den avslutande vertexen i ett rakt linjesegment. Dessa koordinater finns i X- respektive Y-elementen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LineTo()](#LineTo--) | Skapar en instans av [LineTo](../../com.aspose.diagram/lineto) klass. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment. |
+| [getY()](#getY--) | Y-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/lineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/lineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/lineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/lineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LineTo() {#LineTo--}
+```
+public LineTo()
+```
+
+
+Skapar en instans av [LineTo](../../com.aspose.diagram/lineto) klass.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/lineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/lineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/lineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/lineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/linetocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/linetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: LineToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: LineTo-samling.
+type: docs
+weight: 233
+url: /sv/java/com.aspose.diagram/linetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class LineToCollection extends Collection
+```
+
+LineTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public LineTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[LineTo](../../com.aspose.diagram/lineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/listboxactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/listboxactivexcontrol/_index.md
@@ -1,0 +1,772 @@
+---
+title: ListBoxActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en ListBox ActiveX‑kontroll.
+type: docs
+weight: 234
+url: /sv/java/com.aspose.diagram/listboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ListBoxActiveXControl extends ActiveXControl
+```
+
+Representerar en ListBox ActiveX‑kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderOleColor()](#getBorderOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderStyle()](#getBorderStyle--) | typen av ram som används av kontrollen. |
+| [getBoundColumn()](#getBoundColumn--) | Representerar hur Value‑egenskapen bestäms för en ComboBox eller ListBox när MultiSelect‑egenskapens värde (fmMultiSelectSingle). |
+| [getClass()](#getClass--) |  |
+| [getColumnCount()](#getColumnCount--) | Representerar antalet kolumner som ska visas i en ComboBox eller ListBox. |
+| [getColumnWidths()](#getColumnWidths--) | bredden på kolumnen. |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indikerar om kontrollen endast visar kompletta textrader utan att visa några partiella rader. |
+| [getListStyle()](#getListStyle--) | det visuella utseendet. |
+| [getListWidth()](#getListWidth--) | bredden i enheten punkter. |
+| [getMatchEntry()](#getMatchEntry--) | Indikerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getScrollBars()](#getScrollBars--) | Indikerar om kontrollen har vertikala rullningslister, horisontella rullningslister, båda eller ingen. |
+| [getShowColumnHeads()](#getShowColumnHeads--) | Indikerar om kolumnrubriker visas. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getTextColumn()](#getTextColumn--) | Representerar kolumnen i en ComboBox eller ListBox som ska visas för användaren. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getValue()](#getValue--) | värdet för kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--) |
+| [setBoundColumn(int value)](#setBoundColumn-int-) | För beskrivningen av den här egenskapen, se [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--) |
+| [setColumnCount(int value)](#setColumnCount-int-) | För beskrivningen av den här egenskapen, se [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--) |
+| [setColumnWidths(double value)](#setColumnWidths-double-) | För beskrivningen av den här egenskapen, se [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | För beskrivningen av den här egenskapen, se [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--) |
+| [setListStyle(int value)](#setListStyle-int-) | För beskrivningen av den här egenskapen, se [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--) |
+| [setListWidth(double value)](#setListWidth-double-) | För beskrivningen av den här egenskapen, se [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMatchEntry(int value)](#setMatchEntry-int-) | För beskrivningen av den här egenskapen, se [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | För beskrivningen av den här egenskapen, se [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--) |
+| [setShowColumnHeads(boolean value)](#setShowColumnHeads-boolean-) | För beskrivningen av den här egenskapen, se [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--) |
+| [setTextColumn(int value)](#setTextColumn-int-) | För beskrivningen av den här egenskapen, se [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+typen av ram som används av kontrollen.
+
+**Returns:**
+int
+### getBoundColumn() {#getBoundColumn--}
+```
+public int getBoundColumn()
+```
+
+
+Representerar hur Value‑egenskapen bestäms för en ComboBox eller ListBox när MultiSelect‑egenskapens värde (fmMultiSelectSingle).
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColumnCount() {#getColumnCount--}
+```
+public int getColumnCount()
+```
+
+
+Representerar antalet kolumner som ska visas i en ComboBox eller ListBox.
+
+**Returns:**
+int
+### getColumnWidths() {#getColumnWidths--}
+```
+public double getColumnWidths()
+```
+
+
+bredden på kolumnen.
+
+**Returns:**
+double
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indikerar om kontrollen endast visar kompletta textrader utan att visa några partiella rader.
+
+**Returns:**
+boolean
+### getListStyle() {#getListStyle--}
+```
+public int getListStyle()
+```
+
+
+det visuella utseendet.
+
+**Returns:**
+int
+### getListWidth() {#getListWidth--}
+```
+public double getListWidth()
+```
+
+
+bredden i enheten punkter.
+
+**Returns:**
+double
+### getMatchEntry() {#getMatchEntry--}
+```
+public int getMatchEntry()
+```
+
+
+Indikerar hur en ListBox eller ComboBox söker i sin lista när användaren skriver.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indikerar om kontrollen har vertikala rullningslister, horisontella rullningslister, båda eller ingen.
+
+**Returns:**
+int
+### getShowColumnHeads() {#getShowColumnHeads--}
+```
+public boolean getShowColumnHeads()
+```
+
+
+Indikerar om kolumnrubriker visas.
+
+**Returns:**
+boolean
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getTextColumn() {#getTextColumn--}
+```
+public int getTextColumn()
+```
+
+
+Representerar kolumnen i en ComboBox eller ListBox som ska visas för användaren.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+värdet för kontrollen.
+
+**Returns:**
+java.lang.String
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderOleColor()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBorderStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBoundColumn(int value) {#setBoundColumn-int-}
+```
+public void setBoundColumn(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBoundColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getBoundColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setColumnCount(int value) {#setColumnCount-int-}
+```
+public void setColumnCount(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getColumnCount()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setColumnWidths(double value) {#setColumnWidths-double-}
+```
+public void setColumnWidths(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getColumnWidths()](../../com.aspose.diagram/listboxactivexcontrol\#getColumnWidths--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIntegralHeight()](../../com.aspose.diagram/listboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setListStyle(int value) {#setListStyle-int-}
+```
+public void setListStyle(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getListStyle()](../../com.aspose.diagram/listboxactivexcontrol\#getListStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setListWidth(double value) {#setListWidth-double-}
+```
+public void setListWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getListWidth()](../../com.aspose.diagram/listboxactivexcontrol\#getListWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMatchEntry(int value) {#setMatchEntry-int-}
+```
+public void setMatchEntry(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMatchEntry()](../../com.aspose.diagram/listboxactivexcontrol\#getMatchEntry--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getScrollBars()](../../com.aspose.diagram/listboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowColumnHeads(boolean value) {#setShowColumnHeads-boolean-}
+```
+public void setShowColumnHeads(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowColumnHeads()](../../com.aspose.diagram/listboxactivexcontrol\#getShowColumnHeads--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSpecialEffect()](../../com.aspose.diagram/listboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTextColumn(int value) {#setTextColumn-int-}
+```
+public void setTextColumn(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTextColumn()](../../com.aspose.diagram/listboxactivexcontrol\#getTextColumn--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/listboxactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/loadfileformat/_index.md
+++ b/swedish/java/com.aspose.diagram/loadfileformat/_index.md
@@ -1,0 +1,246 @@
+---
+title: LoadFileFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Enumeration för val av diagramformat vid inläsning.
+type: docs
+weight: 235
+url: /sv/java/com.aspose.diagram/loadfileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LoadFileFormat
+```
+
+Enumeration för val av diagramformat vid inläsning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [VDW](#VDW) | MS Visio Vdw webbritningsformat. |
+| [VDX](#VDX) | MS Visio VDX xml-format. |
+| [VSD](#VSD) | MS Visio Vsd binärt format. |
+| [VSDM](#VSDM) | MS Visio Vsdm-filformat som möjliggör makron. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx-filformat. |
+| [VSS](#VSS) | MS Visio Vss binärt stencilformat. |
+| [VSSM](#VSSM) | MS Visio Vssm-filformat som möjliggör makron. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx filformat. |
+| [VST](#VST) | MS Visio Vst binärt mallformat. |
+| [VSTM](#VSTM) | MS Visio Vstm-filformat som möjliggör makron. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx mallfilformat. |
+| [VSX](#VSX) | MS Visio Vsx xml-stencilformat. |
+| [VTX](#VTX) | MS Visio Vtx xml-mallformat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VDW {#VDW}
+```
+public static final int VDW
+```
+
+
+MS Visio Vdw webbritningsformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio VDX xml-format.
+
+### VSD {#VSD}
+```
+public static final int VSD
+```
+
+
+MS Visio Vsd binärt format.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm-filformat som möjliggör makron.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx-filformat.
+
+### VSS {#VSS}
+```
+public static final int VSS
+```
+
+
+MS Visio Vss binärt stencilformat.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm-filformat som möjliggör makron.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx filformat.
+
+### VST {#VST}
+```
+public static final int VST
+```
+
+
+MS Visio Vst binärt mallformat.
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm-filformat som möjliggör makron.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx mallfilformat.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml-stencilformat.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vtx xml-mallformat.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/loadoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/loadoptions/_index.md
@@ -1,0 +1,252 @@
+---
+title: LoadOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när ett diagram läses in i ett Diagram‑objekt.
+type: docs
+weight: 236
+url: /sv/java/com.aspose.diagram/loadoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LoadOptions
+```
+
+Tillåter att ange ytterligare alternativ när ett diagram läses in i ett Diagram‑objekt.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LoadOptions()](#LoadOptions--) | Initierar en ny instans av den här klassen med standardvärden. |
+| [LoadOptions(int format)](#LoadOptions-int-) | Initierar en ny instans av den här klassen med det angivna formatet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getInterruptMonitor()](#getInterruptMonitor--) | avbrottsmontorn. |
+| [getLoadFormat()](#getLoadFormat--) | Anger formatet för diagrammet som ska laddas. |
+| [getLocale()](#getLocale--) | den Locale som användes för diagrammet när filen laddades. |
+| [getPages()](#getPages--) | Anger indexet för de sidor som ska laddas. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInterruptMonitor(AbstractInterruptMonitor value)](#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-) | För beskrivningen av denna egenskap, se [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--) |
+| [setLoadFormat(int value)](#setLoadFormat-int-) | För beskrivningen av denna egenskap, se [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--) |
+| [setLocale(Locale value)](#setLocale-java.util.Locale-) | För beskrivningen av denna egenskap, se [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--) |
+| [setPages(ArrayList value)](#setPages-java.util.ArrayList-) | För beskrivningen av denna egenskap, se [getPages()](../../com.aspose.diagram/loadoptions\#getPages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LoadOptions() {#LoadOptions--}
+```
+public LoadOptions()
+```
+
+
+Initierar en ny instans av den här klassen med standardvärden. Standardfilformatet är satt till Aspose.Diagram.LoadFileFormat.
+
+### LoadOptions(int format) {#LoadOptions-int-}
+```
+public LoadOptions(int format)
+```
+
+
+Initierar en ny instans av den här klassen med det angivna formatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| format | int | Aspose.Diagram.LoadFileFormat laddningsfilformat. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInterruptMonitor() {#getInterruptMonitor--}
+```
+public AbstractInterruptMonitor getInterruptMonitor()
+```
+
+
+avbrottsmontorn.
+
+**Returns:**
+[AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor)
+### getLoadFormat() {#getLoadFormat--}
+```
+public int getLoadFormat()
+```
+
+
+Anger formatet för diagrammet som ska laddas. Standard är Aspose.Diagram.LoadFileFormat. Läs/skriv Aspose.Diagram.LoadFileFormat.
+
+**Returns:**
+int
+### getLocale() {#getLocale--}
+```
+public Locale getLocale()
+```
+
+
+den Locale som användes för diagrammet när filen laddades.
+
+**Returns:**
+java.util.Locale
+### getPages() {#getPages--}
+```
+public ArrayList getPages()
+```
+
+
+Anger indexet för de sidor som ska laddas.
+
+**Returns:**
+java.util.ArrayList
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInterruptMonitor(AbstractInterruptMonitor value) {#setInterruptMonitor-com.aspose.diagram.AbstractInterruptMonitor-}
+```
+public void setInterruptMonitor(AbstractInterruptMonitor value)
+```
+
+
+För beskrivningen av denna egenskap, se [getInterruptMonitor()](../../com.aspose.diagram/loadoptions\#getInterruptMonitor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [AbstractInterruptMonitor](../../com.aspose.diagram/abstractinterruptmonitor) |  |
+
+### setLoadFormat(int value) {#setLoadFormat-int-}
+```
+public void setLoadFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLoadFormat()](../../com.aspose.diagram/loadoptions\#getLoadFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocale(Locale value) {#setLocale-java.util.Locale-}
+```
+public void setLocale(Locale value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLocale()](../../com.aspose.diagram/loadoptions\#getLocale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.Locale |  |
+
+### setPages(ArrayList value) {#setPages-java.util.ArrayList-}
+```
+public void setPages(ArrayList value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPages()](../../com.aspose.diagram/loadoptions\#getPages--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.ArrayList |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/localizefont/_index.md
+++ b/swedish/java/com.aspose.diagram/localizefont/_index.md
@@ -1,0 +1,204 @@
+---
+title: LocalizeFont
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om formtexten ska lokalanpassas och översättas till ett annat språk.
+type: docs
+weight: 237
+url: /sv/java/com.aspose.diagram/localizefont/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class LocalizeFont
+```
+
+Anger om formtexten ska lokaliseras (översättas till ett annat språk).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [LocalizeFont(int value)](#LocalizeFont-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger om formtexten ska lokaliseras (översättas till ett annat språk). |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/localizefont\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LocalizeFont(int value) {#LocalizeFont-int-}
+```
+public LocalizeFont(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om formtexten ska lokaliseras (översättas till ett annat språk).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/localizefont\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/localizefont\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/localizefontvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/localizefontvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: LocalizeFontValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om formtexten ska lokalanpassas och översättas till ett annat språk.
+type: docs
+weight: 238
+url: /sv/java/com.aspose.diagram/localizefontvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class LocalizeFontValue
+```
+
+Anger om formtexten ska lokaliseras (översättas till ett annat språk).
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALWAYS_LOCALIZE_FONT](#ALWAYS-LOCALIZE-FONT) | Lokalanpassa alltid teckensnittet. |
+| [LOCALIZE_FONT_ONLY_ARIAL_SYMBOL](#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL) | Lokalanpassa teckensnittet endast om det är Arial eller Symbol (standard). |
+| [NEVER_LOCALIZE_FONT](#NEVER-LOCALIZE-FONT) | Lokalanpassa aldrig teckensnittet. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_LOCALIZE_FONT {#ALWAYS-LOCALIZE-FONT}
+```
+public static final int ALWAYS_LOCALIZE_FONT
+```
+
+
+Lokalanpassa alltid teckensnittet.
+
+### LOCALIZE_FONT_ONLY_ARIAL_SYMBOL {#LOCALIZE-FONT-ONLY-ARIAL-SYMBOL}
+```
+public static final int LOCALIZE_FONT_ONLY_ARIAL_SYMBOL
+```
+
+
+Lokalanpassa teckensnittet endast om det är Arial eller Symbol (standard).
+
+### NEVER_LOCALIZE_FONT {#NEVER-LOCALIZE-FONT}
+```
+public static final int NEVER_LOCALIZE_FONT
+```
+
+
+Lokalanpassa aldrig teckensnittet.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/margin/_index.md
+++ b/swedish/java/com.aspose.diagram/margin/_index.md
@@ -1,0 +1,194 @@
+---
+title: Margin
+second_title: Aspose.Diagram för Java API-referens
+description: Anger marginalen.
+type: docs
+weight: 239
+url: /sv/java/com.aspose.diagram/margin/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Margin
+```
+
+Anger marginalen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Margin(double value, int unit)](#Margin-double-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUnit()](#getUnit--) | Representerar en måttenhet. |
+| [getValue()](#getValue--) | Anger marginalen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUnit(int value)](#setUnit-int-) | För beskrivningen av den här egenskapen, se [getUnit()](../../com.aspose.diagram/margin\#getUnit--) |
+| [setValue(double value)](#setValue-double-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/margin\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Margin(double value, int unit) {#Margin-double-int-}
+```
+public Margin(double value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+| enhet | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Representerar en måttenhet. Standardvärdet är DP.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public double getValue()
+```
+
+
+Anger marginalen.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUnit()](../../com.aspose.diagram/margin\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setValue(double value) {#setValue-double-}
+```
+public void setValue(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/margin\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/master/_index.md
+++ b/swedish/java/com.aspose.diagram/master/_index.md
@@ -1,0 +1,516 @@
+---
+title: Master
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som definierar en master för dokumentet.
+type: docs
+weight: 240
+url: /sv/java/com.aspose.diagram/master/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Master
+```
+
+Innehåller element som definierar en master för dokumentet. En master är en form på en mall som du använder upprepade gånger för att skapa ritningar. När du drar en form från en mall till ritningssidan blir formen en instans av den mastern, och en lokal kopia av mastern inkluderas i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Master()](#Master--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [dispose()](#dispose--) | Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Anger om masterns text i mallfönstret är vänsterjusterad, högerjusterad eller centrerad. |
+| [getBaseID()](#getBaseID--) | En GUID (globalt unik identifierare) som identifierar mastern över dokument. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Innehåller ett Connect-element för varje anslutning mellan två former i en ritning. |
+| [getHidden()](#getHidden--) | Anger om mastern är dold i användargränssnittet. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIcon()](#getIcon--) | Anger en MIME (Multipurpose Internet Mail Extensions) kodad binär ikon (i .ico-format) för ett Master- eller MasterShortcut-element i ett dokument. |
+| [getIconSize()](#getIconSize--) | Storleken på elementets ikon. |
+| [getIconUpdate()](#getIconUpdate--) | Anger om ikonen genereras automatiskt från mastern själv. |
+| [getMatchByName()](#getMatchByName--) | MatchByName-attributet bestämmer hur Microsoft Visio avgör om ett dokumentmaster redan finns när en instans av en master släpps på ritningssidan. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPageSheet()](#getPageSheet--) | Innehåller element som definierar sidbladet för ett Page- eller Master-element. |
+| [getPatternFlags()](#getPatternFlags--) | PatternFlags-attributet bestämmer om en master beter sig som ett anpassat mönster. |
+| [getPrompt()](#getPrompt--) | Statusfältet och verktygstipset visar en uppmaning för elementet. |
+| [getShapes()](#getShapes--) | Samling av Shape-objekt. |
+| [getUniqueID()](#getUniqueID--) | En GUID som identifierar mastern i dokumentet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | För beskrivningen av denna egenskap, se [getAlignName()](../../com.aspose.diagram/master\#getAlignName--) |
+| [setBaseID(UUID value)](#setBaseID-java.util.UUID-) | För beskrivningen av denna egenskap, se [getBaseID()](../../com.aspose.diagram/master\#getBaseID--) |
+| [setHidden(int value)](#setHidden-int-) | För beskrivningen av denna egenskap, se [getHidden()](../../com.aspose.diagram/master\#getHidden--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/master\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | För beskrivningen av denna egenskap, se [getIcon()](../../com.aspose.diagram/master\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | För beskrivningen av denna egenskap, se [getIconSize()](../../com.aspose.diagram/master\#getIconSize--) |
+| [setIconUpdate(int value)](#setIconUpdate-int-) | För beskrivningen av denna egenskap, se [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--) |
+| [setMatchByName(int value)](#setMatchByName-int-) | För beskrivningen av denna egenskap, se [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/master\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/master\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | För beskrivningen av denna egenskap, se [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/master\#getPrompt--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Master() {#Master--}
+```
+public Master()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Anger om masterns text i mallfönstret är vänsterjusterad, högerjusterad eller centrerad.
+
+**Returns:**
+int
+### getBaseID() {#getBaseID--}
+```
+public UUID getBaseID()
+```
+
+
+En GUID (globalt unik identifierare) som identifierar mastern över dokument.
+
+**Returns:**
+java.util.UUID
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Innehåller ett Connect-element för varje anslutning mellan två former i en ritning.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getHidden() {#getHidden--}
+```
+public int getHidden()
+```
+
+
+Anger om mastern är dold i användargränssnittet.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Anger en MIME (Multipurpose Internet Mail Extensions) kodad binär ikon (i .ico-format) för ett Master- eller MasterShortcut-element i ett dokument.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+Storleken på elementets ikon.
+
+**Returns:**
+int
+### getIconUpdate() {#getIconUpdate--}
+```
+public int getIconUpdate()
+```
+
+
+Anger om ikonen genereras automatiskt från mastern själv.
+
+**Returns:**
+int
+### getMatchByName() {#getMatchByName--}
+```
+public int getMatchByName()
+```
+
+
+MatchByName-attributet bestämmer hur Microsoft Visio avgör om ett dokumentmaster redan finns när en instans av en master släpps på ritningssidan. Det gör att ändringar som görs i ett dokumentmaster tillämpas på nya instanser av mastern, även om instanserna dras från en fristående stencilfil.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Innehåller element som definierar sidbladet för ett Page- eller Master-element.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+PatternFlags-attributet bestämmer om en master beter sig som ett anpassat mönster.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+Statusfältet och verktygstipset visar en uppmaning för elementet.
+
+**Returns:**
+java.lang.String
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Samling av Shape-objekt.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+En GUID som identifierar mastern i dokumentet.
+
+**Returns:**
+java.util.UUID
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAlignName()](../../com.aspose.diagram/master\#getAlignName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBaseID(UUID value) {#setBaseID-java.util.UUID-}
+```
+public void setBaseID(UUID value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBaseID()](../../com.aspose.diagram/master\#getBaseID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.UUID |  |
+
+### setHidden(int value) {#setHidden-int-}
+```
+public void setHidden(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHidden()](../../com.aspose.diagram/master\#getHidden--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/master\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIcon()](../../com.aspose.diagram/master\#getIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIconSize()](../../com.aspose.diagram/master\#getIconSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIconUpdate(int value) {#setIconUpdate-int-}
+```
+public void setIconUpdate(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIconUpdate()](../../com.aspose.diagram/master\#getIconUpdate--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMatchByName(int value) {#setMatchByName-int-}
+```
+public void setMatchByName(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getMatchByName()](../../com.aspose.diagram/master\#getMatchByName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/master\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/master\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPatternFlags()](../../com.aspose.diagram/master\#getPatternFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/master\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/master\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/mastercollection/_index.md
+++ b/swedish/java/com.aspose.diagram/mastercollection/_index.md
@@ -1,0 +1,304 @@
+---
+title: MasterCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Master‑samling.
+type: docs
+weight: 241
+url: /sv/java/com.aspose.diagram/mastercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterCollection extends Collection
+```
+
+Master‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Master master)](#add-com.aspose.diagram.Master-) | Lägg till Master-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getMaster(int ID)](#getMaster-int-) | Hämtar elementet med angivet ID. |
+| [getMasterByName(String name)](#getMasterByName-java.lang.String-) | Hämta master efter namn. |
+| [getMasterShortcuts()](#getMasterShortcuts--) | MasterShortcut‑samling. |
+| [getMaxRelID()](#getMaxRelID--) | hämta det maximala rel-id:t i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [isExist(String name)](#isExist-java.lang.String-) | Finns master i samlingen. |
+| [isExistRelId(String relID)](#isExistRelId-java.lang.String-) | Finns master rel-id i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Master master)](#remove-com.aspose.diagram.Master-) | Ta bort Master-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Master master) {#add-com.aspose.diagram.Master-}
+```
+public int add(Master master)
+```
+
+
+Lägg till Master-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Master get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getMaster(int ID) {#getMaster-int-}
+```
+public Master getMaster(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterByName(String name) {#getMasterByName-java.lang.String-}
+```
+public Master getMasterByName(String name)
+```
+
+
+Hämta master efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Master](../../com.aspose.diagram/master) - 
+### getMasterShortcuts() {#getMasterShortcuts--}
+```
+public MasterShortcutCollection getMasterShortcuts()
+```
+
+
+MasterShortcut‑samling.
+
+**Returns:**
+[MasterShortcutCollection](../../com.aspose.diagram/mastershortcutcollection)
+### getMaxRelID() {#getMaxRelID--}
+```
+public int getMaxRelID()
+```
+
+
+hämta det maximala rel-id:t i samlingen.
+
+**Returns:**
+int -
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### isExist(String name) {#isExist-java.lang.String-}
+```
+public boolean isExist(String name)
+```
+
+
+Finns master i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+boolean -
+### isExistRelId(String relID) {#isExistRelId-java.lang.String-}
+```
+public boolean isExistRelId(String relID)
+```
+
+
+Finns master rel-id i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| relID | java.lang.String |  |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Master master) {#remove-com.aspose.diagram.Master-}
+```
+public void remove(Master master)
+```
+
+
+Ta bort Master-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| master | [Master](../../com.aspose.diagram/master) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/mastershortcut/_index.md
+++ b/swedish/java/com.aspose.diagram/mastershortcut/_index.md
@@ -1,0 +1,388 @@
+---
+title: MasterShortcut
+second_title: Aspose.Diagram för Java API-referens
+description: Anger en master‑genväg som definierats i dokumentet.
+type: docs
+weight: 242
+url: /sv/java/com.aspose.diagram/mastershortcut/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MasterShortcut
+```
+
+Anger en master‑genväg som definierats i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [MasterShortcut()](#MasterShortcut--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignName()](#getAlignName--) | Anger om elementets text i stencil-fönstret är vänsterjusterad, högerjusterad eller centrerad. |
+| [getClass()](#getClass--) |  |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIcon()](#getIcon--) | Anger en MIME (Multipurpose Internet Mail Extensions) kodad binär ikon (i .ico-format) för ett Master- eller MasterShortcut-element i ett dokument. |
+| [getIconSize()](#getIconSize--) | Storleken på elementets ikon. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPatternFlags()](#getPatternFlags--) | Bestämmer om en master beter sig som ett anpassat mönster. |
+| [getPrompt()](#getPrompt--) | Statusfältet och verktygstipset visar en uppmaning för elementet. |
+| [getShortcutHelp()](#getShortcutHelp--) | En hjälpssträng för elementet. |
+| [getShortcutURL()](#getShortcutURL--) | En URL till ett MasterShortcut-element. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignName(int value)](#setAlignName-int-) | För beskrivningen av den här egenskapen, se [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/mastershortcut\#getID--) |
+| [setIcon(byte[] value)](#setIcon-byte---) | För beskrivningen av den här egenskapen, se [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--) |
+| [setIconSize(int value)](#setIconSize-int-) | För beskrivningen av den här egenskapen, se [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/mastershortcut\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--) |
+| [setPatternFlags(int value)](#setPatternFlags-int-) | För beskrivningen av den här egenskapen, se [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--) |
+| [setPrompt(String value)](#setPrompt-java.lang.String-) | För beskrivningen av den här egenskapen, se [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--) |
+| [setShortcutHelp(String value)](#setShortcutHelp-java.lang.String-) | För beskrivningen av den här egenskapen, se [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--) |
+| [setShortcutURL(String value)](#setShortcutURL-java.lang.String-) | För beskrivningen av den här egenskapen, se [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MasterShortcut() {#MasterShortcut--}
+```
+public MasterShortcut()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignName() {#getAlignName--}
+```
+public int getAlignName()
+```
+
+
+Anger om elementets text i stencil-fönstret är vänsterjusterad, högerjusterad eller centrerad.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIcon() {#getIcon--}
+```
+public byte[] getIcon()
+```
+
+
+Anger en MIME (Multipurpose Internet Mail Extensions) kodad binär ikon (i .ico-format) för ett Master- eller MasterShortcut-element i ett dokument.
+
+**Returns:**
+byte[]
+### getIconSize() {#getIconSize--}
+```
+public int getIconSize()
+```
+
+
+Storleken på elementets ikon.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPatternFlags() {#getPatternFlags--}
+```
+public int getPatternFlags()
+```
+
+
+Bestämmer om en master beter sig som ett anpassat mönster.
+
+**Returns:**
+int
+### getPrompt() {#getPrompt--}
+```
+public String getPrompt()
+```
+
+
+Statusfältet och verktygstipset visar en uppmaning för elementet.
+
+**Returns:**
+java.lang.String
+### getShortcutHelp() {#getShortcutHelp--}
+```
+public String getShortcutHelp()
+```
+
+
+En hjälpssträng för elementet.
+
+**Returns:**
+java.lang.String
+### getShortcutURL() {#getShortcutURL--}
+```
+public String getShortcutURL()
+```
+
+
+En URL till ett MasterShortcut-element. Om detta attribut är närvarande är detta MasterShortcut-element en genväg.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignName(int value) {#setAlignName-int-}
+```
+public void setAlignName(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAlignName()](../../com.aspose.diagram/mastershortcut\#getAlignName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/mastershortcut\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIcon(byte[] value) {#setIcon-byte---}
+```
+public void setIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIcon()](../../com.aspose.diagram/mastershortcut\#getIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setIconSize(int value) {#setIconSize-int-}
+```
+public void setIconSize(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIconSize()](../../com.aspose.diagram/mastershortcut\#getIconSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/mastershortcut\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/mastershortcut\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPatternFlags(int value) {#setPatternFlags-int-}
+```
+public void setPatternFlags(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPatternFlags()](../../com.aspose.diagram/mastershortcut\#getPatternFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPrompt(String value) {#setPrompt-java.lang.String-}
+```
+public void setPrompt(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPrompt()](../../com.aspose.diagram/mastershortcut\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setShortcutHelp(String value) {#setShortcutHelp-java.lang.String-}
+```
+public void setShortcutHelp(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShortcutHelp()](../../com.aspose.diagram/mastershortcut\#getShortcutHelp--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setShortcutURL(String value) {#setShortcutURL-java.lang.String-}
+```
+public void setShortcutURL(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShortcutURL()](../../com.aspose.diagram/mastershortcut\#getShortcutURL--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/mastershortcutcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/mastershortcutcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: MasterShortcutCollection
+second_title: Aspose.Diagram för Java API-referens
+description: MasterShortcut‑samling.
+type: docs
+weight: 243
+url: /sv/java/com.aspose.diagram/mastershortcutcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MasterShortcutCollection extends Collection
+```
+
+MasterShortcut‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(MasterShortcut masterShortcut)](#add-com.aspose.diagram.MasterShortcut-) | Lägg till Master-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(MasterShortcut masterShortcut)](#remove-com.aspose.diagram.MasterShortcut-) | Ta bort MasterShortcut‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(MasterShortcut masterShortcut) {#add-com.aspose.diagram.MasterShortcut-}
+```
+public int add(MasterShortcut masterShortcut)
+```
+
+
+Lägg till Master-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MasterShortcut get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[MasterShortcut](../../com.aspose.diagram/mastershortcut) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(MasterShortcut masterShortcut) {#remove-com.aspose.diagram.MasterShortcut-}
+```
+public void remove(MasterShortcut masterShortcut)
+```
+
+
+Ta bort MasterShortcut‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| masterShortcut | [MasterShortcut](../../com.aspose.diagram/mastershortcut) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/measureconst/_index.md
+++ b/swedish/java/com.aspose.diagram/measureconst/_index.md
@@ -1,0 +1,561 @@
+---
+title: MeasureConst
+second_title: Aspose.Diagram för Java API-referens
+description: Måttenheter.
+type: docs
+weight: 244
+url: /sv/java/com.aspose.diagram/measureconst/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class MeasureConst
+```
+
+Enheter av\\ mått.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [AC](#AC) | Acre. |
+| [AD](#AD) | Degrees. |
+| [AM](#AM) | Minutes. |
+| [AS](#AS) | Seconds. |
+| [BOOL](#BOOL) | Boolesk. |
+| [C](#C) | Ciceros. |
+| [CM](#CM) | Centimetres. |
+| [COLOR](#COLOR) | A color value. |
+| [CY](#CY) | Currency. |
+| [C_D](#C-D) | Ciceros/didits. |
+| [D](#D) | Didots. |
+| [DA](#DA) | Default angle units. |
+| [DATE](#DATE) | Date and time. |
+| [DE](#DE) | Default duration units. |
+| [DEG](#DEG) | Fractional degree. |
+| [DL](#DL) | Default length units. |
+| [DP](#DP) | Default page units. |
+| [DT](#DT) | Default type units. |
+| [ED](#ED) | Elapsed days. |
+| [EH](#EH) | Elapsed hours. |
+| [EM](#EM) | Elapsed minutes. |
+| [ES](#ES) | Elapsed seconds. |
+| [EW](#EW) | Elapsed weeks. |
+| [FT](#FT) | Feet. |
+| [F_I](#F-I) | Feet/inch. |
+| [GUID](#GUID) | A global unique identifier. |
+| [HA](#HA) | Hectare. |
+| [IN](#IN) | Inches. |
+| [IN_F](#IN-F) | Inches fractional. |
+| [KM](#KM) | Kilometres. |
+| [M](#M) | Metres. |
+| [MI](#MI) | Miles. |
+| [MI_F](#MI-F) | Milest fractional. |
+| [MM](#MM) | Milimetres. |
+| [MULTIDIM](#MULTIDIM) | Multidimential value. |
+| [NM](#NM) | Nautical miles. |
+| [NUM](#NUM) | Nummer. |
+| [NURBS](#NURBS) | Nurbs curve data. |
+| [P](#P) | Picas. |
+| [PER](#PER) | Percent. |
+| [PNT](#PNT) | 2-D coordinate. |
+| [POLYLINE](#POLYLINE) | Polyline point data. |
+| [PT](#PT) | Points. |
+| [P_PT](#P-PT) | Picas/points. |
+| [RAD](#RAD) | Radians. |
+| [STR](#STR) | Sträng. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [YD](#YD) | Yards. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AC {#AC}
+```
+public static final int AC
+```
+
+
+Acre.
+
+### AD {#AD}
+```
+public static final int AD
+```
+
+
+Degrees.
+
+### AM {#AM}
+```
+public static final int AM
+```
+
+
+Minutes.
+
+### AS {#AS}
+```
+public static final int AS
+```
+
+
+Seconds.
+
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Boolesk.
+
+### C {#C}
+```
+public static final int C
+```
+
+
+Ciceros.
+
+### CM {#CM}
+```
+public static final int CM
+```
+
+
+Centimetres.
+
+### COLOR {#COLOR}
+```
+public static final int COLOR
+```
+
+
+A color value.
+
+### CY {#CY}
+```
+public static final int CY
+```
+
+
+Currency.
+
+### C_D {#C-D}
+```
+public static final int C_D
+```
+
+
+Ciceros/didits.
+
+### D {#D}
+```
+public static final int D
+```
+
+
+Didots.
+
+### DA {#DA}
+```
+public static final int DA
+```
+
+
+Default angle units.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Date and time.
+
+### DE {#DE}
+```
+public static final int DE
+```
+
+
+Default duration units.
+
+### DEG {#DEG}
+```
+public static final int DEG
+```
+
+
+Fractional degree.
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+Default length units.
+
+### DP {#DP}
+```
+public static final int DP
+```
+
+
+Default page units.
+
+### DT {#DT}
+```
+public static final int DT
+```
+
+
+Default type units.
+
+### ED {#ED}
+```
+public static final int ED
+```
+
+
+Elapsed days.
+
+### EH {#EH}
+```
+public static final int EH
+```
+
+
+Elapsed hours.
+
+### EM {#EM}
+```
+public static final int EM
+```
+
+
+Elapsed minutes.
+
+### ES {#ES}
+```
+public static final int ES
+```
+
+
+Elapsed seconds.
+
+### EW {#EW}
+```
+public static final int EW
+```
+
+
+Elapsed weeks.
+
+### FT {#FT}
+```
+public static final int FT
+```
+
+
+Feet.
+
+### F_I {#F-I}
+```
+public static final int F_I
+```
+
+
+Feet/inch.
+
+### GUID {#GUID}
+```
+public static final int GUID
+```
+
+
+A global unique identifier.
+
+### HA {#HA}
+```
+public static final int HA
+```
+
+
+Hectare.
+
+### IN {#IN}
+```
+public static final int IN
+```
+
+
+Inches.
+
+### IN_F {#IN-F}
+```
+public static final int IN_F
+```
+
+
+Inches fractional.
+
+### KM {#KM}
+```
+public static final int KM
+```
+
+
+Kilometres.
+
+### M {#M}
+```
+public static final int M
+```
+
+
+Metres.
+
+### MI {#MI}
+```
+public static final int MI
+```
+
+
+Miles.
+
+### MI_F {#MI-F}
+```
+public static final int MI_F
+```
+
+
+Milest fractional.
+
+### MM {#MM}
+```
+public static final int MM
+```
+
+
+Milimetres.
+
+### MULTIDIM {#MULTIDIM}
+```
+public static final int MULTIDIM
+```
+
+
+Multidimential value.
+
+### NM {#NM}
+```
+public static final int NM
+```
+
+
+Nautical miles.
+
+### NUM {#NUM}
+```
+public static final int NUM
+```
+
+
+Nummer.
+
+### NURBS {#NURBS}
+```
+public static final int NURBS
+```
+
+
+Nurbs curve data.
+
+### P {#P}
+```
+public static final int P
+```
+
+
+Picas.
+
+### PER {#PER}
+```
+public static final int PER
+```
+
+
+Percent.
+
+### PNT {#PNT}
+```
+public static final int PNT
+```
+
+
+2-D coordinate.
+
+### POLYLINE {#POLYLINE}
+```
+public static final int POLYLINE
+```
+
+
+Polyline point data.
+
+### PT {#PT}
+```
+public static final int PT
+```
+
+
+Points.
+
+### P_PT {#P-PT}
+```
+public static final int P_PT
+```
+
+
+Picas/points.
+
+### RAD {#RAD}
+```
+public static final int RAD
+```
+
+
+Radians.
+
+### STR {#STR}
+```
+public static final int STR
+```
+
+
+Sträng.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### YD {#YD}
+```
+public static final int YD
+```
+
+
+Yards.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/memoryfontsource/_index.md
+++ b/swedish/java/com.aspose.diagram/memoryfontsource/_index.md
@@ -1,0 +1,165 @@
+---
+title: MemoryFontSource
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar den enda TrueType‑teckensnittsfilen som lagras i minnet.
+type: docs
+weight: 245
+url: /sv/java/com.aspose.diagram/memoryfontsource/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FontSourceBase](../../com.aspose.diagram/fontsourcebase)
+```
+public class MemoryFontSource extends FontSourceBase
+```
+
+Representerar den enda TrueType‑teckensnittsfilen som lagras i minnet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [MemoryFontSource(byte[] fontData)](#MemoryFontSource-byte---) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFontData()](#getFontData--) | Binär teckensnittsdata. |
+| [getType()](#getType--) | Returnerar typen av teckensnittskälla. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MemoryFontSource(byte[] fontData) {#MemoryFontSource-byte---}
+```
+public MemoryFontSource(byte[] fontData)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fontData | byte[] | Binär teckensnittsdata. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFontData() {#getFontData--}
+```
+public byte[] getFontData()
+```
+
+
+Binär teckensnittsdata.
+
+**Returns:**
+byte[]
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Returnerar typen av teckensnittskälla.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/milestonehelper/_index.md
+++ b/swedish/java/com.aspose.diagram/milestonehelper/_index.md
@@ -1,0 +1,278 @@
+---
+title: MilestoneHelper
+second_title: Aspose.Diagram för Java API-referens
+description: MilestoneHelper för att ange egenskap för milstolpsformen.
+type: docs
+weight: 246
+url: /sv/java/com.aspose.diagram/milestonehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class MilestoneHelper
+```
+
+MilestoneHelper för att ange egenskap för milstolpsformen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [MilestoneHelper(Shape shape)](#MilestoneHelper-com.aspose.diagram.Shape-) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMilestoneDate()](#getMilestoneDate--) | Milstolpsdatum |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshMilestone(Shape timeline)](#refreshMilestone-com.aspose.diagram.Shape-) | Uppdatera milstolpe |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | om data för markörer (milstenar, intervaller) ska uppdateras när de flyttas på tidslinjen |
+|  | [setDateFormat(int value)](#setDateFormat-int-) | DateFormat för shape /// |
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatString(String value)](#setDateFormatString-java.lang.String-) | DateFormat-sträng för shape |
+| [setMilestoneDate(DateTime value)](#setMilestoneDate-com.aspose.diagram.DateTime-) |  |
+| [setType(int value)](#setType-int-) | Typ av shape |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MilestoneHelper(Shape shape) {#MilestoneHelper-com.aspose.diagram.Shape-}
+```
+public MilestoneHelper(Shape shape)
+```
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMilestoneDate() {#getMilestoneDate--}
+```
+public DateTime getMilestoneDate()
+```
+
+
+Milstolpsdatum
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshMilestone(Shape timeline) {#refreshMilestone-com.aspose.diagram.Shape-}
+```
+public void refreshMilestone(Shape timeline)
+```
+
+
+Uppdatera milstolpe
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| timeline | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+om data för markörer (milstenar, intervaller) ska uppdateras när de flyttas på tidslinjen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDateFormat(int value) {#setDateFormat-int-}
+```
+public void setDateFormat(int value)
+```
+
+
+DateFormat för shape ///
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDateFormatString(String value) {#setDateFormatString-java.lang.String-}
+```
+public void setDateFormatString(String value)
+```
+
+
+DateFormat-sträng för shape
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setMilestoneDate(DateTime value) {#setMilestoneDate-com.aspose.diagram.DateTime-}
+```
+public void setMilestoneDate(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+Typ av shape
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/misc/_index.md
+++ b/swedish/java/com.aspose.diagram/misc/_index.md
@@ -1,0 +1,381 @@
+---
+title: Övrigt
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller olika element av former och grupper, såsom de som styr markeringsmarkering och synlighet.
+type: docs
+weight: 247
+url: /sv/java/com.aspose.diagram/misc/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Misc
+```
+
+Innehåller olika element för former och grupper, såsom de som styr markeringsframhävning och synlighet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBegTrigger()](#getBegTrigger--) | Innehåller en triggerformel genererad av Microsoft Visio som avgör om startpunkten för en 1‑D‑form ska flyttas för att behålla dess anslutning till en annan form. |
+| [getCalendar()](#getCalendar--) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [getClass()](#getClass--) |  |
+| [getComment()](#getComment--) | Innehåller kommentartexten i strängformat för en form. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDropOnPageScale()](#getDropOnPageScale--) | Bestämmer den procentandel med vilken en form skalas när den släpps på ritningssidan. |
+| [getDynFeedback()](#getDynFeedback--) | Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutning. |
+| [getEndTrigger()](#getEndTrigger--) | Innehåller en triggerformel genererad av Microsoft Visio. |
+| [getGlueType()](#getGlueType--) | Anger om dynamisk (form‑till‑form) limning är tillåten när man ansluter till en form. |
+| [getHideText()](#getHideText--) | Döljer texten för en form. |
+| [getLangID()](#getLangID--) | Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i. |
+| [getLocalizeMerge()](#getLocalizeMerge--) | Bestämmer om former lokalanpassas (om deras LangID‑element återställs) när de kopieras mellan dokument. |
+| [getNoAlignBox()](#getNoAlignBox--) | Anger om markeringsrektangeln visas när formen är markerad. |
+| [getNoCtlHandles()](#getNoCtlHandles--) | Anger om kontrollhandtagen visas när formen är markerad. |
+| [getNoLiveDynamics()](#getNoLiveDynamics--) | Anger om en form dynamiskt ändrar storlek eller roteras när användaren manipulerar den. |
+| [getNoObjHandles()](#getNoObjHandles--) | Anger om markeringshandtagen visas när formen är markerad. |
+| [getNonPrinting()](#getNonPrinting--) | Anger om en markerad form kan skrivas ut. |
+| [getObjType()](#getObjType--) | Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getShapeKeywords()](#getShapeKeywords--) | Innehåller sökord som har tilldelats anpassade masterformer. |
+| [getUpdateAlignBox()](#getUpdateAlignBox--) | Anger om en forms markeringsrektangel ska beräknas om varje gång ett kontrollhandtag flyttas. |
+| [getWalkPreference()](#getWalkPreference--) | Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position. |
+| [hashCode()](#hashCode--) |  |
+| [isDropSource()](#isDropSource--) | Anger om formen kan läggas till i en grupp genom att släppa den på gruppen. |
+| [isReplaceLockShapeData()](#isReplaceLockShapeData--) | Indikerar om värdena i angivna celler i en masterform skriver över värdena (inklusive lokala värden) för en form som ersätts under en formutbytesoperation. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/misc\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBegTrigger() {#getBegTrigger--}
+```
+public DoubleValue getBegTrigger()
+```
+
+
+Innehåller en triggerformel genererad av Microsoft Visio som avgör om startpunkten för en 1‑D‑form ska flyttas för att behålla dess anslutning till en annan form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getComment() {#getComment--}
+```
+public Str2Value getComment()
+```
+
+
+Innehåller kommentartexten i strängformat för en form.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDropOnPageScale() {#getDropOnPageScale--}
+```
+public DoubleValue getDropOnPageScale()
+```
+
+
+Bestämmer den procentandel med vilken en form skalas när den släpps på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDynFeedback() {#getDynFeedback--}
+```
+public DynFeedback getDynFeedback()
+```
+
+
+Anger vilken typ av visuell återkoppling som ges till användare när de drar en anslutning.
+
+**Returns:**
+[DynFeedback](../../com.aspose.diagram/dynfeedback)
+### getEndTrigger() {#getEndTrigger--}
+```
+public DoubleValue getEndTrigger()
+```
+
+
+Innehåller en triggerformel genererad av Microsoft Visio. Denna triggerformel avgör om slutpunkten för en 1‑D‑form ska flyttas för att behålla dess anslutning till en annan form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getGlueType() {#getGlueType--}
+```
+public GlueType getGlueType()
+```
+
+
+Anger om dynamisk (form‑till‑form) limning är tillåten när man ansluter till en form.
+
+**Returns:**
+[GlueType](../../com.aspose.diagram/gluetype)
+### getHideText() {#getHideText--}
+```
+public BoolValue getHideText()
+```
+
+
+Döljer texten för en form. Du kan visa text, redigera egenskaper och tillämpa stilar på texten i textblocket, men ändringarna visas inte förrän du anger HideText element till 0.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getLocalizeMerge() {#getLocalizeMerge--}
+```
+public BoolValue getLocalizeMerge()
+```
+
+
+Bestämmer om former lokalanpassas (om deras LangID‑element återställs) när de kopieras mellan dokument.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoAlignBox() {#getNoAlignBox--}
+```
+public BoolValue getNoAlignBox()
+```
+
+
+Anger om markeringsrektangeln visas när formen är markerad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoCtlHandles() {#getNoCtlHandles--}
+```
+public BoolValue getNoCtlHandles()
+```
+
+
+Anger om kontrollhandtagen visas när formen är markerad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoLiveDynamics() {#getNoLiveDynamics--}
+```
+public BoolValue getNoLiveDynamics()
+```
+
+
+Anger om en form dynamiskt ändrar storlek eller roteras när användaren manipulerar den.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNoObjHandles() {#getNoObjHandles--}
+```
+public BoolValue getNoObjHandles()
+```
+
+
+Anger om markeringshandtagen visas när formen är markerad.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getNonPrinting() {#getNonPrinting--}
+```
+public BoolValue getNonPrinting()
+```
+
+
+Anger om en markerad form kan skrivas ut.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getObjType() {#getObjType--}
+```
+public ObjType getObjType()
+```
+
+
+Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[ObjType](../../com.aspose.diagram/objtype)
+### getShapeKeywords() {#getShapeKeywords--}
+```
+public Str2Value getShapeKeywords()
+```
+
+
+Innehåller sökord som har tilldelats anpassade masterformer.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getUpdateAlignBox() {#getUpdateAlignBox--}
+```
+public BoolValue getUpdateAlignBox()
+```
+
+
+Anger om en forms markeringsrektangel ska beräknas om varje gång ett kontrollhandtag flyttas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getWalkPreference() {#getWalkPreference--}
+```
+public WalkPreference getWalkPreference()
+```
+
+
+Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position.
+
+**Returns:**
+[WalkPreference](../../com.aspose.diagram/walkpreference)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDropSource() {#isDropSource--}
+```
+public BoolValue isDropSource()
+```
+
+
+Anger om formen kan läggas till i en grupp genom att släppa den på gruppen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### isReplaceLockShapeData() {#isReplaceLockShapeData--}
+```
+public BoolValue isReplaceLockShapeData()
+```
+
+
+Indikerar om värdena i angivna celler i en masterform skriver över värdena (inklusive lokala värden) för en form som ersätts under en formutbytesoperation.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/misc\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/moveto/_index.md
+++ b/swedish/java/com.aspose.diagram/moveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: MoveTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinaterna för den första vertexen i en form eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana.
+type: docs
+weight: 248
+url: /sv/java/com.aspose.diagram/moveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class MoveTo extends Coordinate
+```
+
+Innehåller x- och y-koordinaterna för den första hörnpunkten i en form, eller x- och y-koordinaterna för den första hörnpunkten efter ett avbrott i en bana.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [MoveTo()](#MoveTo--) | Skapar en instans av klassen [MoveTo](../../com.aspose.diagram/moveto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X‑elementet representerar x‑koordinaten för den första vertexen i en bana. |
+| [getY()](#getY--) | Y‑elementet representerar y‑koordinaten för den första vertexen i en bana. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/moveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/moveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/moveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/moveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MoveTo() {#MoveTo--}
+```
+public MoveTo()
+```
+
+
+Skapar en instans av klassen [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X‑elementet representerar x‑koordinaten för den första vertexen i en bana. Om MoveTo‑elementet visas mellan två element, representerar X‑elementet x‑koordinaten för den första vertexen efter avbrottet i banan
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y‑elementet representerar y‑koordinaten för den första vertexen i en bana. Om MoveTo‑elementet visas mellan två element, representerar Y‑elementet y‑koordinaten för den första vertexen efter avbrottet i banan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/moveto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/moveto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/moveto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/moveto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/movetocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/movetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: MoveToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: MoveTo‑samling.
+type: docs
+weight: 249
+url: /sv/java/com.aspose.diagram/movetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class MoveToCollection extends Collection
+```
+
+MoveTo‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public MoveTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[MoveTo](../../com.aspose.diagram/moveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/nurbsto/_index.md
+++ b/swedish/java/com.aspose.diagram/nurbsto/_index.md
@@ -1,0 +1,374 @@
+---
+title: NURBSTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinaterna, positionen för den näst sista knuten, positionen för den sista vikten, positionen för den första knuten och positionen för den första vikten samt formeln för en icke-uniform rationell B-spline NURBS.
+type: docs
+weight: 250
+url: /sv/java/com.aspose.diagram/nurbsto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class NURBSTo extends Coordinate
+```
+
+Innehåller x- och y-koordinaterna, positionen för den näst sista knuten, positionen för den sista vikten, positionen för den första knuten, positionen för den första vikten samt formeln för en icke-uniform rationell B-spline (NURBS). Denna information anges i elementen X, Y, A, B, C, D och E, i den ordningen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [NURBSTo()](#NURBSTo--) | Skapar en instans av klassen [NURBSTo](../../com.aspose.diagram/nurbsto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Den näst sista knuten i den icke-uniforma rationella B-splinen (NURBS). |
+| [getB()](#getB--) | Den sista vikten i den icke-uniforma rationella B-splinen (NURBS). |
+| [getC()](#getC--) | Den första knuten i den icke-uniforma rationella B-splinen (NURBS). |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Den första vikten i den icke-uniforma rationella B-splinen (NURBS). |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getE()](#getE--) | Innehåller en formel för en icke-uniform rationell B-spline (NURBS). |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för den sista kontrollpunkten i en icke-uniform rationell B-spline (NURBS). |
+| [getY()](#getY--) | y-koordinaten för den sista kontrollpunkten i en icke-uniform rationell B-spline (NURBS). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivning av denna egenskap, se [getA()](../../com.aspose.diagram/nurbsto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivning av denna egenskap, se [getB()](../../com.aspose.diagram/nurbsto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivning av denna egenskap, se [getC()](../../com.aspose.diagram/nurbsto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | För beskrivning av denna egenskap, se [getD()](../../com.aspose.diagram/nurbsto\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivning av denna egenskap, se [getDel()](../../com.aspose.diagram/nurbsto\#getDel--) |
+| [setE(StrValue value)](#setE-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getE()](../../com.aspose.diagram/nurbsto\#getE--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/nurbsto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/nurbsto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/nurbsto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NURBSTo() {#NURBSTo--}
+```
+public NURBSTo()
+```
+
+
+Skapar en instans av klassen [NURBSTo](../../com.aspose.diagram/nurbsto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Den näst sista knuten i den icke-uniforma rationella B-splinen (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Den sista vikten i den icke-uniforma rationella B-splinen (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Den första knuten i den icke-uniforma rationella B-splinen (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Den första vikten i den icke-uniforma rationella B-splinen (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getE() {#getE--}
+```
+public StrValue getE()
+```
+
+
+Innehåller en formel för en icke-uniform rationell B-spline (NURBS).
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för den sista kontrollpunkten i en icke-uniform rationell B-spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för den sista kontrollpunkten i en icke-uniform rationell B-spline (NURBS).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivning av denna egenskap, se [getA()](../../com.aspose.diagram/nurbsto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivning av denna egenskap, se [getB()](../../com.aspose.diagram/nurbsto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivning av denna egenskap, se [getC()](../../com.aspose.diagram/nurbsto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+För beskrivning av denna egenskap, se [getD()](../../com.aspose.diagram/nurbsto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivning av denna egenskap, se [getDel()](../../com.aspose.diagram/nurbsto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setE(StrValue value) {#setE-com.aspose.diagram.StrValue-}
+```
+public void setE(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getE()](../../com.aspose.diagram/nurbsto\#getE--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/nurbsto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/nurbsto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/nurbsto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/nurbstocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/nurbstocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: NURBSToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: NURBSTo‑samling.
+type: docs
+weight: 251
+url: /sv/java/com.aspose.diagram/nurbstocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class NURBSToCollection extends Collection
+```
+
+NURBSTo‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public NURBSTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[NURBSTo](../../com.aspose.diagram/nurbsto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/objectkind/_index.md
+++ b/swedish/java/com.aspose.diagram/objectkind/_index.md
@@ -1,0 +1,190 @@
+---
+title: ObjectKind
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av textfält.
+type: docs
+weight: 254
+url: /sv/java/com.aspose.diagram/objectkind/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjectKind
+```
+
+Anger typen av textfält.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ObjectKind(int value)](#ObjectKind-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av textfält. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/objectkind\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjectKind(int value) {#ObjectKind-int-}
+```
+public ObjectKind(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av textfält.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/objectkind\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/objectkindvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/objectkindvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ObjectKindValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av textfält.
+type: docs
+weight: 255
+url: /sv/java/com.aspose.diagram/objectkindvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectKindValue
+```
+
+Anger typen av textfält.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [HORIZONTAL_IN_VERTICAL](#HORIZONTAL-IN-VERTICAL) | Horisontell i vertikal. |
+| [STANDARD](#STANDARD) | Standard. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL_IN_VERTICAL {#HORIZONTAL-IN-VERTICAL}
+```
+public static final int HORIZONTAL_IN_VERTICAL
+```
+
+
+Horisontell i vertikal.
+
+### STANDARD {#STANDARD}
+```
+public static final int STANDARD
+```
+
+
+Standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/objecttype/_index.md
+++ b/swedish/java/com.aspose.diagram/objecttype/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjectType
+second_title: Aspose.Diagram för Java API-referens
+description: Om attributet ForeignType är Object måste ForeignData-elementet också ha ett ObjectType-attribut.
+type: docs
+weight: 256
+url: /sv/java/com.aspose.diagram/objecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjectType
+```
+
+Om attributet ForeignType är "Object" måste ForeignData‑elementet också ha ett ObjectType‑attribut.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CONTROL](#CONTROL) | Kontroll. |
+| [EMBEDDED_OBJECT](#EMBEDDED-OBJECT) | Inbäddat objekt. |
+| [LINKED_OBJECT](#LINKED-OBJECT) | Länkat objekt. |
+| [OLE_2_NAMED](#OLE-2-NAMED) | OLE2 namngiven. |
+| [OLE_2_OBJECT](#OLE-2-OBJECT) | OLE2-objekt. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Kontroll.
+
+### EMBEDDED_OBJECT {#EMBEDDED-OBJECT}
+```
+public static final int EMBEDDED_OBJECT
+```
+
+
+Inbäddat objekt.
+
+### LINKED_OBJECT {#LINKED-OBJECT}
+```
+public static final int LINKED_OBJECT
+```
+
+
+Länkat objekt.
+
+### OLE_2_NAMED {#OLE-2-NAMED}
+```
+public static final int OLE_2_NAMED
+```
+
+
+OLE2 namngiven.
+
+### OLE_2_OBJECT {#OLE-2-OBJECT}
+```
+public static final int OLE_2_OBJECT
+```
+
+
+OLE2-objekt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/objtype/_index.md
+++ b/swedish/java/com.aspose.diagram/objtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ObjType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+type: docs
+weight: 252
+url: /sv/java/com.aspose.diagram/objtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ObjType
+```
+
+Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ObjType(int value)](#ObjType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ObjType(int value) {#ObjType-int-}
+```
+public ObjType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/objtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/objtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/objtypevalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ObjTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+type: docs
+weight: 253
+url: /sv/java/com.aspose.diagram/objtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ObjTypeValue
+```
+
+Anger om objekt kan placeras eller routas i diagram när du använder Microsoft Visio för att placera former på ritningssidan.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DRAWING_CONTEXT](#DRAWING-CONTEXT) | Visio bestämmer baserat på ritningskontexten. |
+| [SHAPE_NOT_PLACEABLE_NOT_ROUTABLE](#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE) | Formen kan inte placeras, kan inte routas. |
+| [SHAPE_PLACEABLE](#SHAPE-PLACEABLE) | Formen kan placeras. |
+| [SHAPE_PLACEABLE_ROUTABLE](#SHAPE-PLACEABLE-ROUTABLE) | Gruppen innehåller placerbara/routbara former. |
+| [SHAPE_ROUTABLE](#SHAPE-ROUTABLE) | Shape är routbar. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING_CONTEXT {#DRAWING-CONTEXT}
+```
+public static final int DRAWING_CONTEXT
+```
+
+
+Visio bestämmer baserat på ritningskontexten.
+
+### SHAPE_NOT_PLACEABLE_NOT_ROUTABLE {#SHAPE-NOT-PLACEABLE-NOT-ROUTABLE}
+```
+public static final int SHAPE_NOT_PLACEABLE_NOT_ROUTABLE
+```
+
+
+Formen kan inte placeras, kan inte routas.
+
+### SHAPE_PLACEABLE {#SHAPE-PLACEABLE}
+```
+public static final int SHAPE_PLACEABLE
+```
+
+
+Formen kan placeras.
+
+### SHAPE_PLACEABLE_ROUTABLE {#SHAPE-PLACEABLE-ROUTABLE}
+```
+public static final int SHAPE_PLACEABLE_ROUTABLE
+```
+
+
+Gruppen innehåller placerbara/routbara former.
+
+### SHAPE_ROUTABLE {#SHAPE-ROUTABLE}
+```
+public static final int SHAPE_ROUTABLE
+```
+
+
+Shape är routbar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/optionsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/optionsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: OptionsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Valfritt osignerat heltal.
+type: docs
+weight: 257
+url: /sv/java/com.aspose.diagram/optionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OptionsValue
+```
+
+Valfri osignerad heltal. Alternativ att tillämpa på datarecordset. Möjliga värden kan vara en kombination av en eller flera av de som visas i följande tabell.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DELAY_QUERY](#DELAY-QUERY) | Kör inte kommandosträngfrågan förrän nästa gång datarecordset uppdateras. |
+| [NO_ADV_CONFIG](#NO-ADV-CONFIG) | Begränsar den kontroll som användare har över hur datarecordset uppdateras i dialogrutan Konfigurera uppdatering för datarecordset. |
+| [NO_EXTERNAL_DATA_UI](#NO-EXTERNAL-DATA-UI) | Förhindrar att data i datarecordset visas i fönstret Extern data. |
+| [NO_LINK_ON_PASTE](#NO-LINK-ON-PASTE) | Kopierar inte shape-data länkar till Urklipp när former kopieras eller klipps. |
+| [NO_REFRESH_UI](#NO-REFRESH-UI) | Förhindrar att datarecordset visas i dialogrutan Uppdatera data. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DELAY_QUERY {#DELAY-QUERY}
+```
+public static final int DELAY_QUERY
+```
+
+
+Kör inte kommandosträngfrågan förrän nästa gång datarecordset uppdateras.
+
+### NO_ADV_CONFIG {#NO-ADV-CONFIG}
+```
+public static final int NO_ADV_CONFIG
+```
+
+
+Begränsar den kontroll som användare har över hur datarecordset uppdateras i dialogrutan Konfigurera uppdatering för datarecordset. I synnerhet kan användare inte ändra primärnyckeln eller ange när shape-data ska skrivas över; dock kan användare ställa in uppdateringsintervallet och kan ändra datakällan.
+
+### NO_EXTERNAL_DATA_UI {#NO-EXTERNAL-DATA-UI}
+```
+public static final int NO_EXTERNAL_DATA_UI
+```
+
+
+Förhindrar att data i datarecordset visas i fönstret Extern data.
+
+### NO_LINK_ON_PASTE {#NO-LINK-ON-PASTE}
+```
+public static final int NO_LINK_ON_PASTE
+```
+
+
+Kopierar inte shape-data länkar till Urklipp när former kopieras eller klipps.
+
+### NO_REFRESH_UI {#NO-REFRESH-UI}
+```
+public static final int NO_REFRESH_UI
+```
+
+
+Förhindrar att datarecordset visas i dialogrutan Uppdatera data.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/outputformat/_index.md
+++ b/swedish/java/com.aspose.diagram/outputformat/_index.md
@@ -1,0 +1,179 @@
+---
+title: OutputFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Anger utdataformatet för en ritning.
+type: docs
+weight: 258
+url: /sv/java/com.aspose.diagram/outputformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class OutputFormat
+```
+
+Anger utdataformatet för en ritning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [OutputFormat(int value)](#OutputFormat-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger utdataformatet för en ritning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/outputformat\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputFormat(int value) {#OutputFormat-int-}
+```
+public OutputFormat(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger utdataformatet för en ritning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/outputformat\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/outputformatvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/outputformatvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: OutputFormatValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger utdataformatet för en ritning.
+type: docs
+weight: 259
+url: /sv/java/com.aspose.diagram/outputformatvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class OutputFormatValue
+```
+
+Anger utdataformatet för en ritning.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEFAULT_PRINT](#DEFAULT-PRINT) | Standard. |
+| [HTML_OR_GIF_OUTPUT](#HTML-OR-GIF-OUTPUT) | HTML- eller GIF-utdata. |
+| [POWER_POINT_SLIDE_SHOW](#POWER-POINT-SLIDE-SHOW) | PowerPoint bildspel. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_PRINT {#DEFAULT-PRINT}
+```
+public static final int DEFAULT_PRINT
+```
+
+
+Standard. Skriv ut.
+
+### HTML_OR_GIF_OUTPUT {#HTML-OR-GIF-OUTPUT}
+```
+public static final int HTML_OR_GIF_OUTPUT
+```
+
+
+HTML- eller GIF-utdata.
+
+### POWER_POINT_SLIDE_SHOW {#POWER-POINT-SLIDE-SHOW}
+```
+public static final int POWER_POINT_SLIDE_SHOW
+```
+
+
+PowerPoint bildspel.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/page/_index.md
+++ b/swedish/java/com.aspose.diagram/page/_index.md
@@ -1,0 +1,1156 @@
+---
+title: Sida
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som definierar en sida i dokumentet.
+type: docs
+weight: 260
+url: /sv/java/com.aspose.diagram/page/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Page
+```
+
+Innehåller element som definierar en sida i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Page()](#Page--) | Konstruktor. |
+| [Page(int ID)](#Page-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [addActiveXControl(int type, double pinX, double pinY, double width, double height)](#addActiveXControl-int-double-double-double-double-) | Skapar en Activex-kontroll. |
+| [addComment(Shape shape, String comment)](#addComment-com.aspose.diagram.Shape-java.lang.String-) | Lägger till en kommentar till en form. |
+| [addComment(double pinX, double pinY, String comment)](#addComment-double-double-java.lang.String-) | Lägger till en kommentar med definierade PinX och PinY. |
+| [addComment(long shapeID, String comment)](#addComment-long-java.lang.String-) | Lägger till en kommentar till en form med formens id. |
+| [addShape(Shape newShape, String masterName)](#addShape-com.aspose.diagram.Shape-java.lang.String-) | Lägger till en form skapad av master till en specifik sida. |
+| [addShape(double pinX, double pinY, double width, double height, InputStream stream)](#addShape-double-double-double-double-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)](#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-) |  |
+| [addShape(double pinX, double pinY, double width, double height, String masterName)](#addShape-double-double-double-double-java.lang.String-) | Lägger till en form skapad av master på sidan med definierade PinX, PinY, bredd och höjd. |
+| [addShape(double pinX, double pinY, String masterName)](#addShape-double-double-java.lang.String-) | Lägger till en form skapad av master på sidan med definierade PinX och PinY. |
+| [addText(double pinX, double pinY, double width, double height, String text)](#addText-double-double-double-double-java.lang.String-) | Lägger till text med definierade PinX och PinY. |
+| [addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)](#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-) | Lägger till text med definierade PinX och PinY. |
+| [applyStyle(int textStyle, int lineStyle, int fillStyle)](#applyStyle-int-int-int-) | Tillämpar stil för hela sidan. |
+| [autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)](#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-) | Automatiskt mellanrum mellan former. |
+| [bringForward(long shapeId)](#bringForward-long-) | Flyttar en form, definierad av ID, fram ett steg i z-ordningen. |
+| [bringToFront(long shapeId)](#bringToFront-long-) | Flyttar en form, definierad av ID, till fronten av z-ordningen. |
+| [centerDrawing()](#centerDrawing--) | Centrerar sidans former i förhållande till sidans omfång. |
+| [connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)](#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Koppla samman former via anslutning. |
+| [connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)](#connectShapesViaConnector-long-int-long-int-long-) | Koppla samman former via anslutning. |
+| [connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)](#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-) | Koppla samman former via anslutning. |
+| [connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)](#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Koppla samman former via anslutningsindex. |
+| [connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)](#connectShapesViaConnectorIndex-long-int-long-int-long-) | Koppla samman former via anslutningsindex. |
+| [copy(Page source)](#copy-com.aspose.diagram.Page-) |  |
+| [dispose()](#dispose--) | Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser. |
+| [drawEllipse(double pinX, double pinY, double width, double height)](#drawEllipse-double-double-double-double-) | Processen för att rita en ellips. |
+| [drawLine(double beginX, double beginY, double endX, double endY)](#drawLine-double-double-double-double-) | Processen för att rita en enkel linje. |
+| [drawLine(double pinX, double pinY, double width, double height, double[] xyArray)](#drawLine-double-double-double-double-double---) | Processen för att rita en linje. |
+| [drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)](#drawPolyline-double-double-double-double-double---) | Processen för att rita en polylinje. |
+| [drawRectangle(double pinX, double pinY, double width, double height)](#drawRectangle-double-double-double-double-) | Processen för att rita en rektangel. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAssociatedPage()](#getAssociatedPage--) | ID för den ursprungliga ritningssidan som markerades på separata markup‑lager av ritningens granskare. |
+| [getBackPage()](#getBackPage--) | Sidans bakgrundssida. |
+| [getBackground()](#getBackground--) | En flagga som indikerar om sidan är en bakgrundssida. |
+| [getClass()](#getClass--) |  |
+| [getConnects()](#getConnects--) | Innehåller ett Connect-element för varje anslutning mellan två former i en ritning. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPageSheet()](#getPageSheet--) | Innehåller element som definierar sidbladet för ett Page- eller Master-element. |
+| [getPages()](#getPages--) | Sidcollection. |
+| [getReviewerID()](#getReviewerID--) | ID för den granskare som är associerad med markup‑lagret. |
+| [getShapes()](#getShapes--) | Formsamling. |
+| [getViewCenterX()](#getViewCenterX--) | ViewCenterX och ViewCenterY anger en mittpunkt på en sida som en ny vy (fönster) antar när den öppnas initialt. |
+| [getViewCenterY()](#getViewCenterY--) | ViewCenterX och ViewCenterY anger en mittpunkt på en sida som en ny vy (fönster) antar när den öppnas initialt. |
+| [getViewScale()](#getViewScale--) | Standardförstoringsfaktor att använda när en ny vy (fönster) av sidan öppnas. |
+| [glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)](#glueShapeToConnectorBeginX-long-java.lang.String-long-) | Fäst form till Connectorns BeginX |
+| [glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)](#glueShapeToConnectorEndX-long-java.lang.String-long-) | Fäst form till Connectorns EndX |
+| [glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)](#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-) | Fäst former. |
+| [glueShapes(long shapeFromId, int placeTo, long shapeToId)](#glueShapes-long-int-long-) | Fäst former |
+| [glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)](#glueShapesInContainer-long-int-int-long-) | Fäst former i behållare |
+| [glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)](#glueShapesInContainer-long-java.lang.String-java.lang.String-long-) | Fäst former i behållare med anslutningsnamn |
+| [glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)](#glueShapesInContainerByID-long-int-int-long-) | Fäst former efter anslutnings‑ID i behållare |
+| [hashCode()](#hashCode--) |  |
+| [layout(LayoutOptions options)](#layout-com.aspose.diagram.LayoutOptions-) | Lägger ut formerna och/eller omdirigerar anslutningarna för sidan. |
+| [moveTo(int index)](#moveTo-int-) | Flyttar sidan till en annan plats bland sidorna. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [sendBackward(long shapeId)](#sendBackward-long-) | Flyttar en form, definierad av ID, ett steg bakåt i z‑ordningen. |
+| [sendToBack(long shapeId)](#sendToBack-long-) | Flyttar en form, definierad av ID, till slutet av z‑ordningen. |
+| [setAssociatedPage(Page value)](#setAssociatedPage-com.aspose.diagram.Page-) | För beskrivningen av denna egenskap, se [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--) |
+| [setBackPage(Page value)](#setBackPage-com.aspose.diagram.Page-) | För beskrivningen av denna egenskap, se [getBackPage()](../../com.aspose.diagram/page\#getBackPage--) |
+| [setBackground(int value)](#setBackground-int-) | För beskrivningen av denna egenskap, se [getBackground()](../../com.aspose.diagram/page\#getBackground--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/page\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/page\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/page\#getNameU--) |
+| [setPages(PageCollection value)](#setPages-com.aspose.diagram.PageCollection-) | För beskrivningen av denna egenskap, se [getPages()](../../com.aspose.diagram/page\#getPages--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Tillämpa ett förinställt tema på den här sidan |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Tillämpa en förinställd temavariant snabbstil på den här sidan |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Tillämpa en förinställd temavariant på den här sidan |
+| [setReviewerID(int value)](#setReviewerID-int-) | För beskrivningen av den här egenskapen, se [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | För beskrivningen av den här egenskapen, se [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | För beskrivningen av den här egenskapen, se [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | För beskrivningen av den här egenskapen, se [getViewScale()](../../com.aspose.diagram/page\#getViewScale--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Page() {#Page--}
+```
+public Page()
+```
+
+
+Konstruktor.
+
+### Page(int ID) {#Page-int-}
+```
+public Page(int ID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+### addActiveXControl(int type, double pinX, double pinY, double width, double height) {#addActiveXControl-int-double-double-double-double-}
+```
+public long addActiveXControl(int type, double pinX, double pinY, double width, double height)
+```
+
+
+Skapar en Activex-kontroll.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | int | Typen av kontrollen. |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger figurens bredd i tum. |
+| höjd | double | Anger figurens höjd i tum. |
+
+**Returns:**
+long - 
+### addComment(Shape shape, String comment) {#addComment-com.aspose.diagram.Shape-java.lang.String-}
+```
+public void addComment(Shape shape, String comment)
+```
+
+
+Lägger till en kommentar till en form.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | Anger figuren som lägger till kommentaren. |
+| kommentar | java.lang.String | Kommentarssträng. |
+
+### addComment(double pinX, double pinY, String comment) {#addComment-double-double-java.lang.String-}
+```
+public void addComment(double pinX, double pinY, String comment)
+```
+
+
+Lägger till en kommentar med definierade PinX och PinY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för kommentarens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för kommentarens pinne (rotationscentrum) i förhållande till sidan. |
+| kommentar | java.lang.String | Kommentarssträng. |
+
+### addComment(long shapeID, String comment) {#addComment-long-java.lang.String-}
+```
+public void addComment(long shapeID, String comment)
+```
+
+
+Lägger till en kommentar till en form med formens id.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeID | long |  |
+| kommentar | java.lang.String | Kommentarssträng. |
+
+### addShape(Shape newShape, String masterName) {#addShape-com.aspose.diagram.Shape-java.lang.String-}
+```
+public long addShape(Shape newShape, String masterName)
+```
+
+
+Lägger till en form skapad av master till en specifik sida.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| newShape | [Shape](../../com.aspose.diagram/shape) | Nytt figurobjekt[Shape](../../com.aspose.diagram/shape). |
+| masterName | java.lang.String | Mästarens namn. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### addShape(double pinX, double pinY, double width, double height, InputStream stream) {#addShape-double-double-double-double-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream stream)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| bredd | double |  |
+| höjd | double |  |
+| ström | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream) {#addShape-double-double-double-double-java.io.InputStream-java.io.InputStream-}
+```
+public long addShape(double pinX, double pinY, double width, double height, InputStream imageStream, InputStream objectDataStream)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double |  |
+| pinY | double |  |
+| bredd | double |  |
+| höjd | double |  |
+| imageStream | java.io.InputStream |  |
+| objectDataStream | java.io.InputStream |  |
+
+**Returns:**
+long
+### addShape(double pinX, double pinY, double width, double height, String masterName) {#addShape-double-double-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, double width, double height, String masterName)
+```
+
+
+Lägger till en form skapad av master på sidan med definierade PinX, PinY, bredd och höjd.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger figurens bredd i tum. |
+| höjd | double | Anger figurens höjd i tum. |
+| masterName | java.lang.String | Mästarens namn. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### addShape(double pinX, double pinY, String masterName) {#addShape-double-double-java.lang.String-}
+```
+public long addShape(double pinX, double pinY, String masterName)
+```
+
+
+Lägger till en form skapad av master på sidan med definierade PinX och PinY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| masterName | java.lang.String | Mästarens namn. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### addText(double pinX, double pinY, double width, double height, String text) {#addText-double-double-double-double-java.lang.String-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text)
+```
+
+
+Lägger till text med definierade PinX och PinY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för textens fästpunkt (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för textens fästpunkt (rotationscentrum) i förhållande till sidan. |
+| bredd | double |  |
+| höjd | double |  |
+| text | java.lang.String | textsträng. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size) {#addText-double-double-double-double-java.lang.String-java.lang.String-java.lang.String-double-}
+```
+public Shape addText(double pinX, double pinY, double width, double height, String text, String fontName, String fontColor, double size)
+```
+
+
+Lägger till text med definierade PinX och PinY.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för textens fästpunkt (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för textens fästpunkt (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger bredden på texten. |
+| höjd | double | Anger höjden på texten. |
+| text | java.lang.String | textsträng. |
+| fontName | java.lang.String | textens teckensnittsnamn. |
+| fontColor | java.lang.String | textens teckensnittsfärg. |
+| size | double | textens teckensnittsstorlek. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Returns a shape object that represents the new text object.
+### applyStyle(int textStyle, int lineStyle, int fillStyle) {#applyStyle-int-int-int-}
+```
+public void applyStyle(int textStyle, int lineStyle, int fillStyle)
+```
+
+
+Tillämpar stil för hela sidan. Standardvärdet är -1.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| textStyle | int | textstil‑id. |
+| lineStyle | int | linjestil‑id. |
+| fillStyle | int | fyllningsstil‑id. |
+
+### autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options) {#autoSpaceShapes-com.aspose.diagram.ShapeCollection-com.aspose.diagram.AutoSpaceOptions-}
+```
+public void autoSpaceShapes(ShapeCollection shapes, AutoSpaceOptions options)
+```
+
+
+Automatiskt mellanrum mellan former.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapes | [ShapeCollection](../../com.aspose.diagram/shapecollection) | Anger att formerna ska placeras automatiskt med jämna mellanrum. |
+| options | [AutoSpaceOptions](../../com.aspose.diagram/autospaceoptions) |  |
+
+### bringForward(long shapeId) {#bringForward-long-}
+```
+public void bringForward(long shapeId)
+```
+
+
+Flyttar en form, definierad av ID, fram ett steg i z-ordningen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### bringToFront(long shapeId) {#bringToFront-long-}
+```
+public void bringToFront(long shapeId)
+```
+
+
+Flyttar en form, definierad av ID, till fronten av z-ordningen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centrerar en sidas former i förhållande till sidans omfång. Att centrera former ändrar inte deras position i förhållande till varandra.
+
+### connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector) {#connectShapesViaConnector-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnector(Shape shapeFrom, int placeFrom, Shape shapeTo, int placeTo, Shape connector)
+```
+
+
+Koppla samman former via anslutning.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | Formen där anslutaren börjar [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | Platsen på den första formen där anslutningen kommer att anslutas Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Platsen på den andra formen där anslutningen kommer att anslutas Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connector | [Shape](../../com.aspose.diagram/shape) | Formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId) {#connectShapesViaConnector-long-int-long-int-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, int placeFrom, long shapeToId, int placeTo, long connectorId)
+```
+
+
+Koppla samman former via anslutning.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för formen där anslutningen börjar [Shape](../../com.aspose.diagram/shape). |
+| placeFrom | int | Platsen på den första formen där anslutningen kommer att anslutas Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| shapeToId | long | ID för formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Platsen på den andra formen där anslutningen kommer att anslutas Aspose.Diagram.Manipulation.ConnectionPointPlace. |
+| connectorId | long | ID för formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId) {#connectShapesViaConnector-long-java.lang.String-long-java.lang.String-long-}
+```
+public void connectShapesViaConnector(long shapeFromId, String fromConnectionName, long shapeToId, String toConnectionName, long connectorId)
+```
+
+
+Koppla samman former via anslutning.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för formen där anslutningen börjar [Shape](../../com.aspose.diagram/shape). |
+| fromConnectionName | java.lang.String | Anslutningsnamnet på den första formen där anslutningen kommer att anslutas. |
+| shapeToId | long | ID för formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| toConnectionName | java.lang.String | Anslutningsnamnet på den andra formen där anslutningen kommer att anslutas. |
+| connectorId | long | ID för formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector) {#connectShapesViaConnectorIndex-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void connectShapesViaConnectorIndex(Shape shapeFrom, int fromIndex, Shape shapeTo, int toIndex, Shape connector)
+```
+
+
+Koppla samman former via anslutningsindex.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | Formen där anslutaren börjar [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | Indexet för anslutningen på den första formen |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | indexet för anslutningen på den andra formen |
+| connector | [Shape](../../com.aspose.diagram/shape) | Formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId) {#connectShapesViaConnectorIndex-long-int-long-int-long-}
+```
+public void connectShapesViaConnectorIndex(long shapeFromId, int fromIndex, long shapeToId, int toIndex, long connectorId)
+```
+
+
+Koppla samman former via anslutningsindex.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för formen där anslutningen börjar [Shape](../../com.aspose.diagram/shape). |
+| fromIndex | int | Indexet för anslutningen på den första formen |
+| shapeToId | long | ID för formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| toIndex | int | indexet för anslutningen på den andra formen |
+| connectorId | long | ID för formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### copy(Page source) {#copy-com.aspose.diagram.Page-}
+```
+public void copy(Page source)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [Page](../../com.aspose.diagram/page) |  |
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser.
+
+### drawEllipse(double pinX, double pinY, double width, double height) {#drawEllipse-double-double-double-double-}
+```
+public long drawEllipse(double pinX, double pinY, double width, double height)
+```
+
+
+Processen för att rita en ellips.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger bredden på formen |
+| höjd | double | Anger höjden på formen |
+
+**Returns:**
+long - 
+### drawLine(double beginX, double beginY, double endX, double endY) {#drawLine-double-double-double-double-}
+```
+public long drawLine(double beginX, double beginY, double endX, double endY)
+```
+
+
+Processen för att rita en enkel linje.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| beginX | double | Anger den inledande x-koordinaten för formens position i förhållande till sidan. |
+| beginY | double | Anger den inledande y-koordinaten för formens position i förhållande till sidan. |
+| endX | double | Anger den avslutande x-koordinaten för formens position i förhållande till sidan. |
+| endY | double | Anger den slutliga y-koordinaten för figurens position i förhållande till sidan. |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### drawLine(double pinX, double pinY, double width, double height, double[] xyArray) {#drawLine-double-double-double-double-double---}
+```
+public long drawLine(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Processen för att rita en linje.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger bredden på formen |
+| höjd | double | Anger höjden på formen |
+| xyArray | double[] | En array med alternerande x- och y-värden som definierar punkter i den nya figuren |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray) {#drawPolyline-double-double-double-double-double---}
+```
+public long drawPolyline(double pinX, double pinY, double width, double height, double[] xyArray)
+```
+
+
+Processen för att rita en polylinje.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger bredden på formen |
+| höjd | double | Anger höjden på formen |
+| xyArray | double[] | En array med alternerande x- och y-värden som definierar punkter i den nya figuren |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### drawRectangle(double pinX, double pinY, double width, double height) {#drawRectangle-double-double-double-double-}
+```
+public long drawRectangle(double pinX, double pinY, double width, double height)
+```
+
+
+Processen för att rita en rektangel.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pinX | double | Anger x-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| pinY | double | Anger y-koordinaten för figurens pinne (rotationscentrum) i förhållande till sidan. |
+| bredd | double | Anger bredden på formen |
+| höjd | double | Anger höjden på formen |
+
+**Returns:**
+long - Det unika ID:t för figuren inom figurkollektionen på den angivna sidan.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAssociatedPage() {#getAssociatedPage--}
+```
+public Page getAssociatedPage()
+```
+
+
+ID för den ursprungliga ritningssidan som markerades på separata markup‑lager av ritningens granskare.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackPage() {#getBackPage--}
+```
+public Page getBackPage()
+```
+
+
+Sidans bakgrundssida.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getBackground() {#getBackground--}
+```
+public int getBackground()
+```
+
+
+En flagga som indikerar om sidan är en bakgrundssida.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnects() {#getConnects--}
+```
+public ConnectCollection getConnects()
+```
+
+
+Innehåller ett Connect-element för varje anslutning mellan två former i en ritning.
+
+**Returns:**
+[ConnectCollection](../../com.aspose.diagram/connectcollection)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPageSheet() {#getPageSheet--}
+```
+public PageSheet getPageSheet()
+```
+
+
+Innehåller element som definierar sidbladet för ett Page- eller Master-element.
+
+**Returns:**
+[PageSheet](../../com.aspose.diagram/pagesheet)
+### getPages() {#getPages--}
+```
+public PageCollection getPages()
+```
+
+
+Sidcollection.
+
+**Returns:**
+[PageCollection](../../com.aspose.diagram/pagecollection)
+### getReviewerID() {#getReviewerID--}
+```
+public int getReviewerID()
+```
+
+
+ID för den granskare som är associerad med markup‑lagret.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Formsamling.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+ViewCenterX och ViewCenterY anger en mittpunkt på en sida som en ny vy (fönster) antar när den öppnas initialt.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+ViewCenterX och ViewCenterY anger en mittpunkt på en sida som en ny vy (fönster) antar när den öppnas initialt.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Standardförstoringsfaktorn som ska användas när en ny vy (fönster) av sidan öppnas. Till exempel, 1 = 100 %; 1,5 = 150 %, osv.
+
+**Returns:**
+double
+### glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId) {#glueShapeToConnectorBeginX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorBeginX(long shapeFromId, String connectionName, long connectorId)
+```
+
+
+Fäst form till Connectorns BeginX
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för formen där anslutningen börjar [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Anslutningsnamnet på figuren där anslutaren kommer att kopplas. |
+| connectorId | long | ID för formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId) {#glueShapeToConnectorEndX-long-java.lang.String-long-}
+```
+public void glueShapeToConnectorEndX(long shapeToId, String connectionName, long connectorId)
+```
+
+
+Fäst form till Connectorns EndX
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeToId | long | ID för formen där anslutningen slutar [Shape](../../com.aspose.diagram/shape). |
+| connectionName | java.lang.String | Anslutningsnamnet på den andra formen där anslutningen kommer att anslutas. |
+| connectorId | long | ID för formen med typen Dynamisk anslutning [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo) {#glueShapes-com.aspose.diagram.Shape-int-com.aspose.diagram.Shape-}
+```
+public void glueShapes(Shape shapeFrom, int placeTo, Shape shapeTo)
+```
+
+
+Fäst former.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFrom | [Shape](../../com.aspose.diagram/shape) | Figuren som är limmad från [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Platsen på den första figuren där Aspose.Diagram.Manipulation.ConnectionPointPlace ska limmas. |
+| shapeTo | [Shape](../../com.aspose.diagram/shape) | Figuren där man ska limma till [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapes(long shapeFromId, int placeTo, long shapeToId) {#glueShapes-long-int-long-}
+```
+public void glueShapes(long shapeFromId, int placeTo, long shapeToId)
+```
+
+
+Fäst former
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för figuren som är limmad från [Shape](../../com.aspose.diagram/shape). |
+| placeTo | int | Platsen på den första figuren där Aspose.Diagram.Manipulation.ConnectionPointPlace ska limmas. |
+| shapeToId | long | ID för figuren där man ska limma till [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId) {#glueShapesInContainer-long-int-int-long-}
+```
+public void glueShapesInContainer(long shapeFromId, int shapeToBeginConnectionIndex, int shapeToEndConnectionIndex, long shapeToId)
+```
+
+
+Fäst former i behållare
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för figuren som är limmad från [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionIndex | int | Platsen på det första anslutningsindexet där man ska limma. |
+| shapeToEndConnectionIndex | int | Platsen på det sista anslutningsindexet där man ska limma. |
+| shapeToId | long | ID för figuren där man ska limma till [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId) {#glueShapesInContainer-long-java.lang.String-java.lang.String-long-}
+```
+public void glueShapesInContainer(long shapeFromId, String shapeToBeginConnectionName, String shapeToEndConnectionName, long shapeToId)
+```
+
+
+Fäst former i behållare med anslutningsnamn
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för figuren som är limmad från [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionName | java.lang.String | Platsen på det första anslutningsnamnet där man ska limma. |
+| shapeToEndConnectionName | java.lang.String | Platsen på det sista anslutningsnamnet där man ska limma. |
+| shapeToId | long | ID för figuren där man ska limma till [Shape](../../com.aspose.diagram/shape). |
+
+### glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId) {#glueShapesInContainerByID-long-int-int-long-}
+```
+public void glueShapesInContainerByID(long shapeFromId, int shapeToBeginConnectionID, int shapeToEndConnectionID, long shapeToId)
+```
+
+
+Fäst former efter anslutnings‑ID i behållare
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeFromId | long | ID för figuren som är limmad från [Shape](../../com.aspose.diagram/shape). |
+| shapeToBeginConnectionID | int | Platsen på det första anslutnings-ID:t där man ska limma. |
+| shapeToEndConnectionID | int | Platsen på det sista anslutnings-ID:t där man ska limma. |
+| shapeToId | long | ID för figuren där man ska limma till [Shape](../../com.aspose.diagram/shape). |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### layout(LayoutOptions options) {#layout-com.aspose.diagram.LayoutOptions-}
+```
+public void layout(LayoutOptions options)
+```
+
+
+Lägger ut formerna och/eller omdirigerar anslutningarna för sidan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| options | [LayoutOptions](../../com.aspose.diagram/layoutoptions) | Använd [LayoutOptions](../../com.aspose.diagram/layoutoptions) för att konfigurera layoutalternativ. |
+
+### moveTo(int index) {#moveTo-int-}
+```
+public void moveTo(int index)
+```
+
+
+Flyttar sidan till en annan plats bland sidorna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Destinationssidans index. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### sendBackward(long shapeId) {#sendBackward-long-}
+```
+public void sendBackward(long shapeId)
+```
+
+
+Flyttar en form, definierad av ID, ett steg bakåt i z‑ordningen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### sendToBack(long shapeId) {#sendToBack-long-}
+```
+public void sendToBack(long shapeId)
+```
+
+
+Flyttar en form, definierad av ID, till slutet av z‑ordningen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shapeId | long | ID of shape.long |
+
+### setAssociatedPage(Page value) {#setAssociatedPage-com.aspose.diagram.Page-}
+```
+public void setAssociatedPage(Page value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAssociatedPage()](../../com.aspose.diagram/page\#getAssociatedPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackPage(Page value) {#setBackPage-com.aspose.diagram.Page-}
+```
+public void setBackPage(Page value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackPage()](../../com.aspose.diagram/page\#getBackPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setBackground(int value) {#setBackground-int-}
+```
+public void setBackground(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackground()](../../com.aspose.diagram/page\#getBackground--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/page\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/page\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/page\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPages(PageCollection value) {#setPages-com.aspose.diagram.PageCollection-}
+```
+public void setPages(PageCollection value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPages()](../../com.aspose.diagram/page\#getPages--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageCollection](../../com.aspose.diagram/pagecollection) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Tillämpa ett förinställt tema på den här sidan
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Tillämpa en förinställd temavariant snabbstil på den här sidan
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Tillämpa en förinställd temavariant på den här sidan
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setReviewerID(int value) {#setReviewerID-int-}
+```
+public void setReviewerID(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getReviewerID()](../../com.aspose.diagram/page\#getReviewerID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewCenterX()](../../com.aspose.diagram/page\#getViewCenterX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewCenterY()](../../com.aspose.diagram/page\#getViewCenterY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewScale()](../../com.aspose.diagram/page\#getViewScale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/pagecollection/_index.md
@@ -1,0 +1,259 @@
+---
+title: PageCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Sidcollection.
+type: docs
+weight: 261
+url: /sv/java/com.aspose.diagram/pagecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PageCollection extends Collection
+```
+
+Sidcollection.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Lägg till sidan i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [dispose()](#dispose--) | Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getPage(int ID)](#getPage-int-) | Hämtar elementet med angivet ID. |
+| [getPage(String name)](#getPage-java.lang.String-) | Hämtar elementet med angivet namn. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Ta bort sidan från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Lägg till sidan i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+Utför applikationsdefinierade uppgifter som är relaterade till att frigöra, släppa eller återställa ohanterade resurser.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Page get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getPage(int ID) {#getPage-int-}
+```
+public Page getPage(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### getPage(String name) {#getPage-java.lang.String-}
+```
+public Page getPage(String name)
+```
+
+
+Hämtar elementet med angivet namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Page](../../com.aspose.diagram/page) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Ta bort sidan från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pageendsavingargs/_index.md
+++ b/swedish/java/com.aspose.diagram/pageendsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageEndSavingArgs
+second_title: Aspose.Diagram för Java API-referens
+description: Information för en sida avslutar sparningsprocessen.
+type: docs
+weight: 262
+url: /sv/java/com.aspose.diagram/pageendsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageEndSavingArgs extends PageSavingArgs
+```
+
+Information för en sida avslutar sparningsprocessen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Totalt sidantal. |
+| [getPageIndex()](#getPageIndex--) | Aktuellt sidindex, nollbaserat. |
+| [hasMorePages()](#hasMorePages--) | Ett värde som indikerar om det finns fler sidor att skriva ut. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHasMorePages(boolean value)](#setHasMorePages-boolean-) | För beskrivningen av den här egenskapen, se [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Totalt sidantal.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktuellt sidindex, nollbaserat.
+
+**Returns:**
+int
+### hasMorePages() {#hasMorePages--}
+```
+public boolean hasMorePages()
+```
+
+
+Ett värde som indikerar om det finns fler sidor att skriva ut. Standardvärdet är sant.
+
+**Returns:**
+boolean
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHasMorePages(boolean value) {#setHasMorePages-boolean-}
+```
+public void setHasMorePages(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [hasMorePages()](../../com.aspose.diagram/pageendsavingargs\#hasMorePages--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagelayout/_index.md
+++ b/swedish/java/com.aspose.diagram/pagelayout/_index.md
@@ -1,0 +1,458 @@
+---
+title: PageLayout
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller celler som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan.
+type: docs
+weight: 263
+url: /sv/java/com.aspose.diagram/pagelayout/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLayout
+```
+
+Innehåller celler som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAvenueSizeX()](#getAvenueSizeX--) | Bestämmer mängden vertikalt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getAvenueSizeY()](#getAvenueSizeY--) | Bestämmer mängden vertikalt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getAvoidPageBreaks()](#getAvoidPageBreaks--) | Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form). |
+| [getBlockSizeX()](#getBlockSizeX--) | Bestämmer den vertikala blockstorleken, det område där var och en av dina former måste få plats på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getBlockSizeY()](#getBlockSizeY--) | Bestämmer mängden horisontellt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getClass()](#getClass--) |  |
+| [getCtrlAsInput()](#getCtrlAsInput--) | Bestämmer vilken form som är förälder när du använder former med kontrollhandtag. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDynamicsOff()](#getDynamicsOff--) | Anger om placerbara former flyttar och anslutningar omdirigeras runt andra former och anslutningar på ritningssidan. |
+| [getEnableGrid()](#getEnableGrid--) | Anger om Microsoft Visio placerar former baserat på ett internt sidrutnät när användaren väljer Lay Out Shapes (Shape menu). |
+| [getLineAdjustFrom()](#getLineAdjustFrom--) | Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra. |
+| [getLineAdjustTo()](#getLineAdjustTo--) | Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra. |
+| [getLineJumpCode()](#getLineJumpCode--) | Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil. |
+| [getLineJumpFactorX()](#getLineJumpFactorX--) | Anger storleken på linjsprång på horisontella segment av dynamiska anslutningar på sidan, som en procentandel av värdet för elementet LineToLineX (som anger det horisontella avståndet mellan alla anslutningar på ritningssidan). |
+| [getLineJumpFactorY()](#getLineJumpFactorY--) | Anger storleken på linjsprång på vertikala segment av dynamiska anslutningar på sidan, som en procentandel av värdet för elementet LineToLineY (som anger det vertikala avståndet mellan alla anslutningar på ritningssidan). |
+| [getLineJumpStyle()](#getLineJumpStyle--) | Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [getLineRouteExt()](#getLineRouteExt--) | Specificerar standardutseendet för alla anslutningar på en sida. |
+| [getLineToLineX()](#getLineToLineX--) | Anger det minsta horisontella avståndet mellan dynamiska anslutningar på ritningssidan. |
+| [getLineToLineY()](#getLineToLineY--) | Anger det minsta vertikala avståndet mellan dynamiska anslutningar på ritningssidan. |
+| [getLineToNodeX()](#getLineToNodeX--) | Anger det minsta vertikala avståndet mellan dynamiska anslutningar och former på ritningssidan. |
+| [getLineToNodeY()](#getLineToNodeY--) | Bestämmer den horisontella blockstorleken, det område där var och en av dina former måste få plats på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan. |
+| [getPageLineJumpDirX()](#getPageLineJumpDirX--) | Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [getPageLineJumpDirY()](#getPageLineJumpDirY--) | Anger det minsta horisontella avståndet mellan dynamiska anslutningar och former på ritningssidan. |
+| [getPageShapeSplit()](#getPageShapeSplit--) | Indikerar om former på sidan kan delas automatiskt. |
+| [getPlaceDepth()](#getPlaceDepth--) | Anger om placerbara former flyttar bort när användaren drar en placerbar form nära en annan placerbar form på ritningssidan. |
+| [getPlaceFlip()](#getPlaceFlip--) | Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio. |
+| [getPlaceStyle()](#getPlaceStyle--) | Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil. |
+| [getPlowCode()](#getPlowCode--) | Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för. |
+| [getResizePage()](#getResizePage--) | Anger om sidan ska förstoras för att omfatta ritningen efter att en användare har valt Lay Out Shapes (Shapes menu). |
+| [getRouteStyle()](#getRouteStyle--) | För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/pagelayout\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAvenueSizeX() {#getAvenueSizeX--}
+```
+public DoubleValue getAvenueSizeX()
+```
+
+
+Bestämmer mängden vertikalt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvenueSizeY() {#getAvenueSizeY--}
+```
+public DoubleValue getAvenueSizeY()
+```
+
+
+Bestämmer mängden vertikalt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getAvoidPageBreaks() {#getAvoidPageBreaks--}
+```
+public BoolValue getAvoidPageBreaks()
+```
+
+
+Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getBlockSizeX() {#getBlockSizeX--}
+```
+public DoubleValue getBlockSizeX()
+```
+
+
+Bestämmer den vertikala blockstorleken, det område där var och en av dina former måste få plats på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBlockSizeY() {#getBlockSizeY--}
+```
+public DoubleValue getBlockSizeY()
+```
+
+
+Bestämmer mängden horisontellt utrymme mellan former på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCtrlAsInput() {#getCtrlAsInput--}
+```
+public BoolValue getCtrlAsInput()
+```
+
+
+Bestämmer vilken form som är förälder när du använder former med kontrollhandtag. Detta element anger beteendet för alla former på ritningssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDynamicsOff() {#getDynamicsOff--}
+```
+public BoolValue getDynamicsOff()
+```
+
+
+Anger om placerbara former flyttar och anslutningar omdirigeras runt andra former och anslutningar på ritningssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableGrid() {#getEnableGrid--}
+```
+public BoolValue getEnableGrid()
+```
+
+
+Anger om Microsoft Visio placerar former baserat på ett internt sidrutnät när användaren väljer Lay Out Shapes (Shape menu).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLineAdjustFrom() {#getLineAdjustFrom--}
+```
+public LineAdjustFrom getLineAdjustFrom()
+```
+
+
+Specificerar vilka dynamiska anslutningar som ska separeras om de ruttas ovanpå varandra.
+
+**Returns:**
+[LineAdjustFrom](../../com.aspose.diagram/lineadjustfrom)
+### getLineAdjustTo() {#getLineAdjustTo--}
+```
+public LineAdjustTo getLineAdjustTo()
+```
+
+
+Specificerar vilka dynamiska anslutningar som ska linjeras ovanpå varandra om de ruttas ovanpå varandra.
+
+**Returns:**
+[LineAdjustTo](../../com.aspose.diagram/lineadjustto)
+### getLineJumpCode() {#getLineJumpCode--}
+```
+public LineJumpCode getLineJumpCode()
+```
+
+
+Specificerar linjesprångsstilen för alla anslutningar på ritningssidan som inte har en lokal linjesprångsstil.
+
+**Returns:**
+[LineJumpCode](../../com.aspose.diagram/linejumpcode)
+### getLineJumpFactorX() {#getLineJumpFactorX--}
+```
+public DoubleValue getLineJumpFactorX()
+```
+
+
+Anger storleken på linjsprång på horisontella segment av dynamiska anslutningar på sidan, som en procentandel av värdet för elementet LineToLineX (som anger det horisontella avståndet mellan alla anslutningar på ritningssidan). Värdet för detta element varierar från 0 till 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpFactorY() {#getLineJumpFactorY--}
+```
+public DoubleValue getLineJumpFactorY()
+```
+
+
+Anger storleken på linjsprång på vertikala segment av dynamiska anslutningar på sidan, som en procentandel av värdet för elementet LineToLineY (som anger det vertikala avståndet mellan alla anslutningar på ritningssidan). Detta element kan ha ett värde från 0 till 10.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineJumpStyle() {#getLineJumpStyle--}
+```
+public LineJumpStyle getLineJumpStyle()
+```
+
+
+Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+
+**Returns:**
+[LineJumpStyle](../../com.aspose.diagram/linejumpstyle)
+### getLineRouteExt() {#getLineRouteExt--}
+```
+public LineRouteExt getLineRouteExt()
+```
+
+
+Specificerar standardutseendet för alla anslutningar på en sida.
+
+**Returns:**
+[LineRouteExt](../../com.aspose.diagram/linerouteext)
+### getLineToLineX() {#getLineToLineX--}
+```
+public DoubleValue getLineToLineX()
+```
+
+
+Anger det minsta horisontella avståndet mellan dynamiska anslutningar på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToLineY() {#getLineToLineY--}
+```
+public DoubleValue getLineToLineY()
+```
+
+
+Anger det minsta vertikala avståndet mellan dynamiska anslutningar på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeX() {#getLineToNodeX--}
+```
+public DoubleValue getLineToNodeX()
+```
+
+
+Anger det minsta vertikala avståndet mellan dynamiska anslutningar och former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLineToNodeY() {#getLineToNodeY--}
+```
+public DoubleValue getLineToNodeY()
+```
+
+
+Bestämmer den horisontella blockstorleken, det område där var och en av dina former måste få plats på ritningssidan när du använder Microsoft Visio för att placera former på ritningssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLineJumpDirX() {#getPageLineJumpDirX--}
+```
+public PageLineJumpDirX getPageLineJumpDirX()
+```
+
+
+Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+
+**Returns:**
+[PageLineJumpDirX](../../com.aspose.diagram/pagelinejumpdirx)
+### getPageLineJumpDirY() {#getPageLineJumpDirY--}
+```
+public PageLineJumpDirY getPageLineJumpDirY()
+```
+
+
+Anger det minsta horisontella avståndet mellan dynamiska anslutningar och former på ritningssidan.
+
+**Returns:**
+[PageLineJumpDirY](../../com.aspose.diagram/pagelinejumpdiry)
+### getPageShapeSplit() {#getPageShapeSplit--}
+```
+public BoolValue getPageShapeSplit()
+```
+
+
+Indikerar om former på sidan kan delas automatiskt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPlaceDepth() {#getPlaceDepth--}
+```
+public PlaceDepth getPlaceDepth()
+```
+
+
+Anger om placerbara former flyttar bort när användaren drar en placerbar form nära en annan placerbar form på ritningssidan.
+
+**Returns:**
+[PlaceDepth](../../com.aspose.diagram/placedepth)
+### getPlaceFlip() {#getPlaceFlip--}
+```
+public PlaceFlip getPlaceFlip()
+```
+
+
+Anger hur placerbara former vänds och/eller roteras på en sida när former placeras med kommandot Lay Out Shapes i Microsoft Visio. Följande hexadecimala värden är tillåtna.
+
+**Returns:**
+[PlaceFlip](../../com.aspose.diagram/placeflip)
+### getPlaceStyle() {#getPlaceStyle--}
+```
+public PlaceStyle getPlaceStyle()
+```
+
+
+Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+
+**Returns:**
+[PlaceStyle](../../com.aspose.diagram/placestyle)
+### getPlowCode() {#getPlowCode--}
+```
+public BoolValue getPlowCode()
+```
+
+
+Bestämmer de dynamiska anslutningarna som du vill lägga till hopp för.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getResizePage() {#getResizePage--}
+```
+public BoolValue getResizePage()
+```
+
+
+Anger om sidan ska förstoras för att omfatta ritningen efter att en användare har valt Lay Out Shapes (Shapes menu).
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getRouteStyle() {#getRouteStyle--}
+```
+public RouteStyle getRouteStyle()
+```
+
+
+För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+
+**Returns:**
+[RouteStyle](../../com.aspose.diagram/routestyle)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/pagelayout\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagelinejumpdirx/_index.md
+++ b/swedish/java/com.aspose.diagram/pagelinejumpdirx/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirX
+second_title: Aspose.Diagram för Java API-referens
+description: Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+type: docs
+weight: 264
+url: /sv/java/com.aspose.diagram/pagelinejumpdirx/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirX
+```
+
+Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PageLineJumpDirX(int value)](#PageLineJumpDirX-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirX(int value) {#PageLineJumpDirX-int-}
+```
+public PageLineJumpDirX(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/pagelinejumpdirx\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/pagelinejumpdirxvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirXValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+type: docs
+weight: 265
+url: /sv/java/com.aspose.diagram/pagelinejumpdirxvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirXValue
+```
+
+Anger riktningen för linjsprång på horisontella segment av dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEFAULT_UP](#DEFAULT-UP) | Standard upp. |
+| [DOWN](#DOWN) | Ned |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [UP](#UP) | Upp. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_UP {#DEFAULT-UP}
+```
+public static final int DEFAULT_UP
+```
+
+
+Standard upp.
+
+### DOWN {#DOWN}
+```
+public static final int DOWN
+```
+
+
+Ned
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### UP {#UP}
+```
+public static final int UP
+```
+
+
+Upp.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagelinejumpdiry/_index.md
+++ b/swedish/java/com.aspose.diagram/pagelinejumpdiry/_index.md
@@ -1,0 +1,179 @@
+---
+title: PageLineJumpDirY
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar riktningen för linjesprång på vertikala dynamiska anslutningar på ritningssidan för vilka du inte har angett en lokal hoppningsriktning.
+type: docs
+weight: 266
+url: /sv/java/com.aspose.diagram/pagelinejumpdiry/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageLineJumpDirY
+```
+
+Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PageLineJumpDirY(int value)](#PageLineJumpDirY-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageLineJumpDirY(int value) {#PageLineJumpDirY-int-}
+```
+public PageLineJumpDirY(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/pagelinejumpdiry\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/pagelinejumpdiryvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PageLineJumpDirYValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar riktningen för linjesprång på vertikala dynamiska anslutningar på ritningssidan för vilka du inte har angett en lokal hoppningsriktning.
+type: docs
+weight: 267
+url: /sv/java/com.aspose.diagram/pagelinejumpdiryvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PageLineJumpDirYValue
+```
+
+Anger riktningen för linjsprång på vertikala dynamiska anslutningar på ritningssidan där du inte har angett en lokal hoppdirektion.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEFAULTLEFT](#DEFAULTLEFT) | Standard vänster. |
+| [LEFT](#LEFT) | Vänster. |
+| [RIGHT](#RIGHT) | Höger. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULTLEFT {#DEFAULTLEFT}
+```
+public static final int DEFAULTLEFT
+```
+
+
+Standard vänster.
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Vänster.
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Höger.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pageprops/_index.md
+++ b/swedish/java/com.aspose.diagram/pageprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PageProps
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller celler som styr sidattribut såsom sidans bredd, höjd och skala.
+type: docs
+weight: 268
+url: /sv/java/com.aspose.diagram/pageprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageProps
+```
+
+Innehåller celler som styr sidattribut, såsom sidbredd, höjd och skala.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDrawingResizeType()](#getDrawingResizeType--) | Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet. |
+| [getDrawingScale()](#getDrawingScale--) | Representerar värdet för ritningsenheten i den aktuella ritningsskalan. |
+| [getDrawingScaleType()](#getDrawingScaleType--) | Anger vilken typ av ritningsskala som ska användas för en sida. |
+| [getDrawingSizeType()](#getDrawingSizeType--) | Anger ritningsstorleken för en sida. |
+| [getInhibitSnap()](#getInhibitSnap--) | Anger om formerna på en förgrundssida fästs till andra objekt på sidan och former på bakgrundssidan. |
+| [getPageHeight()](#getPageHeight--) | Anger sidans höjd i ritningsenheter. |
+| [getPageScale()](#getPageScale--) | Anger värdet för standardsidans enhet i den aktuella ritningsskalan. |
+| [getPageWidth()](#getPageWidth--) | Anger sidans bredd i ritningsenheter. |
+| [getShdwObliqueAngle()](#getShdwObliqueAngle--) | Innehåller ett tal som anger vinkeln för sned riktning när standard sidskuggtyp tillämpas. |
+| [getShdwOffsetX()](#getShdwOffsetX--) | Anger avståndet i sid-enheter som en formes skugga förskjuts horisontellt från formen. |
+| [getShdwOffsetY()](#getShdwOffsetY--) | Anger avståndet i sid-enheter som en formes skugga förskjuts vertikalt från formen. |
+| [getShdwScaleFactor()](#getShdwScaleFactor--) | Anger procentandelen för att förstora eller minska en formes skugga. |
+| [getShdwType()](#getShdwType--) | Anger standardskuggtyp för en sida. |
+| [getUIVisibility()](#getUIVisibility--) | Bestämmer om sidnamnet visas i användargränssnittet (UI). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/pageprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDrawingResizeType() {#getDrawingResizeType--}
+```
+public DrawingResizeType getDrawingResizeType()
+```
+
+
+Bestämmer om ritningssidan automatiskt ändrar storlek för att passa diagrammet.
+
+**Returns:**
+[DrawingResizeType](../../com.aspose.diagram/drawingresizetype)
+### getDrawingScale() {#getDrawingScale--}
+```
+public DoubleValue getDrawingScale()
+```
+
+
+Representerar värdet för ritningsenheten i den aktuella ritningsskalan. Ritningsskalan för sidan är förhållandet mellan sidans enhet som finns i PageScale‑elementet och ritningsenheten. Enheterna i detta element bestämmer standardlängden (DL) för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDrawingScaleType() {#getDrawingScaleType--}
+```
+public DrawingScaleType getDrawingScaleType()
+```
+
+
+Anger vilken typ av ritningsskala som ska användas för en sida.
+
+**Returns:**
+[DrawingScaleType](../../com.aspose.diagram/drawingscaletype)
+### getDrawingSizeType() {#getDrawingSizeType--}
+```
+public DrawingSizeType getDrawingSizeType()
+```
+
+
+Anger ritningsstorleken för en sida.
+
+**Returns:**
+[DrawingSizeType](../../com.aspose.diagram/drawingsizetype)
+### getInhibitSnap() {#getInhibitSnap--}
+```
+public BoolValue getInhibitSnap()
+```
+
+
+Anger om formerna på en förgrundssida fästs till andra objekt på sidan och former på bakgrundssidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageHeight() {#getPageHeight--}
+```
+public DoubleValue getPageHeight()
+```
+
+
+Anger sidans höjd i ritningsenheter.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageScale() {#getPageScale--}
+```
+public DoubleValue getPageScale()
+```
+
+
+Anger värdet för standard sidans enhet i den aktuella ritningsskalan. Ritningsskalan för sidan är förhållandet mellan sidans enhet i PageScale‑elementet och ritningsenheten som visas i DrawingScale‑elementet.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageWidth() {#getPageWidth--}
+```
+public DoubleValue getPageWidth()
+```
+
+
+Anger sidans bredd i ritningsenheter.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwObliqueAngle() {#getShdwObliqueAngle--}
+```
+public DoubleValue getShdwObliqueAngle()
+```
+
+
+Innehåller ett tal som anger vinkeln för sned riktning när standard sidskuggtyp tillämpas.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetX() {#getShdwOffsetX--}
+```
+public DoubleValue getShdwOffsetX()
+```
+
+
+Anger avståndet i sid-enheter som en formes skugga förskjuts horisontellt från formen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwOffsetY() {#getShdwOffsetY--}
+```
+public DoubleValue getShdwOffsetY()
+```
+
+
+Anger avståndet i sid-enheter som en formes skugga förskjuts vertikalt från formen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwScaleFactor() {#getShdwScaleFactor--}
+```
+public DoubleValue getShdwScaleFactor()
+```
+
+
+Anger procentandelen för att förstora eller minska en formes skugga.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getShdwType() {#getShdwType--}
+```
+public ShdwType getShdwType()
+```
+
+
+Anger standardskuggtyp för en sida.
+
+**Returns:**
+[ShdwType](../../com.aspose.diagram/shdwtype)
+### getUIVisibility() {#getUIVisibility--}
+```
+public UIVisibility getUIVisibility()
+```
+
+
+Bestämmer om sidnamnet visas i användargränssnittet (UI). Ett värde på ett anger att sidan inte är synlig; ett värde på noll anger att sidan är synlig.
+
+**Returns:**
+[UIVisibility](../../com.aspose.diagram/uivisibility)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/pageprops\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagesavingargs/_index.md
+++ b/swedish/java/com.aspose.diagram/pagesavingargs/_index.md
@@ -1,0 +1,147 @@
+---
+title: PageSavingArgs
+second_title: Aspose.Diagram för Java API-referens
+description: Information för en sidas sparningsprocess.
+type: docs
+weight: 269
+url: /sv/java/com.aspose.diagram/pagesavingargs/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSavingArgs
+```
+
+Information för en sidas sparningsprocess.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Totalt sidantal. |
+| [getPageIndex()](#getPageIndex--) | Aktuellt sidindex, nollbaserat. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Totalt sidantal.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktuellt sidindex, nollbaserat.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagesheet/_index.md
+++ b/swedish/java/com.aspose.diagram/pagesheet/_index.md
@@ -1,0 +1,426 @@
+---
+title: PageSheet
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som definierar sidbladet för ett Page- eller Master-element.
+type: docs
+weight: 270
+url: /sv/java/com.aspose.diagram/pagesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSheet
+```
+
+Innehåller element som definierar sidbladet för ett Page- eller Master-element.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [copy(PageSheet source)](#copy-com.aspose.diagram.PageSheet-) | Kopierar pagesheet från ett källobjekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActs()](#getActs--) | Innehåller en samling av Act-element. |
+| [getAnnotations()](#getAnnotations--) | Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Innehåller en samling av ConnectionABCD-element. |
+| [getConnections()](#getConnections--) | Innehåller en samling av Connection-element. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-element som PageSheet ärver fyllningsformatering från. |
+| [getForeign()](#getForeign--) | Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. |
+| [getForeignData()](#getForeignData--) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [getHyperlinks()](#getHyperlinks--) | Innehåller en samling Hyperlink-element. |
+| [getLayers()](#getLayers--) | Innehåller en samling av Layer-element. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-element som PageSheet ärver linjeformatering från. |
+| [getPageLayout()](#getPageLayout--) | Innehåller Diagram som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan. |
+| [getPageProps()](#getPageProps--) | Innehåller Diagram som styr sidattribut, såsom sidbredd, höjd och skala. |
+| [getPrintProps()](#getPrintProps--) | Innehåller element som styr hur ritningssidan formateras (visas) på utskriftssidan. |
+| [getProps()](#getProps--) | Innehåller en samling Prop-element. |
+| [getRulerGrid()](#getRulerGrid--) | Innehåller element som specificerar inställningarna för sidans linjaler och rutnät. |
+| [getScratchs()](#getScratchs--) | Innehåller en samling Scratch-element. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Innehåller en samling av SmartTagDef-element. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-element som PageSheet ärver textformatering från. |
+| [getUniqueID()](#getUniqueID--) | En GUID (globalt unik identifierare) för elementet. |
+| [getUsers()](#getUsers--) | Innehåller en samling User-element. |
+| [getXForm()](#getXForm--) | Innehåller element som specificerar generell placeringsinformation om en form. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av den här egenskapen, se [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | För beskrivningen av den här egenskapen, se [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### copy(PageSheet source) {#copy-com.aspose.diagram.PageSheet-}
+```
+public void copy(PageSheet source)
+```
+
+
+Kopierar pagesheet från ett källobjekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [PageSheet](../../com.aspose.diagram/pagesheet) | käll‑pagesheet. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Innehåller en samling av Act-element.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAnnotations() {#getAnnotations--}
+```
+public AnnotationCollection getAnnotations()
+```
+
+
+Innehåller element som innehåller information om kommentarer som infogats i en dokumentsida.
+
+**Returns:**
+[AnnotationCollection](../../com.aspose.diagram/annotationcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Innehåller en samling av ConnectionABCD-element.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Innehåller en samling av Connection-element.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-element som PageSheet ärver fyllningsformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. Inkluderar också element som specificerar avståndet som objektets bild förskjuts inom dess kanter.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Innehåller en samling Hyperlink-element.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getLayers() {#getLayers--}
+```
+public LayerCollection getLayers()
+```
+
+
+Innehåller en samling av Layer-element.
+
+**Returns:**
+[LayerCollection](../../com.aspose.diagram/layercollection)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-element som PageSheet ärver linjeformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Innehåller Diagram som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getPageProps() {#getPageProps--}
+```
+public PageProps getPageProps()
+```
+
+
+Innehåller Diagram som styr sidattribut, såsom sidbredd, höjd och skala.
+
+**Returns:**
+[PageProps](../../com.aspose.diagram/pageprops)
+### getPrintProps() {#getPrintProps--}
+```
+public PrintProps getPrintProps()
+```
+
+
+Innehåller element som styr hur ritningssidan formateras (visas) på utskriftssidan.
+
+**Returns:**
+[PrintProps](../../com.aspose.diagram/printprops)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Innehåller en samling Prop-element.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Innehåller element som specificerar inställningarna för sidans linjaler och rutnät.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Innehåller en samling Scratch-element.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Innehåller en samling av SmartTagDef-element.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-element som PageSheet ärver textformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+En GUID (globalt unik identifierare) för elementet.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Innehåller en samling User-element.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Innehåller element som specificerar generell placeringsinformation om en form.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/pagesheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/pagesheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTextStyle()](../../com.aspose.diagram/pagesheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUniqueID()](../../com.aspose.diagram/pagesheet\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.UUID |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagesize/_index.md
+++ b/swedish/java/com.aspose.diagram/pagesize/_index.md
@@ -1,0 +1,233 @@
+---
+title: PageSize
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller information om sidstorlek för de genererade bilderna.
+type: docs
+weight: 271
+url: /sv/java/com.aspose.diagram/pagesize/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PageSize
+```
+
+Innehåller information om sidstorlek för de genererade bilderna.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PageSize(int paperSizeFormat)](#PageSize-int-) | Initierar en ny instans av den här klassen som kan användas för att ställa in sidstorlek för de genererade bilderna. |
+| [PageSize(float width, float height)](#PageSize-float-float-) | Initierar en ny instans av den här klassen som kan användas för att ställa in sidstorlek för de genererade bilderna. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | sidans höjd i punkter för de genererade bilderna. |
+| [getPaperSizeFormat()](#getPaperSizeFormat--) | pappersstorleksformatet för de genererade bilderna. |
+| [getWidth()](#getWidth--) | sidans bredd i punkter för de genererade bilderna. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--) |
+| [setPaperSizeFormat(int value)](#setPaperSizeFormat-int-) | För beskrivningen av den här egenskapen, se [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--) |
+| [setWidth(float value)](#setWidth-float-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSize(int paperSizeFormat) {#PageSize-int-}
+```
+public PageSize(int paperSizeFormat)
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att ställa in sidstorlek för de genererade bilderna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| paperSizeFormat | int | Kan vara Aspose.Diagram.Saving.PaperSizeFormat. |
+
+### PageSize(float width, float height) {#PageSize-float-float-}
+```
+public PageSize(float width, float height)
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att ställa in sidstorlek för de genererade bilderna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| bredd | float | Sidbredd i punkter för de genererade bilderna. |
+| höjd | float | Sidhöjd i punkter för de genererade bilderna. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+sidans höjd i punkter för de genererade bilderna. Värdet måste vara > 0. Om Height är satt, måste Width också vara satt.
+
+**Returns:**
+float
+### getPaperSizeFormat() {#getPaperSizeFormat--}
+```
+public int getPaperSizeFormat()
+```
+
+
+pappersstorleksformatet för de genererade bilderna. Kan vara Aspose.Diagram.Saving.PaperSizeFormat.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+sidans bredd i punkter för de genererade bilderna. Värdet måste vara > 0. Om Width är satt, måste Height också vara satt.
+
+**Returns:**
+float
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/pagesize\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### setPaperSizeFormat(int value) {#setPaperSizeFormat-int-}
+```
+public void setPaperSizeFormat(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPaperSizeFormat()](../../com.aspose.diagram/pagesize\#getPaperSizeFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/pagesize\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | float |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pagestartsavingargs/_index.md
+++ b/swedish/java/com.aspose.diagram/pagestartsavingargs/_index.md
@@ -1,0 +1,172 @@
+---
+title: PageStartSavingArgs
+second_title: Aspose.Diagram för Java API-referens
+description: Information för en sida påbörjar sparningsprocessen.
+type: docs
+weight: 272
+url: /sv/java/com.aspose.diagram/pagestartsavingargs/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.PageSavingArgs](../../com.aspose.diagram/pagesavingargs)
+```
+public class PageStartSavingArgs extends PageSavingArgs
+```
+
+Information för en sida påbörjar sparningsprocessen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageCount()](#getPageCount--) | Totalt sidantal. |
+| [getPageIndex()](#getPageIndex--) | Aktuellt sidindex, nollbaserat. |
+| [hashCode()](#hashCode--) |  |
+| [isToOutput()](#isToOutput--) | Ett värde som anger om sidan ska skrivas ut. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setToOutput(boolean value)](#setToOutput-boolean-) | För beskrivning av denna egenskap, se [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+Totalt sidantal.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Aktuellt sidindex, nollbaserat.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isToOutput() {#isToOutput--}
+```
+public boolean isToOutput()
+```
+
+
+Ett värde som anger om sidan ska skrivas ut. Standardvärdet är true.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setToOutput(boolean value) {#setToOutput-boolean-}
+```
+public void setToOutput(boolean value)
+```
+
+
+För beskrivning av denna egenskap, se [isToOutput()](../../com.aspose.diagram/pagestartsavingargs\#isToOutput--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/papersizeformat/_index.md
+++ b/swedish/java/com.aspose.diagram/papersizeformat/_index.md
@@ -1,0 +1,435 @@
+---
+title: PaperSizeFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Enumeration för val av pappersstorleksformat vid sparande.
+type: docs
+weight: 273
+url: /sv/java/com.aspose.diagram/papersizeformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PaperSizeFormat
+```
+
+Enumeration för val av pappersstorleksformat vid sparande.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [A_0](#A-0) | A0 pappersstorleksformat(841mm x 1189mm). |
+| [A_1](#A-1) | A1 pappersstorleksformat(594mm x 841mm). |
+| [A_2](#A-2) | A2 pappersstorleksformat(420mm x 594mm). |
+| [A_3](#A-3) | A3 pappersstorleksformat(297mm x 420mm). |
+| [A_4](#A-4) | A4 pappersstorleksformat(210mm x 297mm). |
+| [A_5](#A-5) | A5 pappersstorleksformat(148mm x 210mm). |
+| [A_6](#A-6) | A6 pappersstorleksformat(105mm x 148mm). |
+| [A_7](#A-7) | A7 pappersstorleksformat(74mm x 105mm). |
+| [B_0](#B-0) | B0 pappersstorleksformat(1000mm x 1414mm). |
+| [B_1](#B-1) | B1 pappersstorleksformat(707mm x 1000mm). |
+| [B_2](#B-2) | B2 pappersstorleksformat(500mm x 707mm). |
+| [B_3](#B-3) | B3 pappersstorleksformat(353mm x 500mm). |
+| [B_4](#B-4) | B4 pappersstorleksformat(250mm x 353mm). |
+| [B_5](#B-5) | B5 pappersstorleksformat(176mm x 250mm). |
+| [B_6](#B-6) | B6 pappersstorleksformat(125mm x 176mm). |
+| [B_7](#B-7) | B7 pappersstorleksformat(88mm x 125mm). |
+| [COM_10](#COM-10) | COM10 pappersstorleksformat(104.78mm x 241.3mm). |
+| [COM_9](#COM-9) | COM9 pappersstorleksformat(98.4mm x 225.4mInterpolationMode:Invalidm). |
+| [CUSTOM](#CUSTOM) | Anpassat pappersstorleksformat. |
+| [C_0](#C-0) | C0 pappersstorleksformat(917mm x 1297mm). |
+| [C_1](#C-1) | C1 pappersstorleksformat(648mm x 917mm). |
+| [C_2](#C-2) | C2 pappersstorleksformat(458mm x 648mm). |
+| [C_3](#C-3) | C3 pappersstorleksformat(324mm x 458mm). |
+| [C_4](#C-4) | C4 pappersstorleksformat(229mm x 324mm). |
+| [C_5](#C-5) | C5 pappersstorleksformat(162mm x 229mm). |
+| [C_6](#C-6) | C6 pappersstorleksformat(114mm x 162mm). |
+| [C_7](#C-7) | C7 pappersstorleksformat(81mm x 114mm). |
+| [DL](#DL) | DL pappersstorleksformat(110mm x 220mm). |
+| [EXECUTIVE](#EXECUTIVE) | Executive pappersstorleksformat(184.15mm x 266.7mm). |
+| [LEGAL](#LEGAL) | Legal pappersstorleksformat(215.9mm x 355.6mm). |
+| [LEGAL_13](#LEGAL-13) | Legal13 pappersstorleksformat(215.9mm x 330.2mm). |
+| [LETTER](#LETTER) | Letter pappersstorleksformat(215.9mm x 279.7mm). |
+| [MONARCH](#MONARCH) | Monarch pappersstorleksformat(98.4mm x 190.5mm). |
+| [TABLOID](#TABLOID) | Tabloid pappersstorleksformat(279.4mm x 431.8mm). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### A_0 {#A-0}
+```
+public static final int A_0
+```
+
+
+A0 pappersstorleksformat(841mm x 1189mm).
+
+### A_1 {#A-1}
+```
+public static final int A_1
+```
+
+
+A1 pappersstorleksformat(594mm x 841mm).
+
+### A_2 {#A-2}
+```
+public static final int A_2
+```
+
+
+A2 pappersstorleksformat(420mm x 594mm).
+
+### A_3 {#A-3}
+```
+public static final int A_3
+```
+
+
+A3 pappersstorleksformat(297mm x 420mm).
+
+### A_4 {#A-4}
+```
+public static final int A_4
+```
+
+
+A4 pappersstorleksformat(210mm x 297mm).
+
+### A_5 {#A-5}
+```
+public static final int A_5
+```
+
+
+A5 pappersstorleksformat(148mm x 210mm).
+
+### A_6 {#A-6}
+```
+public static final int A_6
+```
+
+
+A6 pappersstorleksformat(105mm x 148mm).
+
+### A_7 {#A-7}
+```
+public static final int A_7
+```
+
+
+A7 pappersstorleksformat(74mm x 105mm).
+
+### B_0 {#B-0}
+```
+public static final int B_0
+```
+
+
+B0 pappersstorleksformat(1000mm x 1414mm).
+
+### B_1 {#B-1}
+```
+public static final int B_1
+```
+
+
+B1 pappersstorleksformat(707mm x 1000mm).
+
+### B_2 {#B-2}
+```
+public static final int B_2
+```
+
+
+B2 pappersstorleksformat(500mm x 707mm).
+
+### B_3 {#B-3}
+```
+public static final int B_3
+```
+
+
+B3 pappersstorleksformat(353mm x 500mm).
+
+### B_4 {#B-4}
+```
+public static final int B_4
+```
+
+
+B4 pappersstorleksformat(250mm x 353mm).
+
+### B_5 {#B-5}
+```
+public static final int B_5
+```
+
+
+B5 pappersstorleksformat(176mm x 250mm).
+
+### B_6 {#B-6}
+```
+public static final int B_6
+```
+
+
+B6 pappersstorleksformat(125mm x 176mm).
+
+### B_7 {#B-7}
+```
+public static final int B_7
+```
+
+
+B7 pappersstorleksformat(88mm x 125mm).
+
+### COM_10 {#COM-10}
+```
+public static final int COM_10
+```
+
+
+COM10 pappersstorleksformat(104.78mm x 241.3mm).
+
+### COM_9 {#COM-9}
+```
+public static final int COM_9
+```
+
+
+COM9 pappersstorleksformat(98.4mm x 225.4mInterpolationMode:Invalidm).
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Anpassat pappersstorleksformat.
+
+### C_0 {#C-0}
+```
+public static final int C_0
+```
+
+
+C0 pappersstorleksformat(917mm x 1297mm).
+
+### C_1 {#C-1}
+```
+public static final int C_1
+```
+
+
+C1 pappersstorleksformat(648mm x 917mm).
+
+### C_2 {#C-2}
+```
+public static final int C_2
+```
+
+
+C2 pappersstorleksformat(458mm x 648mm).
+
+### C_3 {#C-3}
+```
+public static final int C_3
+```
+
+
+C3 pappersstorleksformat(324mm x 458mm).
+
+### C_4 {#C-4}
+```
+public static final int C_4
+```
+
+
+C4 pappersstorleksformat(229mm x 324mm).
+
+### C_5 {#C-5}
+```
+public static final int C_5
+```
+
+
+C5 pappersstorleksformat(162mm x 229mm).
+
+### C_6 {#C-6}
+```
+public static final int C_6
+```
+
+
+C6 pappersstorleksformat(114mm x 162mm).
+
+### C_7 {#C-7}
+```
+public static final int C_7
+```
+
+
+C7 pappersstorleksformat(81mm x 114mm).
+
+### DL {#DL}
+```
+public static final int DL
+```
+
+
+DL pappersstorleksformat(110mm x 220mm).
+
+### EXECUTIVE {#EXECUTIVE}
+```
+public static final int EXECUTIVE
+```
+
+
+Executive pappersstorleksformat(184.15mm x 266.7mm).
+
+### LEGAL {#LEGAL}
+```
+public static final int LEGAL
+```
+
+
+Legal pappersstorleksformat(215.9mm x 355.6mm).
+
+### LEGAL_13 {#LEGAL-13}
+```
+public static final int LEGAL_13
+```
+
+
+Legal13 pappersstorleksformat(215.9mm x 330.2mm).
+
+### LETTER {#LETTER}
+```
+public static final int LETTER
+```
+
+
+Letter pappersstorleksformat(215.9mm x 279.7mm).
+
+### MONARCH {#MONARCH}
+```
+public static final int MONARCH
+```
+
+
+Monarch pappersstorleksformat(98.4mm x 190.5mm).
+
+### TABLOID {#TABLOID}
+```
+public static final int TABLOID
+```
+
+
+Tabloid pappersstorleksformat(279.4mm x 431.8mm).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/para/_index.md
+++ b/swedish/java/com.aspose.diagram/para/_index.md
@@ -1,0 +1,549 @@
+---
+title: Para
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller styckeformateringselement för figurens text, såsom indrag, radavstånd, punkter och horisontell justering av stycken.
+type: docs
+weight: 274
+url: /sv/java/com.aspose.diagram/para/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Para
+```
+
+Innehåller styckeformateringselement för figurens text, såsom indrag, radavstånd, punktlistor och horisontell justering av stycken.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Para()](#Para--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBullet()](#getBullet--) | Bestämmer punktlistans stil. |
+| [getBulletFont()](#getBulletFont--) | Representerar numret på teckensnittet som används för att formatera texten när en anpassad punktlista sträng anges och värdet i Bullet-elementet är icke-noll. |
+| [getBulletFontSize()](#getBulletFontSize--) | Anger storleken på en punkt. |
+| [getBulletStr()](#getBulletStr--) | \"Används för att skapa en anpassad punktstil. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getFlags()](#getFlags--) | Indikerar om textens riktning är från vänster till höger eller från höger till vänster. |
+| [getHorzAlign()](#getHorzAlign--) | Anger den horisontella justeringen av text i formens textblock. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getIndFirst()](#getIndFirst--) | Anger avståndet den första raden i varje stycke i figurens textblock är indragen från styckets vänstra indrag. |
+| [getIndLeft()](#getIndLeft--) | Anger avståndet alla textrader i ett stycke är indragna från den vänstra marginalen i textblocket. |
+| [getIndRight()](#getIndRight--) | Anger avståndet som alla textrader i ett stycke är indragna från högermarginalen i textblocket. |
+| [getLocalizeBulletFont()](#getLocalizeBulletFont--) | Anger om punktteckensnittet ska lokaliseras (översättas till ett annat språk). |
+| [getSpAfter()](#getSpAfter--) | Anger mängden utrymme som infogas efter varje stycke i figurens textblock. |
+| [getSpBefore()](#getSpBefore--) | Anger mängden utrymme som infogas före varje stycke i figurens textblock. |
+| [getSpLine()](#getSpLine--) | Anger avståndet mellan en textrad och nästa, där 100% är höjden på en textrad. |
+| [getTextPosAfterBullet()](#getTextPosAfterBullet--) | Representerar avståndet mellan första raden i stycket och punkten. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBullet(Bullet value)](#setBullet-com.aspose.diagram.Bullet-) | För beskrivningen av denna egenskap, se [getBullet()](../../com.aspose.diagram/para\#getBullet--) |
+| [setBulletFont(IntValue value)](#setBulletFont-com.aspose.diagram.IntValue-) | För beskrivningen av denna egenskap, se [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--) |
+| [setBulletFontSize(DoubleValue value)](#setBulletFontSize-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--) |
+| [setBulletStr(Str2Value value)](#setBulletStr-com.aspose.diagram.Str2Value-) | För beskrivningen av denna egenskap, se [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/para\#getDel--) |
+| [setFlags(BoolValue value)](#setFlags-com.aspose.diagram.BoolValue-) | För beskrivningen av denna egenskap, se [getFlags()](../../com.aspose.diagram/para\#getFlags--) |
+| [setHorzAlign(HorzAlign value)](#setHorzAlign-com.aspose.diagram.HorzAlign-) | För beskrivningen av denna egenskap, se [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/para\#getIX--) |
+| [setIndFirst(DoubleValue value)](#setIndFirst-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--) |
+| [setIndLeft(DoubleValue value)](#setIndLeft-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--) |
+| [setIndRight(DoubleValue value)](#setIndRight-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getIndRight()](../../com.aspose.diagram/para\#getIndRight--) |
+| [setLocalizeBulletFont(LocalizeFont value)](#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-) | För beskrivningen av denna egenskap, se [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--) |
+| [setSpAfter(DoubleValue value)](#setSpAfter-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--) |
+| [setSpBefore(DoubleValue value)](#setSpBefore-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--) |
+| [setSpLine(DoubleValue value)](#setSpLine-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getSpLine()](../../com.aspose.diagram/para\#getSpLine--) |
+| [setTextPosAfterBullet(DoubleValue value)](#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Para() {#Para--}
+```
+public Para()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBullet() {#getBullet--}
+```
+public Bullet getBullet()
+```
+
+
+Bestämmer punktlistans stil.
+
+**Returns:**
+[Bullet](../../com.aspose.diagram/bullet)
+### getBulletFont() {#getBulletFont--}
+```
+public IntValue getBulletFont()
+```
+
+
+Representerar numret på teckensnittet som används för att formatera texten när en anpassad punktlista sträng anges och värdet i Bullet-elementet är icke-noll.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getBulletFontSize() {#getBulletFontSize--}
+```
+public DoubleValue getBulletFontSize()
+```
+
+
+Anger storleken på en punkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBulletStr() {#getBulletStr--}
+```
+public Str2Value getBulletStr()
+```
+
+
+"Används för att skapa en anpassad punktstil. Ange stilen som en sträng (inom citattecken). Till exempel kan du ange strängen, ""ooo."""
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getFlags() {#getFlags--}
+```
+public BoolValue getFlags()
+```
+
+
+Indikerar om textens riktning är från vänster till höger eller från höger till vänster.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHorzAlign() {#getHorzAlign--}
+```
+public HorzAlign getHorzAlign()
+```
+
+
+Anger den horisontella justeringen av text i formens textblock.
+
+**Returns:**
+[HorzAlign](../../com.aspose.diagram/horzalign)
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getIndFirst() {#getIndFirst--}
+```
+public DoubleValue getIndFirst()
+```
+
+
+Anger avståndet som den första raden i varje stycke i figurens textblock är indragen från styckets vänstra indrag. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir första radens indrag oförändrat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndLeft() {#getIndLeft--}
+```
+public DoubleValue getIndLeft()
+```
+
+
+Anger avståndet som alla textrader i ett stycke är indragna från vänstermarginalen i textblocket. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir vänsterindraget oförändrat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getIndRight() {#getIndRight--}
+```
+public DoubleValue getIndRight()
+```
+
+
+Anger avståndet som alla textrader i ett stycke är indragna från högermarginalen i textblocket. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir högra indraget detsamma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocalizeBulletFont() {#getLocalizeBulletFont--}
+```
+public LocalizeFont getLocalizeBulletFont()
+```
+
+
+Anger om punktteckensnittet ska lokaliseras (översättas till ett annat språk).
+
+**Returns:**
+[LocalizeFont](../../com.aspose.diagram/localizefont)
+### getSpAfter() {#getSpAfter--}
+```
+public DoubleValue getSpAfter()
+```
+
+
+Anger mängden utrymme som infogas efter varje stycke i figurens textblock.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpBefore() {#getSpBefore--}
+```
+public DoubleValue getSpBefore()
+```
+
+
+Anger mängden utrymme som infogas före varje stycke i figurens textblock.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getSpLine() {#getSpLine--}
+```
+public DoubleValue getSpLine()
+```
+
+
+Anger avståndet mellan en textrad och nästa, där 100% är höjden på en textrad.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextPosAfterBullet() {#getTextPosAfterBullet--}
+```
+public DoubleValue getTextPosAfterBullet()
+```
+
+
+Representerar avståndet mellan första raden i stycket och punkten.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBullet(Bullet value) {#setBullet-com.aspose.diagram.Bullet-}
+```
+public void setBullet(Bullet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBullet()](../../com.aspose.diagram/para\#getBullet--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Bullet](../../com.aspose.diagram/bullet) |  |
+
+### setBulletFont(IntValue value) {#setBulletFont-com.aspose.diagram.IntValue-}
+```
+public void setBulletFont(IntValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBulletFont()](../../com.aspose.diagram/para\#getBulletFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setBulletFontSize(DoubleValue value) {#setBulletFontSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBulletFontSize(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBulletFontSize()](../../com.aspose.diagram/para\#getBulletFontSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBulletStr(Str2Value value) {#setBulletStr-com.aspose.diagram.Str2Value-}
+```
+public void setBulletStr(Str2Value value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBulletStr()](../../com.aspose.diagram/para\#getBulletStr--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/para\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setFlags(BoolValue value) {#setFlags-com.aspose.diagram.BoolValue-}
+```
+public void setFlags(BoolValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFlags()](../../com.aspose.diagram/para\#getFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHorzAlign(HorzAlign value) {#setHorzAlign-com.aspose.diagram.HorzAlign-}
+```
+public void setHorzAlign(HorzAlign value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHorzAlign()](../../com.aspose.diagram/para\#getHorzAlign--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [HorzAlign](../../com.aspose.diagram/horzalign) |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/para\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIndFirst(DoubleValue value) {#setIndFirst-com.aspose.diagram.DoubleValue-}
+```
+public void setIndFirst(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIndFirst()](../../com.aspose.diagram/para\#getIndFirst--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndLeft(DoubleValue value) {#setIndLeft-com.aspose.diagram.DoubleValue-}
+```
+public void setIndLeft(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIndLeft()](../../com.aspose.diagram/para\#getIndLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setIndRight(DoubleValue value) {#setIndRight-com.aspose.diagram.DoubleValue-}
+```
+public void setIndRight(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIndRight()](../../com.aspose.diagram/para\#getIndRight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocalizeBulletFont(LocalizeFont value) {#setLocalizeBulletFont-com.aspose.diagram.LocalizeFont-}
+```
+public void setLocalizeBulletFont(LocalizeFont value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLocalizeBulletFont()](../../com.aspose.diagram/para\#getLocalizeBulletFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [LocalizeFont](../../com.aspose.diagram/localizefont) |  |
+
+### setSpAfter(DoubleValue value) {#setSpAfter-com.aspose.diagram.DoubleValue-}
+```
+public void setSpAfter(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpAfter()](../../com.aspose.diagram/para\#getSpAfter--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpBefore(DoubleValue value) {#setSpBefore-com.aspose.diagram.DoubleValue-}
+```
+public void setSpBefore(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpBefore()](../../com.aspose.diagram/para\#getSpBefore--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setSpLine(DoubleValue value) {#setSpLine-com.aspose.diagram.DoubleValue-}
+```
+public void setSpLine(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpLine()](../../com.aspose.diagram/para\#getSpLine--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextPosAfterBullet(DoubleValue value) {#setTextPosAfterBullet-com.aspose.diagram.DoubleValue-}
+```
+public void setTextPosAfterBullet(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextPosAfterBullet()](../../com.aspose.diagram/para\#getTextPosAfterBullet--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/paracollection/_index.md
+++ b/swedish/java/com.aspose.diagram/paracollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: ParaCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Styckesamling.
+type: docs
+weight: 275
+url: /sv/java/com.aspose.diagram/paracollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ParaCollection extends Collection
+```
+
+Styckesamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Para item)](#add-com.aspose.diagram.Para-) | Lägg till Para-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getPara(int IX)](#getPara-int-) | Hämtar elementet på det angivna indexet IX. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Para item)](#remove-com.aspose.diagram.Para-) | Ta bort Para-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Para item) {#add-com.aspose.diagram.Para-}
+```
+public int add(Para item)
+```
+
+
+Lägg till Para-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Para get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getPara(int IX) {#getPara-int-}
+```
+public Para getPara(int IX)
+```
+
+
+Hämtar elementet på det angivna indexet IX. Returnerar Null om elementet inte finns.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int |  |
+
+**Returns:**
+[Para](../../com.aspose.diagram/para) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Para item) {#remove-com.aspose.diagram.Para-}
+```
+public void remove(Para item)
+```
+
+
+Ta bort Para-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Para](../../com.aspose.diagram/para) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfcompliance/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfcompliance/_index.md
@@ -1,0 +1,156 @@
+---
+title: PdfCompliance
+second_title: Aspose.Diagram för Java API-referens
+description: Anger PDF‑kompatibilitetsnivån för utdatafilen.
+type: docs
+weight: 276
+url: /sv/java/com.aspose.diagram/pdfcompliance/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfCompliance
+```
+
+Anger PDF‑kompatibilitetsnivån för utdatafilen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [PDF_15](#PDF-15) | Utdatafilen kommer att vara PDF 1.5‑kompatibel. |
+| [PDF_A_1_A](#PDF-A-1-A) | Utdatafilen kommer att vara PDF/A-1a‑kompatibel. |
+| [PDF_A_1_B](#PDF-A-1-B) | Utdatafilen kommer att vara PDF/A-1b‑kompatibel. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PDF_15 {#PDF-15}
+```
+public static final int PDF_15
+```
+
+
+Utdatafilen kommer att vara PDF 1.5‑kompatibel.
+
+### PDF_A_1_A {#PDF-A-1-A}
+```
+public static final int PDF_A_1_A
+```
+
+
+Utdatafilen kommer att vara PDF/A-1a‑kompatibel.
+
+### PDF_A_1_B {#PDF-A-1-B}
+```
+public static final int PDF_A_1_B
+```
+
+
+Utdatafilen kommer att vara PDF/A-1b‑kompatibel.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/_index.md
@@ -1,0 +1,174 @@
+---
+title: PdfDigitalSignatureHashAlgorithm
+second_title: Aspose.Diagram för Java API-referens
+description: Anger den digitala hash‑algoritmen som används av digital signatur.
+type: docs
+weight: 277
+url: /sv/java/com.aspose.diagram/pdfdigitalsignaturehashalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfDigitalSignatureHashAlgorithm
+```
+
+Anger den digitala hash‑algoritmen som används av digital signatur.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [MD_5](#MD-5) | SHA-1 hash-algoritm. |
+| [SHA_1](#SHA-1) | SHA-1 hash-algoritm. |
+| [SHA_256](#SHA-256) | SHA-256 hash-algoritm. |
+| [SHA_384](#SHA-384) | SHA-384 hash-algoritm. |
+| [SHA_512](#SHA-512) | SHA-512 hash-algoritm. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MD_5 {#MD-5}
+```
+public static final int MD_5
+```
+
+
+SHA-1 hash-algoritm.
+
+### SHA_1 {#SHA-1}
+```
+public static final int SHA_1
+```
+
+
+SHA-1 hash-algoritm.
+
+### SHA_256 {#SHA-256}
+```
+public static final int SHA_256
+```
+
+
+SHA-256 hash-algoritm.
+
+### SHA_384 {#SHA-384}
+```
+public static final int SHA_384
+```
+
+
+SHA-384 hash-algoritm.
+
+### SHA_512 {#SHA-512}
+```
+public static final int SHA_512
+```
+
+
+SHA-512 hash-algoritm.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfEncryptionAlgorithm
+second_title: Aspose.Diagram för Java API-referens
+description: Anger krypteringsalgoritmen som ska användas för att kryptera ett PDF‑dokument.
+type: docs
+weight: 278
+url: /sv/java/com.aspose.diagram/pdfencryptionalgorithm/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfEncryptionAlgorithm
+```
+
+Anger krypteringsalgoritmen som ska användas för att kryptera ett PDF‑dokument.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [RC_4_128](#RC-4-128) | RC4-kryptering, nyckellängd på 128 bitar. |
+| [RC_4_40](#RC-4-40) | RC4-kryptering, nyckellängd på 40 bitar. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC_4_128 {#RC-4-128}
+```
+public static final int RC_4_128
+```
+
+
+RC4-kryptering, nyckellängd på 128 bitar.
+
+### RC_4_40 {#RC-4-40}
+```
+public static final int RC_4_40
+```
+
+
+RC4-kryptering, nyckellängd på 40 bitar.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfencryptiondetails/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfencryptiondetails/_index.md
@@ -1,0 +1,245 @@
+---
+title: PdfEncryptionDetails
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller detaljer för en PDF‑kryptering.
+type: docs
+weight: 279
+url: /sv/java/com.aspose.diagram/pdfencryptiondetails/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+Innehåller detaljer för en PDF‑kryptering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | krypteringsläget. |
+| [getOwnerPassword()](#getOwnerPassword--) | ägarlösenordet. |
+| [getPermissions()](#getPermissions--) | behörigheterna. |
+| [getUserPassword()](#getUserPassword--) | användarlösenordet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(int value)](#setEncryptionAlgorithm-int-) | För beskrivningen av denna egenskap, se [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--) |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | För beskrivningen av denna egenskap, se [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--) |
+| [setPermissions(int value)](#setPermissions-int-) | För beskrivningen av denna egenskap, se [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--) |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | För beskrivningen av denna egenskap, se [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int encryptionAlgorithm)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| userPassword | java.lang.String |  |
+| ownerPassword | java.lang.String |  |
+| encryptionAlgorithm | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public int getEncryptionAlgorithm()
+```
+
+
+krypteringsläget.
+
+**Returns:**
+int
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+Ägarlösenordet. Att öppna dokumentet med rätt ägarlösenord (förutsatt att det inte är samma som användarlösenordet) ger full (ägare) åtkomst till dokumentet. Denna obegränsade åtkomst inkluderar möjligheten att ändra dokumentets\u9225\u6a9a lösenord och åtkomstbehörigheter.
+
+**Returns:**
+java.lang.String
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+behörigheterna.
+
+**Returns:**
+int
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+Användarlösenordet. Att öppna dokumentet med rätt användarlösenord (eller öppna ett dokument som inte har ett användarlösenord) möjliggör ytterligare operationer enligt de användaråtkomstbehörigheter som anges i dokumentets\u9225\u6a9a krypteringsordbok.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(int value) {#setEncryptionAlgorithm-int-}
+```
+public void setEncryptionAlgorithm(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEncryptionAlgorithm()](../../com.aspose.diagram/pdfencryptiondetails\#getEncryptionAlgorithm--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getOwnerPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getOwnerPassword--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPermissions()](../../com.aspose.diagram/pdfencryptiondetails\#getPermissions--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUserPassword()](../../com.aspose.diagram/pdfencryptiondetails\#getUserPassword--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfpermissions/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfpermissions/_index.md
@@ -1,0 +1,219 @@
+---
+title: PdfPermissions
+second_title: Aspose.Diagram för Java API-referens
+description: Anger användarbehörigheter för PDF‑dokumentet.
+type: docs
+weight: 280
+url: /sv/java/com.aspose.diagram/pdfpermissions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfPermissions
+```
+
+Anger användarbehörigheter för PDF‑dokumentet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALLOW_ALL](#ALLOW-ALL) | Tillåter alla operationer på PDF‑dokumentet. |
+| [CONTENT_COPY](#CONTENT-COPY) | Tillåter kopiering eller på annat sätt extrahering av text och grafik från dokumentet, inklusive extrahering för tillgänglighetsändamål. |
+| [CONTENT_COPY_FOR_ACCESSIBILITY](#CONTENT-COPY-FOR-ACCESSIBILITY) | Tillåter extrahering av text och grafik för att stödja tillgänglighet för funktionshindrade användare eller för andra ändamål. |
+| [DISALLOW_ALL](#DISALLOW-ALL) | Tillåter inte några operationer på PDF‑dokumentet. |
+| [DOCUMENT_ASSEMBLY](#DOCUMENT-ASSEMBLY) | Tillåter sammansättning av dokumentet: infogning, rotation eller borttagning av sidor samt skapande av navigeringselement som bokmärken eller miniatyrbilder. |
+| [FILL_IN](#FILL-IN) | Tillåter ifyllning av formulär och signering av dokumentet. |
+| [HIGH_RESOLUTION_PRINTING](#HIGH-RESOLUTION-PRINTING) | Tillåter utskrift av dokumentet i högsta möjliga upplösning. När RC4 40‑bitars kryptering används ignoreras detta alternativ och utskrift i hög upplösning tillåts när Printing är inställt. |
+| [MODIFY_ANNOTATIONS](#MODIFY-ANNOTATIONS) | Tillåter att lägga till eller ändra textanteckningar. |
+| [MODIFY_CONTENTS](#MODIFY-CONTENTS) | Tillåter att ändra dokumentets\u9225\u6a9a innehåll. |
+| [PRINTING](#PRINTING) | Tillåter utskrift av dokumentet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ALL {#ALLOW-ALL}
+```
+public static final int ALLOW_ALL
+```
+
+
+Tillåter alla operationer på PDF‑dokumentet.
+
+### CONTENT_COPY {#CONTENT-COPY}
+```
+public static final int CONTENT_COPY
+```
+
+
+Tillåter kopiering eller på annat sätt extrahering av text och grafik från dokumentet, inklusive extrahering för tillgänglighetsändamål.
+
+### CONTENT_COPY_FOR_ACCESSIBILITY {#CONTENT-COPY-FOR-ACCESSIBILITY}
+```
+public static final int CONTENT_COPY_FOR_ACCESSIBILITY
+```
+
+
+Tillåter att extrahera text och grafik för att stödja tillgänglighet för funktionshindrade användare eller för andra ändamål. Vid användning av RC4 40-bitars kryptering ignoreras detta alternativ och tillgänglighet tillåts när som helst när ContentCopy är aktiverat.
+
+### DISALLOW_ALL {#DISALLOW-ALL}
+```
+public static final int DISALLOW_ALL
+```
+
+
+Tillåter inte några operationer på PDF-dokumentet. Detta är standardvärdet.
+
+### DOCUMENT_ASSEMBLY {#DOCUMENT-ASSEMBLY}
+```
+public static final int DOCUMENT_ASSEMBLY
+```
+
+
+Tillåter att montera dokumentet: infoga, rotera eller ta bort sidor samt skapa navigeringselement såsom bokmärken eller miniatyrbilder. Vid användning av RC4 40-bitars kryptering ignoreras detta alternativ och dokumentmontering tillåts när ModifyContents är aktiverat.
+
+### FILL_IN {#FILL-IN}
+```
+public static final int FILL_IN
+```
+
+
+Tillåter ifyllning av formulär och signering av dokumentet. Vid användning av RC4 40-bitars kryptering ignoreras detta alternativ och ifyllning av formulär tillåts när som helst när ModifyAnnotations är aktiverat.
+
+### HIGH_RESOLUTION_PRINTING {#HIGH-RESOLUTION-PRINTING}
+```
+public static final int HIGH_RESOLUTION_PRINTING
+```
+
+
+Tillåter utskrift av dokumentet i högsta möjliga upplösning. När RC4 40‑bitars kryptering används ignoreras detta alternativ och utskrift i hög upplösning tillåts när Printing är inställt.
+
+### MODIFY_ANNOTATIONS {#MODIFY-ANNOTATIONS}
+```
+public static final int MODIFY_ANNOTATIONS
+```
+
+
+Tillåter att lägga till eller ändra textanteckningar. Vid användning av RC4 40-bitars kryptering tillåter detta alternativ även ifyllning av formulärfält.
+
+### MODIFY_CONTENTS {#MODIFY-CONTENTS}
+```
+public static final int MODIFY_CONTENTS
+```
+
+
+Tillåter att ändra dokumentets\u9225\u6a9a innehåll.
+
+### PRINTING {#PRINTING}
+```
+public static final int PRINTING
+```
+
+
+Tillåter utskrift av dokumentet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdfsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/pdfsaveoptions/_index.md
@@ -1,0 +1,679 @@
+---
+title: PdfSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ vid rendering av diagramssidor till PDF.
+type: docs
+weight: 281
+url: /sv/java/com.aspose.diagram/pdfsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PdfSaveOptions extends RenderingSaveOptions
+```
+
+Tillåter att ange ytterligare alternativ vid rendering av diagramssidor till PDF.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCompliance()](#getCompliance--) | Önskad överensstämmelsesnivå för genererat PDF-dokument. |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | en krypteringsdetalj. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definierar om dolda sidor ska exporteras eller inte. |
+| [getHorizontalResolution()](#getHorizontalResolution--) | den horisontella upplösningen för genererade bilder, i punkter per tum. |
+| [getJpegQuality()](#getJpegQuality--) | Anger kvaliteten på JPEG-komprimering för bilder (om JPEG-komprimering används). |
+| [getPageCount()](#getPageCount--) | antalet sidor som ska renderas i PDF. |
+| [getPageIndex()](#getPageIndex--) | det nollbaserade indexet för den första sidan som ska renderas. |
+| [getPageSavingCallback()](#getPageSavingCallback--) | Styr/indikera framsteg för sidlagringsprocessen. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska sparas som bild eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger formatet som de renderade diagrammetsidorna kommer att sparas i om detta sparaalternativobjekt används. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getSplitMultiPages()](#getSplitMultiPages--) | Definierar om diagrammet ska delas upp i flera sidor enligt sidans inställning. |
+| [getTextCompression()](#getTextCompression--) | Anger komprimeringstyp som ska användas för alla innehållsströmmar förutom bilder. |
+| [getVerticalResolution()](#getVerticalResolution--) | den vertikala upplösningen för genererade bilder, i punkter per tum. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCompliance(int value)](#setCompliance-int-) | För beskrivningen av denna egenskap, se [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-) | För beskrivningen av denna egenskap, se [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | För beskrivningen av denna egenskap, se [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--) |
+| [setHorizontalResolution(int value)](#setHorizontalResolution-int-) | För beskrivningen av denna egenskap, se [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--) |
+| [setJpegQuality(int value)](#setJpegQuality-int-) | För beskrivningen av denna egenskap, se [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivningen av denna egenskap, se [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivningen av denna egenskap, se [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--) |
+| [setPageSavingCallback(IPageSavingCallback value)](#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-) | För beskrivningen av denna egenskap, se [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivningen av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setSplitMultiPages(boolean value)](#setSplitMultiPages-boolean-) | För beskrivningen av denna egenskap, se [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--) |
+| [setTextCompression(int value)](#setTextCompression-int-) | För beskrivningen av denna egenskap, se [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--) |
+| [setVerticalResolution(int value)](#setVerticalResolution-int-) | För beskrivningen av denna egenskap, se [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCompliance() {#getCompliance--}
+```
+public int getCompliance()
+```
+
+
+Önskad efterlevnadsnivå för genererat PDF-dokument. Standard är PdfCompliance.PDF\_15.
+
+**Returns:**
+int
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+en krypteringsdetalj. Om den inte är angiven utförs ingen kryptering.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails)
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definierar om dolda sidor ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getHorizontalResolution() {#getHorizontalResolution--}
+```
+public int getHorizontalResolution()
+```
+
+
+den horisontella upplösningen för genererade bilder, i punkter per tum. Gäller genereringsmetoden för bilder förutom EMF-formatbilder. Standardvärdet är 96.
+
+**Returns:**
+int
+### getJpegQuality() {#getJpegQuality--}
+```
+public int getJpegQuality()
+```
+
+
+Anger kvaliteten på JPEG-komprimering för bilder (om JPEG-komprimering används). Standard är 95.
+
+**Returns:**
+int
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+antalet sidor som ska renderas i PDF. Standard är MaxValue vilket betyder att alla diagrammets sidor kommer att renderas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+det 0-baserade indexet för den första sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getPageSavingCallback() {#getPageSavingCallback--}
+```
+public IPageSavingCallback getPageSavingCallback()
+```
+
+
+Styr/indikera framsteg för sidlagringsprocessen.
+
+**Returns:**
+[IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback)
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska sparas i bilden eller bara förgrunden. Om true – renderas endast förgrundssidor (med bakgrund om den finns). Om false – renderas förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket de renderade diagrammenyerna ska sparas om detta spara-alternativobjekt används. Kan endast vara Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSplitMultiPages() {#getSplitMultiPages--}
+```
+public boolean getSplitMultiPages()
+```
+
+
+Definierar om diagrammet ska delas upp i flera sidor enligt sidans inställning. Standardvärdet är falskt.
+
+**Returns:**
+boolean
+### getTextCompression() {#getTextCompression--}
+```
+public int getTextCompression()
+```
+
+
+Anger komprimeringstyp som ska användas för alla innehållsströmmar förutom bilder. Standard är PdfTextCompression.FLATE.
+
+**Returns:**
+int
+### getVerticalResolution() {#getVerticalResolution--}
+```
+public int getVerticalResolution()
+```
+
+
+Den vertikala upplösningen för genererade bilder, i punkter per tum. Gäller genereringsmetoden för bilder förutom Emf-formatbilder. Standardvärdet är 96.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCompliance(int value) {#setCompliance-int-}
+```
+public void setCompliance(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCompliance()](../../com.aspose.diagram/pdfsaveoptions\#getCompliance--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.diagram.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEncryptionDetails()](../../com.aspose.diagram/pdfsaveoptions\#getEncryptionDetails--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.diagram/pdfencryptiondetails) |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getExportHiddenPage()](../../com.aspose.diagram/pdfsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setHorizontalResolution(int value) {#setHorizontalResolution-int-}
+```
+public void setHorizontalResolution(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHorizontalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getHorizontalResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setJpegQuality(int value) {#setJpegQuality-int-}
+```
+public void setJpegQuality(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getJpegQuality()](../../com.aspose.diagram/pdfsaveoptions\#getJpegQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPageCount()](../../com.aspose.diagram/pdfsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPageIndex()](../../com.aspose.diagram/pdfsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageSavingCallback(IPageSavingCallback value) {#setPageSavingCallback-com.aspose.diagram.IPageSavingCallback-}
+```
+public void setPageSavingCallback(IPageSavingCallback value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPageSavingCallback()](../../com.aspose.diagram/pdfsaveoptions\#getPageSavingCallback--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IPageSavingCallback](../../com.aspose.diagram/ipagesavingcallback) |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/pdfsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/pdfsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setSplitMultiPages(boolean value) {#setSplitMultiPages-boolean-}
+```
+public void setSplitMultiPages(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSplitMultiPages()](../../com.aspose.diagram/pdfsaveoptions\#getSplitMultiPages--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTextCompression(int value) {#setTextCompression-int-}
+```
+public void setTextCompression(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextCompression()](../../com.aspose.diagram/pdfsaveoptions\#getTextCompression--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setVerticalResolution(int value) {#setVerticalResolution-int-}
+```
+public void setVerticalResolution(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getVerticalResolution()](../../com.aspose.diagram/pdfsaveoptions\#getVerticalResolution--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pdftextcompression/_index.md
+++ b/swedish/java/com.aspose.diagram/pdftextcompression/_index.md
@@ -1,0 +1,147 @@
+---
+title: PdfTextCompression
+second_title: Aspose.Diagram för Java API-referens
+description: Anger en komprimeringstyp som tillämpas på allt innehåll i PDF‑filen förutom bilder.
+type: docs
+weight: 282
+url: /sv/java/com.aspose.diagram/pdftextcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PdfTextCompression
+```
+
+Anger en komprimeringstyp som tillämpas på allt innehåll i PDF‑filen förutom bilder.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FLATE](#FLATE) | Flate (ZIP)-komprimering. |
+| [NONE](#NONE) | Ingen komprimering. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLATE {#FLATE}
+```
+public static final int FLATE
+```
+
+
+Flate (ZIP)-komprimering.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen komprimering.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pinposvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/pinposvalue/_index.md
@@ -1,0 +1,219 @@
+---
+title: PinPosValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger nålpositionen för formen.
+type: docs
+weight: 283
+url: /sv/java/com.aspose.diagram/pinposvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PinPosValue
+```
+
+Anger nålpositionen för formen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM_CENTER](#BOTTOM-CENTER) | bottom-center |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | nedre-vänster. |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | nedre-höger |
+| [CENTER_CENTER](#CENTER-CENTER) | centrum-centrum |
+| [CENTER_LEFT](#CENTER-LEFT) | centrum-vänster. |
+| [CENTER_RIGHT](#CENTER-RIGHT) | centrum-höger |
+| [TOP_CENTER](#TOP-CENTER) | övre-mitten |
+| [TOP_LEFT](#TOP-LEFT) | vänster-övre |
+| [TOP_RIGHT](#TOP-RIGHT) | övre-höger |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_CENTER {#BOTTOM-CENTER}
+```
+public static final int BOTTOM_CENTER
+```
+
+
+bottom-center
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+nedre-vänster.
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+nedre-höger
+
+### CENTER_CENTER {#CENTER-CENTER}
+```
+public static final int CENTER_CENTER
+```
+
+
+centrum-centrum
+
+### CENTER_LEFT {#CENTER-LEFT}
+```
+public static final int CENTER_LEFT
+```
+
+
+centrum-vänster.
+
+### CENTER_RIGHT {#CENTER-RIGHT}
+```
+public static final int CENTER_RIGHT
+```
+
+
+centrum-höger
+
+### TOP_CENTER {#TOP-CENTER}
+```
+public static final int TOP_CENTER
+```
+
+
+övre-mitten
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+vänster-övre
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+övre-höger
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pixeloffsetmode/_index.md
+++ b/swedish/java/com.aspose.diagram/pixeloffsetmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: PixelOffsetMode
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur pixlar förskjuts under rendering.
+type: docs
+weight: 284
+url: /sv/java/com.aspose.diagram/pixeloffsetmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PixelOffsetMode
+```
+
+Anger hur pixlar förskjuts under rendering.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEFAULT](#DEFAULT) | Anger standardläget. |
+| [HALF](#HALF) | Anger att pixlar förskjuts med -.5 enheter, både horisontellt och vertikalt, för hög hastighetskantutjämning. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Anger rendering med hög kvalitet och låg hastighet. |
+| [HIGH_SPEED](#HIGH-SPEED) | Anger rendering med hög hastighet och låg kvalitet. |
+| [INVALID](#INVALID) | Anger ett ogiltigt läge. |
+| [NONE](#NONE) | Anger ingen pixelförskjutning. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Anger standardläget.
+
+### HALF {#HALF}
+```
+public static final int HALF
+```
+
+
+Anger att pixlar förskjuts med -.5 enheter, både horisontellt och vertikalt, för hög hastighetskantutjämning.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Anger rendering med hög kvalitet och låg hastighet.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Anger rendering med hög hastighet och låg kvalitet.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Anger ett ogiltigt läge.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Anger ingen pixelförskjutning.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placedepth/_index.md
+++ b/swedish/java/com.aspose.diagram/placedepth/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceDepth
+second_title: Aspose.Diagram för Java API-referens
+description: För en ritning som läggs ut automatiskt specificeras metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+type: docs
+weight: 285
+url: /sv/java/com.aspose.diagram/placedepth/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceDepth
+```
+
+För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PlaceDepth(int value)](#PlaceDepth-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/placedepth\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceDepth(int value) {#PlaceDepth-int-}
+```
+public PlaceDepth(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/placedepth\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placedepthvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/placedepthvalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: PlaceDepthValue
+second_title: Aspose.Diagram för Java API-referens
+description: För en ritning som läggs ut automatiskt specificeras metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+type: docs
+weight: 286
+url: /sv/java/com.aspose.diagram/placedepthvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceDepthValue
+```
+
+För en ritning som läggs ut automatiskt, anger metoden som ritningen analyseras med innan layouten skapas och bestämmer layouttypen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEEP](#DEEP) | Djup. |
+| [MEDIUM](#MEDIUM) | Mellan. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [SHALLOW](#SHALLOW) | Ytlig. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEEP {#DEEP}
+```
+public static final int DEEP
+```
+
+
+Djup.
+
+### MEDIUM {#MEDIUM}
+```
+public static final int MEDIUM
+```
+
+
+Mellan.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### SHALLOW {#SHALLOW}
+```
+public static final int SHALLOW
+```
+
+
+Ytlig.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placeflip/_index.md
+++ b/swedish/java/com.aspose.diagram/placeflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceFlip
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio.
+type: docs
+weight: 287
+url: /sv/java/com.aspose.diagram/placeflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceFlip
+```
+
+Anger hur placerbara former vänds och/eller roteras på en sida när former placeras med kommandot Lay Out Shapes i Microsoft Visio. Följande hexadecimala värden är tillåtna.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PlaceFlip(int value)](#PlaceFlip-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceFlip(int value) {#PlaceFlip-int-}
+```
+public PlaceFlip(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger hur placerbara former vänds och/eller roteras på en sida när former placeras med kommandot Lay Out Shapes i Microsoft Visio. Följande hexadecimala värden är tillåtna.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+For the description of this property, please see [getValue()](../../com.aspose.diagram/placeflip\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placeflipvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/placeflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PlaceFlipValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur placerbara former vänds och/eller roteras på en sida när former läggs ut med kommandot Lay Out Shapes i Microsoft Visio.
+type: docs
+weight: 288
+url: /sv/java/com.aspose.diagram/placeflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceFlipValue
+```
+
+Anger hur placerbara former vänds och/eller roteras på en sida när former placeras med kommandot Lay Out Shapes i Microsoft Visio. Följande hexadecimala värden är tillåtna.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DEFAULT_NO_FLIP](#DEFAULT-NO-FLIP) | Standard. |
+| [FLIP_90_INCREMENTS](#FLIP-90-INCREMENTS) | Vänd i steg om 90 grader. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Vänd horisontellt. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Vänd vertikalt. |
+| [NO_FLIP](#NO-FLIP) | Ingen vändning. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DEFAULT_NO_FLIP {#DEFAULT-NO-FLIP}
+```
+public static final int DEFAULT_NO_FLIP
+```
+
+
+Standard. Vänd inte.
+
+### FLIP_90_INCREMENTS {#FLIP-90-INCREMENTS}
+```
+public static final int FLIP_90_INCREMENTS
+```
+
+
+Vänd i steg om 90 grader.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Vänd horisontellt.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Vänd vertikalt.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Ingen vändning.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placestyle/_index.md
+++ b/swedish/java/com.aspose.diagram/placestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: PlaceStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur former placeras på sidan när former läggs ut när en användare väljer menyn Lay Out Shapes Shape.
+type: docs
+weight: 289
+url: /sv/java/com.aspose.diagram/placestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PlaceStyle
+```
+
+Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PlaceStyle(int value)](#PlaceStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form). |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/placestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PlaceStyle(int value) {#PlaceStyle-int-}
+```
+public PlaceStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/placestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/placestylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/placestylevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: PlaceStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur former placeras på sidan när former läggs ut när en användare väljer menyn Lay Out Shapes Shape.
+type: docs
+weight: 290
+url: /sv/java/com.aspose.diagram/placestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PlaceStyleValue
+```
+
+Anger hur former placeras på sidan när former läggs ut när en användare väljer Lay Out Shapes (menyn Form).
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM_TO_TOP](#BOTTOM-TO-TOP) | Nerifrån upp. |
+| [CIRCULAR](#CIRCULAR) | Cirkulär. |
+| [DEFAULT_RADIAL](#DEFAULT-RADIAL) | Standard. |
+| [LEFT_TO_RIGHT](#LEFT-TO-RIGHT) | Vänster till höger. |
+| [RADIAL](#RADIAL) | Radial. |
+| [RIGHT_TO_LEFT](#RIGHT-TO-LEFT) | Höger till vänster. |
+| [TOP_TO_BOTTOM](#TOP-TO-BOTTOM) | Uppifrån ner. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_TO_TOP {#BOTTOM-TO-TOP}
+```
+public static final int BOTTOM_TO_TOP
+```
+
+
+Nerifrån upp.
+
+### CIRCULAR {#CIRCULAR}
+```
+public static final int CIRCULAR
+```
+
+
+Cirkulär.
+
+### DEFAULT_RADIAL {#DEFAULT-RADIAL}
+```
+public static final int DEFAULT_RADIAL
+```
+
+
+Standard. Radial.
+
+### LEFT_TO_RIGHT {#LEFT-TO-RIGHT}
+```
+public static final int LEFT_TO_RIGHT
+```
+
+
+Vänster till höger.
+
+### RADIAL {#RADIAL}
+```
+public static final int RADIAL
+```
+
+
+Radial.
+
+### RIGHT_TO_LEFT {#RIGHT-TO-LEFT}
+```
+public static final int RIGHT_TO_LEFT
+```
+
+
+Höger till vänster.
+
+### TOP_TO_BOTTOM {#TOP-TO-BOTTOM}
+```
+public static final int TOP_TO_BOTTOM
+```
+
+
+Uppifrån ner.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/polylineto/_index.md
+++ b/swedish/java/com.aspose.diagram/polylineto/_index.md
@@ -1,0 +1,274 @@
+---
+title: PolylineTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för den sista punkten i en polylinje samt en polylinjeformel.
+type: docs
+weight: 291
+url: /sv/java/com.aspose.diagram/polylineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class PolylineTo extends Coordinate
+```
+
+Innehåller x- och y-koordinater för den sista punkten i en polyline och en polyline-formel. Koordinaterna anges i X- och Y-elementen, och formeln anges i A-elementet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PolylineTo()](#PolylineTo--) | Skapar en instans av klassen [PolylineTo](../../com.aspose.diagram/polylineto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Polyline-formeln. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för den avslutande vertexen i en polyline. |
+| [getY()](#getY--) | y-koordinaten för den avslutande vertexen i en polyline. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(StrValue value)](#setA-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/polylineto\#getA--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/polylineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/polylineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/polylineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/polylineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PolylineTo() {#PolylineTo--}
+```
+public PolylineTo()
+```
+
+
+Skapar en instans av klassen [PolylineTo](../../com.aspose.diagram/polylineto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public StrValue getA()
+```
+
+
+Polyline-formeln.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för den avslutande vertexen i en polyline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för den avslutande vertexen i en polyline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(StrValue value) {#setA-com.aspose.diagram.StrValue-}
+```
+public void setA(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/polylineto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/polylineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/polylineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/polylineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/polylineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/polylinetocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/polylinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: PolylineToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: PolylineTo-samling.
+type: docs
+weight: 292
+url: /sv/java/com.aspose.diagram/polylinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PolylineToCollection extends Collection
+```
+
+PolylineTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public PolylineTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[PolylineTo](../../com.aspose.diagram/polylineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pos/_index.md
+++ b/swedish/java/com.aspose.diagram/pos/_index.md
@@ -1,0 +1,204 @@
+---
+title: Pos
+second_title: Aspose.Diagram för Java API-referens
+description: Anger positionen för figurens text i förhållande till baslinjen.
+type: docs
+weight: 293
+url: /sv/java/com.aspose.diagram/pos/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Pos
+```
+
+Anger textens position i formen relativt till baslinjen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Pos(int value)](#Pos-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger textens position i formen relativt till baslinjen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/pos\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/pos\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pos(int value) {#Pos-int-}
+```
+public Pos(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger textens position i formen relativt till baslinjen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/pos\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/pos\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/posvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/posvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PosValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger positionen för figurens text i förhållande till baslinjen.
+type: docs
+weight: 294
+url: /sv/java/com.aspose.diagram/posvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PosValue
+```
+
+Anger textens position i formen relativt till baslinjen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NORMAL_POSITION](#NORMAL-POSITION) | Normal position. |
+| [SUBSCRIPT](#SUBSCRIPT) | Nedsänkt. |
+| [SUPERSCRIPT](#SUPERSCRIPT) | Upphöjd. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NORMAL_POSITION {#NORMAL-POSITION}
+```
+public static final int NORMAL_POSITION
+```
+
+
+Normal position.
+
+### SUBSCRIPT {#SUBSCRIPT}
+```
+public static final int SUBSCRIPT
+```
+
+
+Nedsänkt.
+
+### SUPERSCRIPT {#SUPERSCRIPT}
+```
+public static final int SUPERSCRIPT
+```
+
+
+Upphöjd.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/pp/_index.md
+++ b/swedish/java/com.aspose.diagram/pp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Pp
+second_title: Aspose.Diagram för Java API-referens
+description: Anger början på en körning av styckeegenskaper.
+type: docs
+weight: 295
+url: /sv/java/com.aspose.diagram/pp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Pp extends FormatTxt
+```
+
+Anger början av ett styckeegenskapssegment. Segmentet definieras till slutet av texten eller tills nästa
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Pp(int IX)](#Pp-int-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pp(int IX) {#Pp-int-}
+```
+public Pp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int | Indexet för Para-elementet som anger formateringen som tillämpas på detta segment. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetcameratype/_index.md
+++ b/swedish/java/com.aspose.diagram/presetcameratype/_index.md
@@ -1,0 +1,687 @@
+---
+title: PresetCameraType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar olika algoritmiska metoder för att ställa in alla kamerainställningar inklusive position.
+type: docs
+weight: 296
+url: /sv/java/com.aspose.diagram/presetcameratype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetCameraType
+```
+
+Representerar olika algoritmiska metoder för att ställa in alla kamerainställningar, inklusive position.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ISOMETRIC_BOTTOM_DOWN](#ISOMETRIC-BOTTOM-DOWN) |  |
+| [ISOMETRIC_BOTTOM_UP](#ISOMETRIC-BOTTOM-UP) |  |
+| [ISOMETRIC_LEFT_DOWN](#ISOMETRIC-LEFT-DOWN) |  |
+| [ISOMETRIC_LEFT_UP](#ISOMETRIC-LEFT-UP) |  |
+| [ISOMETRIC_OFF_AXIS_1_LEFT](#ISOMETRIC-OFF-AXIS-1-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_1_RIGHT](#ISOMETRIC-OFF-AXIS-1-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_1_TOP](#ISOMETRIC-OFF-AXIS-1-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_2_LEFT](#ISOMETRIC-OFF-AXIS-2-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_2_RIGHT](#ISOMETRIC-OFF-AXIS-2-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_2_TOP](#ISOMETRIC-OFF-AXIS-2-TOP) |  |
+| [ISOMETRIC_OFF_AXIS_3_BOTTOM](#ISOMETRIC-OFF-AXIS-3-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_3_LEFT](#ISOMETRIC-OFF-AXIS-3-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_3_RIGHT](#ISOMETRIC-OFF-AXIS-3-RIGHT) |  |
+| [ISOMETRIC_OFF_AXIS_4_BOTTOM](#ISOMETRIC-OFF-AXIS-4-BOTTOM) |  |
+| [ISOMETRIC_OFF_AXIS_4_LEFT](#ISOMETRIC-OFF-AXIS-4-LEFT) |  |
+| [ISOMETRIC_OFF_AXIS_4_RIGHT](#ISOMETRIC-OFF-AXIS-4-RIGHT) |  |
+| [ISOMETRIC_RIGHT_DOWN](#ISOMETRIC-RIGHT-DOWN) |  |
+| [ISOMETRIC_RIGHT_UP](#ISOMETRIC-RIGHT-UP) |  |
+| [ISOMETRIC_TOP_DOWN](#ISOMETRIC-TOP-DOWN) |  |
+| [ISOMETRIC_TOP_UP](#ISOMETRIC-TOP-UP) |  |
+| [LEGACY_OBLIQUE_BOTTOM](#LEGACY-OBLIQUE-BOTTOM) |  |
+| [LEGACY_OBLIQUE_BOTTOM_LEFT](#LEGACY-OBLIQUE-BOTTOM-LEFT) |  |
+| [LEGACY_OBLIQUE_BOTTOM_RIGHT](#LEGACY-OBLIQUE-BOTTOM-RIGHT) |  |
+| [LEGACY_OBLIQUE_FRONT](#LEGACY-OBLIQUE-FRONT) |  |
+| [LEGACY_OBLIQUE_LEFT](#LEGACY-OBLIQUE-LEFT) |  |
+| [LEGACY_OBLIQUE_RIGHT](#LEGACY-OBLIQUE-RIGHT) |  |
+| [LEGACY_OBLIQUE_TOP](#LEGACY-OBLIQUE-TOP) |  |
+| [LEGACY_OBLIQUE_TOP_LEFT](#LEGACY-OBLIQUE-TOP-LEFT) |  |
+| [LEGACY_OBLIQUE_TOP_RIGHT](#LEGACY-OBLIQUE-TOP-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM](#LEGACY-PERSPECTIVE-BOTTOM) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_LEFT](#LEGACY-PERSPECTIVE-BOTTOM-LEFT) |  |
+| [LEGACY_PERSPECTIVE_BOTTOM_RIGHT](#LEGACY-PERSPECTIVE-BOTTOM-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_FRONT](#LEGACY-PERSPECTIVE-FRONT) |  |
+| [LEGACY_PERSPECTIVE_LEFT](#LEGACY-PERSPECTIVE-LEFT) |  |
+| [LEGACY_PERSPECTIVE_RIGHT](#LEGACY-PERSPECTIVE-RIGHT) |  |
+| [LEGACY_PERSPECTIVE_TOP](#LEGACY-PERSPECTIVE-TOP) |  |
+| [LEGACY_PERSPECTIVE_TOP_LEFT](#LEGACY-PERSPECTIVE-TOP-LEFT) |  |
+| [LEGACY_PERSPECTIVE_TOP_RIGHT](#LEGACY-PERSPECTIVE-TOP-RIGHT) |  |
+| [OBLIQUE_BOTTOM](#OBLIQUE-BOTTOM) |  |
+| [OBLIQUE_BOTTOM_LEFT](#OBLIQUE-BOTTOM-LEFT) |  |
+| [OBLIQUE_BOTTOM_RIGHT](#OBLIQUE-BOTTOM-RIGHT) |  |
+| [OBLIQUE_LEFT](#OBLIQUE-LEFT) |  |
+| [OBLIQUE_RIGHT](#OBLIQUE-RIGHT) |  |
+| [OBLIQUE_TOP](#OBLIQUE-TOP) |  |
+| [OBLIQUE_TOP_LEFT](#OBLIQUE-TOP-LEFT) |  |
+| [OBLIQUE_TOP_RIGHT](#OBLIQUE-TOP-RIGHT) |  |
+| [ORTHOGRAPHIC_FRONT](#ORTHOGRAPHIC-FRONT) |  |
+| [PERSPECTIVE_ABOVE](#PERSPECTIVE-ABOVE) |  |
+| [PERSPECTIVE_ABOVE_LEFT_FACING](#PERSPECTIVE-ABOVE-LEFT-FACING) |  |
+| [PERSPECTIVE_ABOVE_RIGHT_FACING](#PERSPECTIVE-ABOVE-RIGHT-FACING) |  |
+| [PERSPECTIVE_BELOW](#PERSPECTIVE-BELOW) |  |
+| [PERSPECTIVE_CONTRASTING_LEFT_FACING](#PERSPECTIVE-CONTRASTING-LEFT-FACING) |  |
+| [PERSPECTIVE_CONTRASTING_RIGHT_FACING](#PERSPECTIVE-CONTRASTING-RIGHT-FACING) |  |
+| [PERSPECTIVE_FRONT](#PERSPECTIVE-FRONT) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING](#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING](#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING) |  |
+| [PERSPECTIVE_HEROIC_LEFT_FACING](#PERSPECTIVE-HEROIC-LEFT-FACING) |  |
+| [PERSPECTIVE_HEROIC_RIGHT_FACING](#PERSPECTIVE-HEROIC-RIGHT-FACING) |  |
+| [PERSPECTIVE_LEFT](#PERSPECTIVE-LEFT) |  |
+| [PERSPECTIVE_RELAXED](#PERSPECTIVE-RELAXED) |  |
+| [PERSPECTIVE_RELAXED_MODERATELY](#PERSPECTIVE-RELAXED-MODERATELY) |  |
+| [PERSPECTIVE_RIGHT](#PERSPECTIVE-RIGHT) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ISOMETRIC_BOTTOM_DOWN {#ISOMETRIC-BOTTOM-DOWN}
+```
+public static final int ISOMETRIC_BOTTOM_DOWN
+```
+
+
+
+
+### ISOMETRIC_BOTTOM_UP {#ISOMETRIC-BOTTOM-UP}
+```
+public static final int ISOMETRIC_BOTTOM_UP
+```
+
+
+
+
+### ISOMETRIC_LEFT_DOWN {#ISOMETRIC-LEFT-DOWN}
+```
+public static final int ISOMETRIC_LEFT_DOWN
+```
+
+
+
+
+### ISOMETRIC_LEFT_UP {#ISOMETRIC-LEFT-UP}
+```
+public static final int ISOMETRIC_LEFT_UP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_LEFT {#ISOMETRIC-OFF-AXIS-1-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_RIGHT {#ISOMETRIC-OFF-AXIS-1-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_1_TOP {#ISOMETRIC-OFF-AXIS-1-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_1_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_LEFT {#ISOMETRIC-OFF-AXIS-2-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_RIGHT {#ISOMETRIC-OFF-AXIS-2-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_2_TOP {#ISOMETRIC-OFF-AXIS-2-TOP}
+```
+public static final int ISOMETRIC_OFF_AXIS_2_TOP
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_BOTTOM {#ISOMETRIC-OFF-AXIS-3-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_LEFT {#ISOMETRIC-OFF-AXIS-3-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_3_RIGHT {#ISOMETRIC-OFF-AXIS-3-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_3_RIGHT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_BOTTOM {#ISOMETRIC-OFF-AXIS-4-BOTTOM}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_BOTTOM
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_LEFT {#ISOMETRIC-OFF-AXIS-4-LEFT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_LEFT
+```
+
+
+
+
+### ISOMETRIC_OFF_AXIS_4_RIGHT {#ISOMETRIC-OFF-AXIS-4-RIGHT}
+```
+public static final int ISOMETRIC_OFF_AXIS_4_RIGHT
+```
+
+
+
+
+### ISOMETRIC_RIGHT_DOWN {#ISOMETRIC-RIGHT-DOWN}
+```
+public static final int ISOMETRIC_RIGHT_DOWN
+```
+
+
+
+
+### ISOMETRIC_RIGHT_UP {#ISOMETRIC-RIGHT-UP}
+```
+public static final int ISOMETRIC_RIGHT_UP
+```
+
+
+
+
+### ISOMETRIC_TOP_DOWN {#ISOMETRIC-TOP-DOWN}
+```
+public static final int ISOMETRIC_TOP_DOWN
+```
+
+
+
+
+### ISOMETRIC_TOP_UP {#ISOMETRIC-TOP-UP}
+```
+public static final int ISOMETRIC_TOP_UP
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM {#LEGACY-OBLIQUE-BOTTOM}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_LEFT {#LEGACY-OBLIQUE-BOTTOM-LEFT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_BOTTOM_RIGHT {#LEGACY-OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_FRONT {#LEGACY-OBLIQUE-FRONT}
+```
+public static final int LEGACY_OBLIQUE_FRONT
+```
+
+
+
+
+### LEGACY_OBLIQUE_LEFT {#LEGACY-OBLIQUE-LEFT}
+```
+public static final int LEGACY_OBLIQUE_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_RIGHT {#LEGACY-OBLIQUE-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_RIGHT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP {#LEGACY-OBLIQUE-TOP}
+```
+public static final int LEGACY_OBLIQUE_TOP
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_LEFT {#LEGACY-OBLIQUE-TOP-LEFT}
+```
+public static final int LEGACY_OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_OBLIQUE_TOP_RIGHT {#LEGACY-OBLIQUE-TOP-RIGHT}
+```
+public static final int LEGACY_OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM {#LEGACY-PERSPECTIVE-BOTTOM}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_LEFT {#LEGACY-PERSPECTIVE-BOTTOM-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_BOTTOM_RIGHT {#LEGACY-PERSPECTIVE-BOTTOM-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_BOTTOM_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_FRONT {#LEGACY-PERSPECTIVE-FRONT}
+```
+public static final int LEGACY_PERSPECTIVE_FRONT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_LEFT {#LEGACY-PERSPECTIVE-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_RIGHT {#LEGACY-PERSPECTIVE-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_RIGHT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP {#LEGACY-PERSPECTIVE-TOP}
+```
+public static final int LEGACY_PERSPECTIVE_TOP
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_LEFT {#LEGACY-PERSPECTIVE-TOP-LEFT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_LEFT
+```
+
+
+
+
+### LEGACY_PERSPECTIVE_TOP_RIGHT {#LEGACY-PERSPECTIVE-TOP-RIGHT}
+```
+public static final int LEGACY_PERSPECTIVE_TOP_RIGHT
+```
+
+
+
+
+### OBLIQUE_BOTTOM {#OBLIQUE-BOTTOM}
+```
+public static final int OBLIQUE_BOTTOM
+```
+
+
+
+
+### OBLIQUE_BOTTOM_LEFT {#OBLIQUE-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_BOTTOM_LEFT
+```
+
+
+
+
+### OBLIQUE_BOTTOM_RIGHT {#OBLIQUE-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_BOTTOM_RIGHT
+```
+
+
+
+
+### OBLIQUE_LEFT {#OBLIQUE-LEFT}
+```
+public static final int OBLIQUE_LEFT
+```
+
+
+
+
+### OBLIQUE_RIGHT {#OBLIQUE-RIGHT}
+```
+public static final int OBLIQUE_RIGHT
+```
+
+
+
+
+### OBLIQUE_TOP {#OBLIQUE-TOP}
+```
+public static final int OBLIQUE_TOP
+```
+
+
+
+
+### OBLIQUE_TOP_LEFT {#OBLIQUE-TOP-LEFT}
+```
+public static final int OBLIQUE_TOP_LEFT
+```
+
+
+
+
+### OBLIQUE_TOP_RIGHT {#OBLIQUE-TOP-RIGHT}
+```
+public static final int OBLIQUE_TOP_RIGHT
+```
+
+
+
+
+### ORTHOGRAPHIC_FRONT {#ORTHOGRAPHIC-FRONT}
+```
+public static final int ORTHOGRAPHIC_FRONT
+```
+
+
+
+
+### PERSPECTIVE_ABOVE {#PERSPECTIVE-ABOVE}
+```
+public static final int PERSPECTIVE_ABOVE
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_LEFT_FACING {#PERSPECTIVE-ABOVE-LEFT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_ABOVE_RIGHT_FACING {#PERSPECTIVE-ABOVE-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_ABOVE_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_BELOW {#PERSPECTIVE-BELOW}
+```
+public static final int PERSPECTIVE_BELOW
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_LEFT_FACING {#PERSPECTIVE-CONTRASTING-LEFT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_CONTRASTING_RIGHT_FACING {#PERSPECTIVE-CONTRASTING-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_CONTRASTING_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_FRONT {#PERSPECTIVE-FRONT}
+```
+public static final int PERSPECTIVE_FRONT
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING {#PERSPECTIVE-HEROIC-EXTREME-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING {#PERSPECTIVE-HEROIC-EXTREME-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_EXTREME_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_LEFT_FACING {#PERSPECTIVE-HEROIC-LEFT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_LEFT_FACING
+```
+
+
+
+
+### PERSPECTIVE_HEROIC_RIGHT_FACING {#PERSPECTIVE-HEROIC-RIGHT-FACING}
+```
+public static final int PERSPECTIVE_HEROIC_RIGHT_FACING
+```
+
+
+
+
+### PERSPECTIVE_LEFT {#PERSPECTIVE-LEFT}
+```
+public static final int PERSPECTIVE_LEFT
+```
+
+
+
+
+### PERSPECTIVE_RELAXED {#PERSPECTIVE-RELAXED}
+```
+public static final int PERSPECTIVE_RELAXED
+```
+
+
+
+
+### PERSPECTIVE_RELAXED_MODERATELY {#PERSPECTIVE-RELAXED-MODERATELY}
+```
+public static final int PERSPECTIVE_RELAXED_MODERATELY
+```
+
+
+
+
+### PERSPECTIVE_RIGHT {#PERSPECTIVE-RIGHT}
+```
+public static final int PERSPECTIVE_RIGHT
+```
+
+
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/presetcolormatricsvalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: PresetColorMatricsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Används för att ange färgegenskapen för Shape-temastilar
+type: docs
+weight: 297
+url: /sv/java/com.aspose.diagram/presetcolormatricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetColorMatricsValue
+```
+
+Används för att ställa in färgegenskapen för formens temastil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [COLOR_1](#COLOR-1) | Färg1. |
+| [COLOR_2](#COLOR-2) | Färg2. |
+| [COLOR_3](#COLOR-3) | Färg3. |
+| [COLOR_4](#COLOR-4) | Färg4. |
+| [COLOR_5](#COLOR-5) | Färg5. |
+| [COLOR_6](#COLOR-6) | Färg6. |
+| [COLOR_7](#COLOR-7) | Färg7. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COLOR_1 {#COLOR-1}
+```
+public static final int COLOR_1
+```
+
+
+Färg1.
+
+### COLOR_2 {#COLOR-2}
+```
+public static final int COLOR_2
+```
+
+
+Färg2.
+
+### COLOR_3 {#COLOR-3}
+```
+public static final int COLOR_3
+```
+
+
+Färg3.
+
+### COLOR_4 {#COLOR-4}
+```
+public static final int COLOR_4
+```
+
+
+Färg4.
+
+### COLOR_5 {#COLOR-5}
+```
+public static final int COLOR_5
+```
+
+
+Färg5.
+
+### COLOR_6 {#COLOR-6}
+```
+public static final int COLOR_6
+```
+
+
+Färg6.
+
+### COLOR_7 {#COLOR-7}
+```
+public static final int COLOR_7
+```
+
+
+Färg7.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetquickstylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/presetquickstylevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetQuickStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger värdet för temats snabbstil.
+type: docs
+weight: 298
+url: /sv/java/com.aspose.diagram/presetquickstylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetQuickStyleValue
+```
+
+Anger värdet för temats snabbstil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [VARIANT_STYLE_1](#VARIANT-STYLE-1) | VariantStyle1. |
+| [VARIANT_STYLE_2](#VARIANT-STYLE-2) | VariantStyle2. |
+| [VARIANT_STYLE_3](#VARIANT-STYLE-3) | VariantStyle3. |
+| [VARIANT_STYLE_4](#VARIANT-STYLE-4) | VariantStyle4. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_STYLE_1 {#VARIANT-STYLE-1}
+```
+public static final int VARIANT_STYLE_1
+```
+
+
+VariantStyle1.
+
+### VARIANT_STYLE_2 {#VARIANT-STYLE-2}
+```
+public static final int VARIANT_STYLE_2
+```
+
+
+VariantStyle2.
+
+### VARIANT_STYLE_3 {#VARIANT-STYLE-3}
+```
+public static final int VARIANT_STYLE_3
+```
+
+
+VariantStyle3.
+
+### VARIANT_STYLE_4 {#VARIANT-STYLE-4}
+```
+public static final int VARIANT_STYLE_4
+```
+
+
+VariantStyle4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetshadowtype/_index.md
+++ b/swedish/java/com.aspose.diagram/presetshadowtype/_index.md
@@ -1,0 +1,354 @@
+---
+title: PresetShadowType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar förinställd skuggtyp.
+type: docs
+weight: 299
+url: /sv/java/com.aspose.diagram/presetshadowtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetShadowType
+```
+
+Representerar förinställd skuggtyp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BELOW](#BELOW) | Yttre skugga nedanför. |
+| [CUSTOM](#CUSTOM) | Anpassad skugga. |
+| [INSIDE_BOTTOM](#INSIDE-BOTTOM) | Inre skugga i botten. |
+| [INSIDE_CENTER](#INSIDE-CENTER) | Inre skugga i mitten. |
+| [INSIDE_DIAGONAL_BOTTOM_LEFT](#INSIDE-DIAGONAL-BOTTOM-LEFT) | Inre skugga i diagonal nedre vänster. |
+| [INSIDE_DIAGONAL_BOTTOM_RIGHT](#INSIDE-DIAGONAL-BOTTOM-RIGHT) | Inre skugga i diagonal nedre höger. |
+| [INSIDE_DIAGONAL_TOP_LEFT](#INSIDE-DIAGONAL-TOP-LEFT) | Inre skugga i diagonal övre vänster. |
+| [INSIDE_DIAGONAL_TOP_RIGHT](#INSIDE-DIAGONAL-TOP-RIGHT) | Inre skugga i diagonal övre höger. |
+| [INSIDE_LEFT](#INSIDE-LEFT) | Inre skugga i vänster. |
+| [INSIDE_RIGHT](#INSIDE-RIGHT) | Inre skugga i höger. |
+| [INSIDE_TOP](#INSIDE-TOP) | Inre skugga i toppen. |
+| [NO_SHADOW](#NO-SHADOW) | Ingen skugga. |
+| [OFFSET_BOTTOM](#OFFSET-BOTTOM) | Yttre skugga förskjuten mot botten. |
+| [OFFSET_CENTER](#OFFSET-CENTER) | Yttre skugga förskjuten i mitten. |
+| [OFFSET_DIAGONAL_BOTTOM_LEFT](#OFFSET-DIAGONAL-BOTTOM-LEFT) | Yttre skugga förskjuten i diagonal nedre vänster. |
+| [OFFSET_DIAGONAL_BOTTOM_RIGHT](#OFFSET-DIAGONAL-BOTTOM-RIGHT) | Yttre skugga förskjuten i diagonal nedre höger. |
+| [OFFSET_DIAGONAL_TOP_LEFT](#OFFSET-DIAGONAL-TOP-LEFT) | Yttre skugga förskjuten i diagonal övre vänster. |
+| [OFFSET_DIAGONAL_TOP_RIGHT](#OFFSET-DIAGONAL-TOP-RIGHT) | Yttre skugga förskjuten i diagonal övre höger. |
+| [OFFSET_LEFT](#OFFSET-LEFT) | Yttre skugga förskjuten åt vänster. |
+| [OFFSET_RIGHT](#OFFSET-RIGHT) | Yttre skugga förskjuten åt höger. |
+| [OFFSET_TOP](#OFFSET-TOP) | Yttre skugga förskjuten uppåt. |
+| [PERSPECTIVE_DIAGONAL_LOWER_LEFT](#PERSPECTIVE-DIAGONAL-LOWER-LEFT) | Yttre skugga perspektiv diagonal nedre vänster. |
+| [PERSPECTIVE_DIAGONAL_LOWER_RIGHT](#PERSPECTIVE-DIAGONAL-LOWER-RIGHT) | Yttre skugga perspektiv diagonal nedre höger. |
+| [PERSPECTIVE_DIAGONAL_UPPER_LEFT](#PERSPECTIVE-DIAGONAL-UPPER-LEFT) | Yttre skugga perspektiv diagonal övre vänster. |
+| [PERSPECTIVE_DIAGONAL_UPPER_RIGHT](#PERSPECTIVE-DIAGONAL-UPPER-RIGHT) | Yttre skugga perspektiv diagonal övre höger. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BELOW {#BELOW}
+```
+public static final int BELOW
+```
+
+
+Yttre skugga nedanför.
+
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Anpassad skugga.
+
+### INSIDE_BOTTOM {#INSIDE-BOTTOM}
+```
+public static final int INSIDE_BOTTOM
+```
+
+
+Inre skugga i botten.
+
+### INSIDE_CENTER {#INSIDE-CENTER}
+```
+public static final int INSIDE_CENTER
+```
+
+
+Inre skugga i mitten.
+
+### INSIDE_DIAGONAL_BOTTOM_LEFT {#INSIDE-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Inre skugga i diagonal nedre vänster.
+
+### INSIDE_DIAGONAL_BOTTOM_RIGHT {#INSIDE-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Inre skugga i diagonal nedre höger.
+
+### INSIDE_DIAGONAL_TOP_LEFT {#INSIDE-DIAGONAL-TOP-LEFT}
+```
+public static final int INSIDE_DIAGONAL_TOP_LEFT
+```
+
+
+Inre skugga i diagonal övre vänster.
+
+### INSIDE_DIAGONAL_TOP_RIGHT {#INSIDE-DIAGONAL-TOP-RIGHT}
+```
+public static final int INSIDE_DIAGONAL_TOP_RIGHT
+```
+
+
+Inre skugga i diagonal övre höger.
+
+### INSIDE_LEFT {#INSIDE-LEFT}
+```
+public static final int INSIDE_LEFT
+```
+
+
+Inre skugga i vänster.
+
+### INSIDE_RIGHT {#INSIDE-RIGHT}
+```
+public static final int INSIDE_RIGHT
+```
+
+
+Inre skugga i höger.
+
+### INSIDE_TOP {#INSIDE-TOP}
+```
+public static final int INSIDE_TOP
+```
+
+
+Inre skugga i toppen.
+
+### NO_SHADOW {#NO-SHADOW}
+```
+public static final int NO_SHADOW
+```
+
+
+Ingen skugga.
+
+### OFFSET_BOTTOM {#OFFSET-BOTTOM}
+```
+public static final int OFFSET_BOTTOM
+```
+
+
+Yttre skugga förskjuten mot botten.
+
+### OFFSET_CENTER {#OFFSET-CENTER}
+```
+public static final int OFFSET_CENTER
+```
+
+
+Yttre skugga förskjuten i mitten.
+
+### OFFSET_DIAGONAL_BOTTOM_LEFT {#OFFSET-DIAGONAL-BOTTOM-LEFT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_LEFT
+```
+
+
+Yttre skugga förskjuten i diagonal nedre vänster.
+
+### OFFSET_DIAGONAL_BOTTOM_RIGHT {#OFFSET-DIAGONAL-BOTTOM-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_BOTTOM_RIGHT
+```
+
+
+Yttre skugga förskjuten i diagonal nedre höger.
+
+### OFFSET_DIAGONAL_TOP_LEFT {#OFFSET-DIAGONAL-TOP-LEFT}
+```
+public static final int OFFSET_DIAGONAL_TOP_LEFT
+```
+
+
+Yttre skugga förskjuten i diagonal övre vänster.
+
+### OFFSET_DIAGONAL_TOP_RIGHT {#OFFSET-DIAGONAL-TOP-RIGHT}
+```
+public static final int OFFSET_DIAGONAL_TOP_RIGHT
+```
+
+
+Yttre skugga förskjuten i diagonal övre höger.
+
+### OFFSET_LEFT {#OFFSET-LEFT}
+```
+public static final int OFFSET_LEFT
+```
+
+
+Yttre skugga förskjuten åt vänster.
+
+### OFFSET_RIGHT {#OFFSET-RIGHT}
+```
+public static final int OFFSET_RIGHT
+```
+
+
+Yttre skugga förskjuten åt höger.
+
+### OFFSET_TOP {#OFFSET-TOP}
+```
+public static final int OFFSET_TOP
+```
+
+
+Yttre skugga förskjuten uppåt.
+
+### PERSPECTIVE_DIAGONAL_LOWER_LEFT {#PERSPECTIVE-DIAGONAL-LOWER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_LEFT
+```
+
+
+Yttre skugga perspektiv diagonal nedre vänster.
+
+### PERSPECTIVE_DIAGONAL_LOWER_RIGHT {#PERSPECTIVE-DIAGONAL-LOWER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_LOWER_RIGHT
+```
+
+
+Yttre skugga perspektiv diagonal nedre höger.
+
+### PERSPECTIVE_DIAGONAL_UPPER_LEFT {#PERSPECTIVE-DIAGONAL-UPPER-LEFT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_LEFT
+```
+
+
+Yttre skugga perspektiv diagonal övre vänster.
+
+### PERSPECTIVE_DIAGONAL_UPPER_RIGHT {#PERSPECTIVE-DIAGONAL-UPPER-RIGHT}
+```
+public static final int PERSPECTIVE_DIAGONAL_UPPER_RIGHT
+```
+
+
+Yttre skugga perspektiv diagonal övre höger.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetstylematricsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/presetstylematricsvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: PresetStyleMatricsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Används för att ställa in formens temastil‑egenskap.
+type: docs
+weight: 300
+url: /sv/java/com.aspose.diagram/presetstylematricsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetStyleMatricsValue
+```
+
+Används för att ställa in formens temastil‑egenskap.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [STYLE_1](#STYLE-1) | Style1 |
+| [STYLE_2](#STYLE-2) | Style2 |
+| [STYLE_3](#STYLE-3) | Style3 |
+| [STYLE_4](#STYLE-4) | Style4 |
+| [STYLE_5](#STYLE-5) | Style5 |
+| [STYLE_6](#STYLE-6) | Style6 |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### STYLE_1 {#STYLE-1}
+```
+public static final int STYLE_1
+```
+
+
+Style1
+
+### STYLE_2 {#STYLE-2}
+```
+public static final int STYLE_2
+```
+
+
+Style2
+
+### STYLE_3 {#STYLE-3}
+```
+public static final int STYLE_3
+```
+
+
+Style3
+
+### STYLE_4 {#STYLE-4}
+```
+public static final int STYLE_4
+```
+
+
+Style4
+
+### STYLE_5 {#STYLE-5}
+```
+public static final int STYLE_5
+```
+
+
+Style5
+
+### STYLE_6 {#STYLE-6}
+```
+public static final int STYLE_6
+```
+
+
+Style6
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetthemevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/presetthemevalue/_index.md
@@ -1,0 +1,372 @@
+---
+title: PresetThemeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger temavärdet.
+type: docs
+weight: 301
+url: /sv/java/com.aspose.diagram/presetthemevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeValue
+```
+
+Anger temavärdet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BUBBLE](#BUBBLE) | Bubbla |
+| [CLOUDS](#CLOUDS) | Moln |
+| [DAYBREAK](#DAYBREAK) | Daggry |
+| [FACET](#FACET) | Facett |
+| [GEMSTONE](#GEMSTONE) | Ädelsten |
+| [INTEGRAL](#INTEGRAL) | Integral |
+| [ION](#ION) | Ion |
+| [LINEAR](#LINEAR) | Linear |
+| [LINES](#LINES) | Lines |
+| [MARKER](#MARKER) | Marker |
+| [NO_THEME](#NO-THEME) | NoTheme |
+| [OFFICE](#OFFICE) | Office |
+| [ORGANIC](#ORGANIC) | Organic |
+| [PARALLEL](#PARALLEL) | Parallel |
+| [PEN](#PEN) | Pen |
+| [PENCIL](#PENCIL) | Pencil |
+| [PROMINENCE](#PROMINENCE) | Prominence |
+| [RADIANCE](#RADIANCE) | Radiance |
+| [RETROSPECT](#RETROSPECT) | Retrospect |
+| [SEQUENCE](#SEQUENCE) | Sequence |
+| [SHADE](#SHADE) | Shade |
+| [SIMPLE](#SIMPLE) | Simple |
+| [SLICE](#SLICE) | Slice |
+| [SMOKE](#SMOKE) | Smoke |
+| [WHISP](#WHISP) | Whisp |
+| [WHITE_BOARD](#WHITE-BOARD) | WhiteBoard |
+| [ZEPHYR](#ZEPHYR) | Zephyr |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BUBBLE {#BUBBLE}
+```
+public static final int BUBBLE
+```
+
+
+Bubbla
+
+### CLOUDS {#CLOUDS}
+```
+public static final int CLOUDS
+```
+
+
+Moln
+
+### DAYBREAK {#DAYBREAK}
+```
+public static final int DAYBREAK
+```
+
+
+Daggry
+
+### FACET {#FACET}
+```
+public static final int FACET
+```
+
+
+Facett
+
+### GEMSTONE {#GEMSTONE}
+```
+public static final int GEMSTONE
+```
+
+
+Ädelsten
+
+### INTEGRAL {#INTEGRAL}
+```
+public static final int INTEGRAL
+```
+
+
+Integral
+
+### ION {#ION}
+```
+public static final int ION
+```
+
+
+Ion
+
+### LINEAR {#LINEAR}
+```
+public static final int LINEAR
+```
+
+
+Linear
+
+### LINES {#LINES}
+```
+public static final int LINES
+```
+
+
+Lines
+
+### MARKER {#MARKER}
+```
+public static final int MARKER
+```
+
+
+Marker
+
+### NO_THEME {#NO-THEME}
+```
+public static final int NO_THEME
+```
+
+
+NoTheme
+
+### OFFICE {#OFFICE}
+```
+public static final int OFFICE
+```
+
+
+Office
+
+### ORGANIC {#ORGANIC}
+```
+public static final int ORGANIC
+```
+
+
+Organic
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Parallel
+
+### PEN {#PEN}
+```
+public static final int PEN
+```
+
+
+Pen
+
+### PENCIL {#PENCIL}
+```
+public static final int PENCIL
+```
+
+
+Pencil
+
+### PROMINENCE {#PROMINENCE}
+```
+public static final int PROMINENCE
+```
+
+
+Prominence
+
+### RADIANCE {#RADIANCE}
+```
+public static final int RADIANCE
+```
+
+
+Radiance
+
+### RETROSPECT {#RETROSPECT}
+```
+public static final int RETROSPECT
+```
+
+
+Retrospect
+
+### SEQUENCE {#SEQUENCE}
+```
+public static final int SEQUENCE
+```
+
+
+Sequence
+
+### SHADE {#SHADE}
+```
+public static final int SHADE
+```
+
+
+Shade
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Simple
+
+### SLICE {#SLICE}
+```
+public static final int SLICE
+```
+
+
+Slice
+
+### SMOKE {#SMOKE}
+```
+public static final int SMOKE
+```
+
+
+Smoke
+
+### WHISP {#WHISP}
+```
+public static final int WHISP
+```
+
+
+Whisp
+
+### WHITE_BOARD {#WHITE-BOARD}
+```
+public static final int WHITE_BOARD
+```
+
+
+WhiteBoard
+
+### ZEPHYR {#ZEPHYR}
+```
+public static final int ZEPHYR
+```
+
+
+Zephyr
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/presetthemevariantvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/presetthemevariantvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PresetThemeVariantValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger värdet för temavarianten.
+type: docs
+weight: 302
+url: /sv/java/com.aspose.diagram/presetthemevariantvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PresetThemeVariantValue
+```
+
+Anger värdet för temavarianten.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [VARIANT_1](#VARIANT-1) | Variant1. |
+| [VARIANT_2](#VARIANT-2) | Variant2. |
+| [VARIANT_3](#VARIANT-3) | Variant3. |
+| [VARIANT_4](#VARIANT-4) | Variant4. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VARIANT_1 {#VARIANT-1}
+```
+public static final int VARIANT_1
+```
+
+
+Variant1.
+
+### VARIANT_2 {#VARIANT-2}
+```
+public static final int VARIANT_2
+```
+
+
+Variant2.
+
+### VARIANT_3 {#VARIANT-3}
+```
+public static final int VARIANT_3
+```
+
+
+Variant3.
+
+### VARIANT_4 {#VARIANT-4}
+```
+public static final int VARIANT_4
+```
+
+
+Variant4.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/previewscope/_index.md
+++ b/swedish/java/com.aspose.diagram/previewscope/_index.md
@@ -1,0 +1,179 @@
+---
+title: PreviewScope
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om dokumentet innehåller en förhandsgranskning och i så fall om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+type: docs
+weight: 303
+url: /sv/java/com.aspose.diagram/previewscope/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PreviewScope
+```
+
+Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PreviewScope(int value)](#PreviewScope-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/previewscope\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PreviewScope(int value) {#PreviewScope-int-}
+```
+public PreviewScope(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/previewscope\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/previewscopevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/previewscopevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PreviewScopeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om dokumentet innehåller en förhandsgranskning och i så fall om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+type: docs
+weight: 304
+url: /sv/java/com.aspose.diagram/previewscopevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PreviewScopeValue
+```
+
+Anger om dokumentet innehåller en förhandsgranskning och, i så fall, om förhandsgranskningen visar endast den första sidan eller alla sidor i dokumentet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALL_PAGES](#ALL-PAGES) | Alla sidor. |
+| [FIRST_PAGE](#FIRST-PAGE) | Första sidan. |
+| [NO_PREVIEW](#NO-PREVIEW) | Ingen förhandsgranskning. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALL_PAGES {#ALL-PAGES}
+```
+public static final int ALL_PAGES
+```
+
+
+Alla sidor.
+
+### FIRST_PAGE {#FIRST-PAGE}
+```
+public static final int FIRST_PAGE
+```
+
+
+Första sidan.
+
+### NO_PREVIEW {#NO-PREVIEW}
+```
+public static final int NO_PREVIEW
+```
+
+
+Ingen förhandsgranskning.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/printpageorientation/_index.md
+++ b/swedish/java/com.aspose.diagram/printpageorientation/_index.md
@@ -1,0 +1,180 @@
+---
+title: PrintPageOrientation
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+type: docs
+weight: 305
+url: /sv/java/com.aspose.diagram/printpageorientation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintPageOrientation
+```
+
+Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PrintPageOrientation(PrintProps pp, int value)](#PrintPageOrientation-com.aspose.diagram.PrintProps-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer om sidan skrivs ut i stående eller liggande orientering. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintPageOrientation(PrintProps pp, int value) {#PrintPageOrientation-com.aspose.diagram.PrintProps-int-}
+```
+public PrintPageOrientation(PrintProps pp, int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| pp | [PrintProps](../../com.aspose.diagram/printprops) |  |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/printpageorientation\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/printpageorientationvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/printpageorientationvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: PrintPageOrientationValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+type: docs
+weight: 306
+url: /sv/java/com.aspose.diagram/printpageorientationvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PrintPageOrientationValue
+```
+
+Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [LANDSCAPE](#LANDSCAPE) | Liggande. |
+| [PORTRAIT](#PORTRAIT) | Stående. |
+| [SAME_AS_PRINTER](#SAME-AS-PRINTER) | Samma som skrivaren. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LANDSCAPE {#LANDSCAPE}
+```
+public static final int LANDSCAPE
+```
+
+
+Liggande.
+
+### PORTRAIT {#PORTRAIT}
+```
+public static final int PORTRAIT
+```
+
+
+Stående.
+
+### SAME_AS_PRINTER {#SAME-AS-PRINTER}
+```
+public static final int SAME_AS_PRINTER
+```
+
+
+Samma som skrivaren.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/printprops/_index.md
+++ b/swedish/java/com.aspose.diagram/printprops/_index.md
@@ -1,0 +1,315 @@
+---
+title: PrintProps
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr hur ritningssidan som formateras visas på utskriftssidan.
+type: docs
+weight: 307
+url: /sv/java/com.aspose.diagram/printprops/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class PrintProps
+```
+
+Innehåller element som styr hur ritningssidan formateras (visas) på utskriftssidan.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenterX()](#getCenterX--) | Bestämmer om ritningssidan är centrerad horisontellt på den utskrivna sidan. |
+| [getCenterY()](#getCenterY--) | Bestämmer om ritningssidan är centrerad vertikalt på den utskrivna sidan. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getOnPage()](#getOnPage--) | Anger om ritningen skrivs ut på ett specifikt antal utskriftssidor. |
+| [getPageBottomMargin()](#getPageBottomMargin--) | Anger marginalen längst ner på den utskrivna sidan. |
+| [getPageLeftMargin()](#getPageLeftMargin--) | Anger marginalen till vänster på den utskrivna sidan. |
+| [getPageRightMargin()](#getPageRightMargin--) | Anger marginalen till höger på den utskrivna sidan. |
+| [getPageTopMargin()](#getPageTopMargin--) | Anger marginalen högst upp på utskriftssidan. |
+| [getPagesX()](#getPagesX--) | Bestämmer antalet utskriftssidor som ritningssidan ska anpassas till horisontellt. |
+| [getPagesY()](#getPagesY--) | Bestämmer antalet utskriftssidor som ritningssidan ska anpassas till vertikalt. |
+| [getPaperKind()](#getPaperKind--) | Anger papperstypen som sidan ska skrivas ut på. |
+| [getPaperSource()](#getPaperSource--) | Bestämmer papperskällan för sidan. |
+| [getPrintGrid()](#getPrintGrid--) | Anger om rutnätet ska skrivas ut när en dokumentsida skrivs ut. |
+| [getPrintPageOrientation()](#getPrintPageOrientation--) | Bestämmer om sidan skrivs ut i stående eller liggande orientering. |
+| [getScaleX()](#getScaleX--) | Anger procentandelen för förstoring av ritningssidan på utskriftssidan, i x‑riktningen (horisontellt). |
+| [getScaleY()](#getScaleY--) | Anger procentandelen för förstoring av ritningssidan på utskriftsidan, i y-riktningen (vertikal). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se gärna [getDel()](../../com.aspose.diagram/printprops\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenterX() {#getCenterX--}
+```
+public BoolValue getCenterX()
+```
+
+
+Bestämmer om ritningssidan är centrerad horisontellt på den utskrivna sidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getCenterY() {#getCenterY--}
+```
+public BoolValue getCenterY()
+```
+
+
+Bestämmer om ritningssidan är centrerad vertikalt på den utskrivna sidan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getOnPage() {#getOnPage--}
+```
+public BoolValue getOnPage()
+```
+
+
+Anger om ritningen skrivs ut på ett specifikt antal utskriftssidor.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPageBottomMargin() {#getPageBottomMargin--}
+```
+public DoubleValue getPageBottomMargin()
+```
+
+
+Anger marginalen längst ner på den utskrivna sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageLeftMargin() {#getPageLeftMargin--}
+```
+public DoubleValue getPageLeftMargin()
+```
+
+
+Anger marginalen till vänster på den utskrivna sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageRightMargin() {#getPageRightMargin--}
+```
+public DoubleValue getPageRightMargin()
+```
+
+
+Anger marginalen till höger på den utskrivna sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPageTopMargin() {#getPageTopMargin--}
+```
+public DoubleValue getPageTopMargin()
+```
+
+
+Anger marginalen högst upp på utskriftssidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPagesX() {#getPagesX--}
+```
+public IntValue getPagesX()
+```
+
+
+Bestämmer antalet utskriftssidor som ritningssidan ska anpassas till horisontellt.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPagesY() {#getPagesY--}
+```
+public IntValue getPagesY()
+```
+
+
+Bestämmer antalet utskriftssidor som ritningssidan ska anpassas till vertikalt.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperKind() {#getPaperKind--}
+```
+public IntValue getPaperKind()
+```
+
+
+Anger papperstypen som sidan ska skrivas ut på.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPaperSource() {#getPaperSource--}
+```
+public IntValue getPaperSource()
+```
+
+
+Bestämmer papperskällan för sidan.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getPrintGrid() {#getPrintGrid--}
+```
+public BoolValue getPrintGrid()
+```
+
+
+Anger om rutnätet ska skrivas ut när en dokumentsida skrivs ut.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPrintPageOrientation() {#getPrintPageOrientation--}
+```
+public PrintPageOrientation getPrintPageOrientation()
+```
+
+
+Bestämmer om sidan skrivs ut i stående eller liggande orientering.
+
+**Returns:**
+[PrintPageOrientation](../../com.aspose.diagram/printpageorientation)
+### getScaleX() {#getScaleX--}
+```
+public DoubleValue getScaleX()
+```
+
+
+Anger procentandelen för förstoring av ritningssidan på utskriftssidan, i x‑riktningen (horisontellt).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getScaleY() {#getScaleY--}
+```
+public DoubleValue getScaleY()
+```
+
+
+Anger procentandelen för förstoring av ritningssidan på utskriftsidan, i y-riktningen (vertikal).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se gärna [getDel()](../../com.aspose.diagram/printprops\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/printsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/printsaveoptions/_index.md
@@ -1,0 +1,429 @@
+---
+title: PrintSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ vid utskrift av diagram.
+type: docs
+weight: 308
+url: /sv/java/com.aspose.diagram/printsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class PrintSaveOptions extends RenderingSaveOptions
+```
+
+Tillåter att ange ytterligare alternativ vid utskrift av diagram.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [PrintSaveOptions()](#PrintSaveOptions--) | Initierar en ny instans av denna klass |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getPageCount()](#getPageCount--) | antalet sidor som ska renderas när du sparar till en flersidig fil. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska skrivas ut eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivningen av denna egenskap, se [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivningen av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintSaveOptions() {#PrintSaveOptions--}
+```
+public PrintSaveOptions()
+```
+
+
+Initierar en ny instans av denna klass
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+antalet sidor som ska renderas när du sparar till en flersidig fil. Standard är MaxValue vilket betyder att alla diagrammets sidor kommer att skrivas ut.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska skrivas ut eller endast förgrunden. Om true - skrivs endast förgrundssidor (med bakgrund om den finns). Om false - skrivs förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPageCount()](../../com.aspose.diagram/printsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/printsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/prop/_index.md
+++ b/swedish/java/com.aspose.diagram/prop/_index.md
@@ -1,0 +1,384 @@
+---
+title: Egenskap
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element för att definiera anpassade egenskaper och element för att associera data med en form.
+type: docs
+weight: 309
+url: /sv/java/com.aspose.diagram/prop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Prop
+```
+
+Innehåller element för att definiera anpassade egenskaper och element för att associera data med en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Prop()](#Prop--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCalendar()](#getCalendar--) | Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getFormat()](#getFormat--) | Format‑elementet specificerar formateringen av en anpassad egenskap som är en sträng, fast lista, nummer, variabel lista, datum eller tid, varaktighet eller valuta. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getInvisible()](#getInvisible--) | Osynligt element specificerar om den anpassade egenskapen är synlig i dialogrutan Anpassade egenskaper i Microsoft Visio. |
+| [getLabel()](#getLabel--) | Specificerar etiketten som visas för användare i dialogrutan Anpassade egenskaper. |
+| [getLangID()](#getLangID--) | Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPrompt()](#getPrompt--) | Prompt‑elementet specificerar beskrivande eller instruktiv text som visas för användare i dialogrutan Anpassade egenskaper när egenskapen är markerad. |
+| [getSortKey()](#getSortKey--) | Det specificerar en nyckel som bestämmer i vilken ordning anpassade egenskaper listas i programmets användargränssnitt. |
+| [getType()](#getType--) | Typ anger en datatyp för det anpassade egenskapsvärdet. |
+| [getValue()](#getValue--) | Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument. |
+| [getVerify()](#getVerify--) | Specificerar om användaren frågas att ange information för en anpassad egenskap för en form när en instans skapas eller formen dupliceras eller kopieras. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/prop\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/prop\#getID--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/prop\#getIX--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/prop\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/prop\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Prop() {#Prop--}
+```
+public Prop()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Prop deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCalendar() {#getCalendar--}
+```
+public Calendar getCalendar()
+```
+
+
+Bestämmer den kalender som används för anpassade egenskaper, textfält och elementformler.
+
+**Returns:**
+[Calendar](../../com.aspose.diagram/calendar)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getFormat() {#getFormat--}
+```
+public StrValue getFormat()
+```
+
+
+Format-elementet specificerar formateringen av en anpassad egenskap som är en sträng, fast lista, tal, variabel lista, datum eller tid, varaktighet eller valuta. Den anpassade egenskapstypen specificeras i motsvarande Type-element.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getInvisible() {#getInvisible--}
+```
+public BoolValue getInvisible()
+```
+
+
+Osynligt element specificerar om den anpassade egenskapen är synlig i dialogrutan Anpassade egenskaper i Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLabel() {#getLabel--}
+```
+public Str2Value getLabel()
+```
+
+
+Specificerar etiketten som visas för användare i dialogrutan Anpassade egenskaper.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getLangID() {#getLangID--}
+```
+public IntValue getLangID()
+```
+
+
+Anger språk‑ID (LCID) för det språk som cellformeln, texten, den anpassade egenskapen eller kommentaren angavs i.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Prompt-elementet specificerar beskrivande eller instruktiv text som visas för användare i dialogrutan Anpassade egenskaper när egenskapen är markerad. Denna text visas också som verktygstips när muspekaren hålls över egenskapen i fönstret Anpassade egenskaper.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getSortKey() {#getSortKey--}
+```
+public Str2Value getSortKey()
+```
+
+
+Det specificerar en nyckel som bestämmer i vilken ordning anpassade egenskaper listas i programmets användargränssnitt.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getType() {#getType--}
+```
+public TypeProp getType()
+```
+
+
+Typ anger en datatyp för det anpassade egenskapsvärdet.
+
+**Returns:**
+[TypeProp](../../com.aspose.diagram/typeprop)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getVerify() {#getVerify--}
+```
+public BoolValue getVerify()
+```
+
+
+Specificerar om användaren frågas att ange information för en anpassad egenskap för en form när en instans skapas eller formen dupliceras eller kopieras.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/prop\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/prop\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/prop\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/prop\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/prop\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/propcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/propcollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: PropCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Prop‑samling.
+type: docs
+weight: 310
+url: /sv/java/com.aspose.diagram/propcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class PropCollection extends Collection
+```
+
+Prop‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Prop item)](#add-com.aspose.diagram.Prop-) | Lägg till Prop-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getProp(int ID)](#getProp-int-) | Hämtar elementet med angivet ID. |
+| [getProp(String name)](#getProp-java.lang.String-) | Hämtar elementet med angivet namn. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Prop item)](#remove-com.aspose.diagram.Prop-) | Ta bort Prop-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Prop item) {#add-com.aspose.diagram.Prop-}
+```
+public int add(Prop item)
+```
+
+
+Lägg till Prop-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Prop get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getProp(int ID) {#getProp-int-}
+```
+public Prop getProp(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### getProp(String name) {#getProp-java.lang.String-}
+```
+public Prop getProp(String name)
+```
+
+
+Hämtar elementet med angivet namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Prop](../../com.aspose.diagram/prop) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Prop item) {#remove-com.aspose.diagram.Prop-}
+```
+public void remove(Prop item)
+```
+
+
+Ta bort Prop-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Prop](../../com.aspose.diagram/prop) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/proptype/_index.md
+++ b/swedish/java/com.aspose.diagram/proptype/_index.md
@@ -1,0 +1,165 @@
+---
+title: PropType
+second_title: Aspose.Diagram för Java API-referens
+description: Typ av egenskap.
+type: docs
+weight: 311
+url: /sv/java/com.aspose.diagram/proptype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class PropType
+```
+
+Typ av egenskap.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOOL](#BOOL) | Boolesk. |
+| [DATE](#DATE) | Datum. |
+| [NUMBER](#NUMBER) | Nummer. |
+| [STRING](#STRING) | Sträng. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOL {#BOOL}
+```
+public static final int BOOL
+```
+
+
+Boolesk.
+
+### DATE {#DATE}
+```
+public static final int DATE
+```
+
+
+Datum.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Nummer.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Sträng.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/protection/_index.md
+++ b/swedish/java/com.aspose.diagram/protection/_index.md
@@ -1,0 +1,370 @@
+---
+title: Skydd
+second_title: Aspose.Diagram för Java API-referens
+description: Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer.
+type: docs
+weight: 312
+url: /sv/java/com.aspose.diagram/protection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Protection
+```
+
+Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. Det skyddar inte heller mot ändringar som görs i ShapeSheet-fönstret.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getLockAspect()](#getLockAspect--) | Anger om bildförhållandet för formen är låst. |
+| [getLockBegin()](#getLockBegin--) | Anger om startpunkten för en 1‑D‑form är låst till en specifik plats. |
+| [getLockCalcWH()](#getLockCalcWH--) | Anger om en formes markeringsrektangel är låst så att den inte kan beräknas om när en hörnpunkt redigeras eller en elementtyp ändras i Geom‑elementet. |
+| [getLockCrop()](#getLockCrop--) | Anger om ett främmande objekt är låst så att det inte kan beskäras med Beskär‑verktyget i Microsoft Visio. |
+| [getLockCustProp()](#getLockCustProp--) | Bestämmer om användaren kan lägga till, ta bort eller ändra anpassade egenskaper i användargränssnittet (UI) genom att använda dialogrutan Definiera anpassade egenskaper. |
+| [getLockDelete()](#getLockDelete--) | Anger om en form är låst så att den inte kan tas bort. |
+| [getLockEnd()](#getLockEnd--) | Anger om slutpunkten för en 1‑D‑form är låst till en specifik plats. |
+| [getLockFormat()](#getLockFormat--) | Anger om formateringen av en form är låst så att den inte kan ändras. |
+| [getLockFromGroupFormat()](#getLockFromGroupFormat--) | Tillåter en delform att blockera formateringsändringar som appliceras på en överordnad gruppform i Visio‑användargränssnittet och som annars skulle spridas ner till enskilda gruppformer. |
+| [getLockGroup()](#getLockGroup--) | Anger om en grupp är låst så att den inte kan avgrupperas. |
+| [getLockHeight()](#getLockHeight--) | Anger om formens höjd är låst. |
+| [getLockMoveX()](#getLockMoveX--) | Anger om formens horisontella position är låst så att den inte kan flyttas horisontellt. |
+| [getLockMoveY()](#getLockMoveY--) | Anger om formens vertikala position är låst så att den inte kan flyttas vertikalt. |
+| [getLockRotate()](#getLockRotate--) | Anger om formen är låst så att den inte kan roteras med Rotations‑verktyget eller kommandona Rotera vänster eller Rotera höger i Microsoft Visio. |
+| [getLockSelect()](#getLockSelect--) | Anger om en formes markeringsrektangel är låst så att den inte kan beräknas om när en hörnpunkt redigeras eller en elementtyp ändras i Geom‑elementet. |
+| [getLockTextEdit()](#getLockTextEdit--) | Anger om texten i en form är låst så att den inte kan redigeras. |
+| [getLockThemeColors()](#getLockThemeColors--) | Förhindrar att användare tillämpar temafärger på formen. |
+| [getLockThemeEffects()](#getLockThemeEffects--) | Förhindrar att användare applicerar temaeffekter på formen. |
+| [getLockVtxEdit()](#getLockVtxEdit--) | Anger om hörnen på en form är låsta så att de inte kan redigeras med några verktyg i verktygsfältet. |
+| [getLockWidth()](#getLockWidth--) | Anger om formens bredd är låst så att den förblir oförändrad när formen ändras i storlek. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/protection\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getLockAspect() {#getLockAspect--}
+```
+public BoolValue getLockAspect()
+```
+
+
+Anger om bildförhållandet för formen är låst. Om låst kan formen endast storleksändras proportionellt; den kan inte storleksändras i en enda dimension.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockBegin() {#getLockBegin--}
+```
+public BoolValue getLockBegin()
+```
+
+
+Anger om startpunkten för en 1‑D‑form är låst till en specifik plats.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCalcWH() {#getLockCalcWH--}
+```
+public BoolValue getLockCalcWH()
+```
+
+
+Anger om en formes markeringsrektangel är låst så att den inte kan beräknas om när en hörnpunkt redigeras eller en elementtyp ändras i Geom‑elementet.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCrop() {#getLockCrop--}
+```
+public BoolValue getLockCrop()
+```
+
+
+Anger om ett främmande objekt är låst så att det inte kan beskäras med Beskär‑verktyget i Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockCustProp() {#getLockCustProp--}
+```
+public BoolValue getLockCustProp()
+```
+
+
+Bestämmer om användaren kan lägga till, ta bort eller ändra anpassade egenskaper i användargränssnittet (UI) genom att använda dialogrutan Definiera anpassade egenskaper.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockDelete() {#getLockDelete--}
+```
+public BoolValue getLockDelete()
+```
+
+
+Anger om en form är låst så att den inte kan tas bort.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockEnd() {#getLockEnd--}
+```
+public BoolValue getLockEnd()
+```
+
+
+Anger om slutpunkten för en 1‑D‑form är låst till en specifik plats.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFormat() {#getLockFormat--}
+```
+public BoolValue getLockFormat()
+```
+
+
+Anger om formateringen av en form är låst så att den inte kan ändras. Specifikt skyddar detta element mot att ändra text-, linje- och fyllningsformatering, eller att ändra vilket Stil‑element formen ärver från.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockFromGroupFormat() {#getLockFromGroupFormat--}
+```
+public BoolValue getLockFromGroupFormat()
+```
+
+
+Tillåter en delform att blockera formateringsändringar som appliceras på en överordnad gruppform i Visio‑användargränssnittet och som annars skulle spridas ner till enskilda gruppformer.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockGroup() {#getLockGroup--}
+```
+public BoolValue getLockGroup()
+```
+
+
+Anger om en grupp är låst så att den inte kan avgrupperas.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockHeight() {#getLockHeight--}
+```
+public BoolValue getLockHeight()
+```
+
+
+Anger om formens höjd är låst. Om låst förblir dess höjd oförändrad när formen ändras i storlek.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveX() {#getLockMoveX--}
+```
+public BoolValue getLockMoveX()
+```
+
+
+Anger om formens horisontella position är låst så att den inte kan flyttas horisontellt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockMoveY() {#getLockMoveY--}
+```
+public BoolValue getLockMoveY()
+```
+
+
+Anger om formens vertikala position är låst så att den inte kan flyttas vertikalt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockRotate() {#getLockRotate--}
+```
+public BoolValue getLockRotate()
+```
+
+
+Anger om formen är låst så att den inte kan roteras med Rotations‑verktyget eller kommandona Rotera vänster eller Rotera höger i Microsoft Visio.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockSelect() {#getLockSelect--}
+```
+public BoolValue getLockSelect()
+```
+
+
+Anger om en formes markeringsrektangel är låst så att den inte kan beräknas om när en hörnpunkt redigeras eller en elementtyp ändras i Geom‑elementet.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockTextEdit() {#getLockTextEdit--}
+```
+public BoolValue getLockTextEdit()
+```
+
+
+Anger om texten i en form är låst så att den inte kan redigeras. Texten kan dock fortfarande formateras genom att tillämpa en stil, med Stil‑alternativen på fliken Teckensnitt i textrutan.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeColors() {#getLockThemeColors--}
+```
+public BoolValue getLockThemeColors()
+```
+
+
+Förhindrar att användare tillämpar temafärger på formen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockThemeEffects() {#getLockThemeEffects--}
+```
+public BoolValue getLockThemeEffects()
+```
+
+
+Förhindrar att användare applicerar temaeffekter på formen.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockVtxEdit() {#getLockVtxEdit--}
+```
+public BoolValue getLockVtxEdit()
+```
+
+
+Anger om hörnen på en form är låsta så att de inte kan redigeras med några verktyg i verktygsfältet.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getLockWidth() {#getLockWidth--}
+```
+public BoolValue getLockWidth()
+```
+
+
+Anger om formens bredd är låst så att den förblir oförändrad när formen ändras i storlek.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/protection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/radiobuttonactivexcontrol/_index.md
@@ -1,0 +1,679 @@
+---
+title: RadioButtonActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en RadioButton ActiveX‑kontroll.
+type: docs
+weight: 313
+url: /sv/java/com.aspose.diagram/radiobuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.ToggleButtonActiveXControl](../../com.aspose.diagram/togglebuttonactivexcontrol)
+```
+public class RadioButtonActiveXControl extends ToggleButtonActiveXControl
+```
+
+Representerar en RadioButton ActiveX‑kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Acceleratortangenten för kontrollen. |
+| [getAlignment()](#getAlignment--) | Positionen för Caption relativt kontrollen. |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getCaption()](#getCaption--) | Den beskrivande texten som visas på en kontroll. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getGroupName()](#getGroupName--) | Gruppens namn. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPicturePosition()](#getPicturePosition--) | platsen för kontrollens bild relativt dess rubrik. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getValue()](#getValue--) | Anger om kontrollen är markerad eller inte. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isTripleState()](#isTripleState--) | Anger hur den angivna kontrollen kommer att visa Null‑värden. |
+| [isWordWrapped()](#isWordWrapped--) | Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAlignment(int value)](#setAlignment-int-) | För beskrivningen av denna egenskap, se [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setGroupName(String value)](#setGroupName-java.lang.String-) | För beskrivningen av denna egenskap, se [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | För beskrivningen av denna egenskap, se [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Acceleratortangenten för kontrollen.
+
+**Returns:**
+char
+### getAlignment() {#getAlignment--}
+```
+public int getAlignment()
+```
+
+
+Positionen för Caption relativt kontrollen.
+
+**Returns:**
+int
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Den beskrivande texten som visas på en kontroll.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getGroupName() {#getGroupName--}
+```
+public String getGroupName()
+```
+
+
+Gruppens namn.
+
+**Returns:**
+java.lang.String
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+platsen för kontrollens bild relativt dess rubrik.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om kontrollen är markerad eller inte.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Anger hur den angivna kontrollen kommer att visa Null‑värden.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inställning | Beskrivning                                                                                                                                     |
+| True    | Kontrollen kommer att cykla genom tillstånd för Ja, Nej och Null‑värden. Kontrollen visas nedtonad (grå) när dess Value‑egenskap är satt till Null. |
+| False   | (Standard) Kontrollen kommer att cykla genom tillstånd för Ja och Nej‑värden. Null‑värden visas som om de vore Nej‑värden.                           |
+
+|
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setAlignment(int value) {#setAlignment-int-}
+```
+public void setAlignment(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAlignment()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setGroupName(String value) {#setGroupName-java.lang.String-}
+```
+public void setGroupName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getGroupName()](../../com.aspose.diagram/radiobuttonactivexcontrol\#getGroupName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/radiobuttonactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rectanglealignmenttype/_index.md
+++ b/swedish/java/com.aspose.diagram/rectanglealignmenttype/_index.md
@@ -1,0 +1,210 @@
+---
+title: RectangleAlignmentType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar hur två rektanglar placeras relativt till varandra.
+type: docs
+weight: 314
+url: /sv/java/com.aspose.diagram/rectanglealignmenttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RectangleAlignmentType
+```
+
+Representerar hur två rektanglar placeras relativt till varandra.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Nederst |
+| [BOTTOM_LEFT](#BOTTOM-LEFT) | Nedre vänster |
+| [BOTTOM_RIGHT](#BOTTOM-RIGHT) | Nedre höger |
+| [CENTER](#CENTER) | Centrerad |
+| [LEFT](#LEFT) | Vänster |
+| [RIGHT](#RIGHT) | Höger |
+| [TOP](#TOP) | Överst |
+| [TOP_LEFT](#TOP-LEFT) | Övre vänster |
+| [TOP_RIGHT](#TOP-RIGHT) | Övre höger |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Nederst
+
+### BOTTOM_LEFT {#BOTTOM-LEFT}
+```
+public static final int BOTTOM_LEFT
+```
+
+
+Nedre vänster
+
+### BOTTOM_RIGHT {#BOTTOM-RIGHT}
+```
+public static final int BOTTOM_RIGHT
+```
+
+
+Nedre höger
+
+### CENTER {#CENTER}
+```
+public static final int CENTER
+```
+
+
+Centrerad
+
+### LEFT {#LEFT}
+```
+public static final int LEFT
+```
+
+
+Vänster
+
+### RIGHT {#RIGHT}
+```
+public static final int RIGHT
+```
+
+
+Höger
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Överst
+
+### TOP_LEFT {#TOP-LEFT}
+```
+public static final int TOP_LEFT
+```
+
+
+Övre vänster
+
+### TOP_RIGHT {#TOP-RIGHT}
+```
+public static final int TOP_RIGHT
+```
+
+
+Övre höger
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/reflectioneffecttype/_index.md
+++ b/swedish/java/com.aspose.diagram/reflectioneffecttype/_index.md
@@ -1,0 +1,226 @@
+---
+title: ReflectionEffectType
+second_title: Aspose.Diagram för Java API-referens
+description: 
+type: docs
+weight: 315
+url: /sv/java/com.aspose.diagram/reflectioneffecttype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ReflectionEffectType
+```
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CUSTOM](#CUSTOM) | Anpassad reflektionseffekt. |
+| [FULL_REFLECTION_4_PT_OFFSET](#FULL-REFLECTION-4-PT-OFFSET) | Full reflektion, 4 pt förskjutning. |
+| [FULL_REFLECTION_8_PT_OFFSET](#FULL-REFLECTION-8-PT-OFFSET) | Full reflektion, 8 pt förskjutning. |
+| [FULL_REFLECTION_TOUCHING](#FULL-REFLECTION-TOUCHING) | Full reflektion, berörande. |
+| [HALF_REFLECTION_4_PT_OFFSET](#HALF-REFLECTION-4-PT-OFFSET) | Halv reflektion, 4 pt förskjutning. |
+| [HALF_REFLECTION_8_PT_OFFSET](#HALF-REFLECTION-8-PT-OFFSET) | Halv reflektion, 8 pt förskjutning. |
+| [HALF_REFLECTION_TOUCHING](#HALF-REFLECTION-TOUCHING) | Halv reflektion, berörande. |
+| [NONE](#NONE) | Ingen reflektionseffekt. |
+| [TIGHT_REFLECTION_4_PT_OFFSET](#TIGHT-REFLECTION-4-PT-OFFSET) | Stram reflektion, 4 pt offset. |
+| [TIGHT_REFLECTION_8_PT_OFFSET](#TIGHT-REFLECTION-8-PT-OFFSET) | Stram reflektion, 8 pt offset. |
+| [TIGHT_REFLECTION_TOUCHING](#TIGHT-REFLECTION-TOUCHING) | Stram reflektion, berörande. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CUSTOM {#CUSTOM}
+```
+public static final int CUSTOM
+```
+
+
+Anpassad reflektionseffekt.
+
+### FULL_REFLECTION_4_PT_OFFSET {#FULL-REFLECTION-4-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_4_PT_OFFSET
+```
+
+
+Full reflektion, 4 pt förskjutning.
+
+### FULL_REFLECTION_8_PT_OFFSET {#FULL-REFLECTION-8-PT-OFFSET}
+```
+public static final int FULL_REFLECTION_8_PT_OFFSET
+```
+
+
+Full reflektion, 8 pt förskjutning.
+
+### FULL_REFLECTION_TOUCHING {#FULL-REFLECTION-TOUCHING}
+```
+public static final int FULL_REFLECTION_TOUCHING
+```
+
+
+Full reflektion, berörande.
+
+### HALF_REFLECTION_4_PT_OFFSET {#HALF-REFLECTION-4-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_4_PT_OFFSET
+```
+
+
+Halv reflektion, 4 pt förskjutning.
+
+### HALF_REFLECTION_8_PT_OFFSET {#HALF-REFLECTION-8-PT-OFFSET}
+```
+public static final int HALF_REFLECTION_8_PT_OFFSET
+```
+
+
+Halv reflektion, 8 pt förskjutning.
+
+### HALF_REFLECTION_TOUCHING {#HALF-REFLECTION-TOUCHING}
+```
+public static final int HALF_REFLECTION_TOUCHING
+```
+
+
+Halv reflektion, berörande.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen reflektionseffekt.
+
+### TIGHT_REFLECTION_4_PT_OFFSET {#TIGHT-REFLECTION-4-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_4_PT_OFFSET
+```
+
+
+Stram reflektion, 4 pt offset.
+
+### TIGHT_REFLECTION_8_PT_OFFSET {#TIGHT-REFLECTION-8-PT-OFFSET}
+```
+public static final int TIGHT_REFLECTION_8_PT_OFFSET
+```
+
+
+Stram reflektion, 8 pt offset.
+
+### TIGHT_REFLECTION_TOUCHING {#TIGHT-REFLECTION-TOUCHING}
+```
+public static final int TIGHT_REFLECTION_TOUCHING
+```
+
+
+Stram reflektion, berörande.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relcubbezto/_index.md
+++ b/swedish/java/com.aspose.diagram/relcubbezto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelCubBezTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för en RelCubBezTo-punkter.
+type: docs
+weight: 316
+url: /sv/java/com.aspose.diagram/relcubbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelCubBezTo extends Coordinate
+```
+
+Innehåller x- och y-koordinater för en RelCubBezTo:s punkter.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RelCubBezTo()](#RelCubBezTo--) | Skapar en instans av klassen [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | X-koordinaten för kontrollpunkten i början av kurvan i relativa koordinater. |
+| [getB()](#getB--) | Y-koordinaten för kontrollpunkten i början av kurvan i relativa koordinater. |
+| [getC()](#getC--) | X-koordinaten för kontrollpunkten i slutet av kurvan i relativa koordinater. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Y-koordinaten för kontrollpunkten i slutet av kurvan i relativa koordinater. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X-koordinaten för slutpunkten i relativa koordinater. |
+| [getY()](#getY--) | Y-koordinaten för slutpunkten i relativa koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relcubbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relcubbezto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/relcubbezto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getD()](../../com.aspose.diagram/relcubbezto\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relcubbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relcubbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelCubBezTo() {#RelCubBezTo--}
+```
+public RelCubBezTo()
+```
+
+
+Skapar en instans av klassen [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+X-koordinaten för kontrollpunkten i början av kurvan i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Y-koordinaten för kontrollpunkten i början av kurvan i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+X-koordinaten för kontrollpunkten i slutet av kurvan i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Y-koordinaten för kontrollpunkten i slutet av kurvan i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten för slutpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten för slutpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relcubbezto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relcubbezto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/relcubbezto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getD()](../../com.aspose.diagram/relcubbezto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relcubbezto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relcubbezto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relcubbezto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relcubbezto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relcubbeztocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/relcubbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelCubBezToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RelCubBezTo‑samling.
+type: docs
+weight: 317
+url: /sv/java/com.aspose.diagram/relcubbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelCubBezToCollection extends Collection
+```
+
+RelCubBezTo‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelCubBezTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RelCubBezTo](../../com.aspose.diagram/relcubbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relellipticalarcto/_index.md
+++ b/swedish/java/com.aspose.diagram/relellipticalarcto/_index.md
@@ -1,0 +1,349 @@
+---
+title: RelEllipticalArcTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar information om en elliptisk båge. Koordinaterna anges som relativa koordinater.
+type: docs
+weight: 318
+url: /sv/java/com.aspose.diagram/relellipticalarcto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelEllipticalArcTo extends Coordinate
+```
+
+Innehåller element som specificerar information om en elliptisk båge. Koordinaterna anges som relativa koordinater.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RelEllipticalArcTo()](#RelEllipticalArcTo--) | Skapar en instans av klassen [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | x-koordinaten för bågens kontrollpunkt. |
+| [getB()](#getB--) | y-koordinaten för en bågs kontrollpunkt. |
+| [getC()](#getC--) | Vinkeln på en bågs huvudaxel i förhållande till förälderns x‑axel. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Förhållandet mellan en bågs huvudaxel och dess sekundära axel. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för den avslutande hörnet av en elliptisk båge. |
+| [getY()](#getY--) | y-koordinaten för den avslutande hörnet av en elliptisk båge. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--) |
+| [setD(DoubleValue value)](#setD-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelEllipticalArcTo() {#RelEllipticalArcTo--}
+```
+public RelEllipticalArcTo()
+```
+
+
+Skapar en instans av klassen [EllipticalArcTo](../../com.aspose.diagram/ellipticalarcto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+x-koordinaten för bågens kontrollpunkt. Kontrollpunkten bör placeras ungefär halvvägs mellan bågens start- och slutvertexer. Annars kan bågen växa till en extrem storlek för att passera genom kontrollpunkten, med oförutsägbara resultat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+y-koordinaten för en bågs kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Vinkeln på en bågs huvudaxel i förhållande till förälderns x‑axel.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public DoubleValue getD()
+```
+
+
+Förhållandet mellan en bågs huvudaxel och dess sekundära axel. Trots den vanliga betydelsen av dessa ord behöver huvudaxeln inte vara större än den sekundära axeln, så detta förhållande behöver inte vara större än 1. Att sätta detta element till ett värde mindre än eller lika med 0 eller större än 1000 kan leda till oförutsägbara resultat.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för den avslutande hörnet av en elliptisk båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för den avslutande hörnet av en elliptisk båge.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relellipticalarcto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relellipticalarcto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getC()](../../com.aspose.diagram/relellipticalarcto\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(DoubleValue value) {#setD-com.aspose.diagram.DoubleValue-}
+```
+public void setD(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getD()](../../com.aspose.diagram/relellipticalarcto\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relellipticalarcto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relellipticalarcto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relellipticalarcto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relellipticalarcto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relellipticalarctocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/relellipticalarctocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelEllipticalArcToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RelEllipticalArcTo‑samling.
+type: docs
+weight: 319
+url: /sv/java/com.aspose.diagram/relellipticalarctocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelEllipticalArcToCollection extends Collection
+```
+
+RelEllipticalArcTo‑samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelEllipticalArcTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RelEllipticalArcTo](../../com.aspose.diagram/relellipticalarcto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rellineto/_index.md
+++ b/swedish/java/com.aspose.diagram/rellineto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelLineTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för den avslutande hörnpunkten i ett rakt linjesegment.
+type: docs
+weight: 320
+url: /sv/java/com.aspose.diagram/rellineto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelLineTo extends Coordinate
+```
+
+Innehåller x- och y-koordinater för den avslutande vertexen i ett rakt linjesegment. Dessa koordinater finns i X- respektive Y-elementen. Koordinaterna anges som relativa koordinater.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RelLineTo()](#RelLineTo--) | Skapar en instans av [LineTo](../../com.aspose.diagram/lineto) klass. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment. |
+| [getY()](#getY--) | Y-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/rellineto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/rellineto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/rellineto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/rellineto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelLineTo() {#RelLineTo--}
+```
+public RelLineTo()
+```
+
+
+Skapar en instans av [LineTo](../../com.aspose.diagram/lineto) klass.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten för den avslutande hörnpunkten på ett rakt linjesegment.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/rellineto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/rellineto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/rellineto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/rellineto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rellinetocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/rellinetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelLineToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RelLineTo-samling.
+type: docs
+weight: 321
+url: /sv/java/com.aspose.diagram/rellinetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelLineToCollection extends Collection
+```
+
+RelLineTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelLineTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RelLineTo](../../com.aspose.diagram/rellineto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relmoveto/_index.md
+++ b/swedish/java/com.aspose.diagram/relmoveto/_index.md
@@ -1,0 +1,249 @@
+---
+title: RelMoveTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinaterna för den första vertexen i en form eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana. Koordinater anges som relativa koordinater.
+type: docs
+weight: 322
+url: /sv/java/com.aspose.diagram/relmoveto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelMoveTo extends Coordinate
+```
+
+Innehåller x- och y-koordinaterna för den första vertexen i en form, eller innehåller x- och y-koordinaterna för den första vertexen efter ett avbrott i en bana. Koordinaterna anges som relativa koordinater.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RelMoveTo()](#RelMoveTo--) | Skapar en instans av klassen [MoveTo](../../com.aspose.diagram/moveto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X‑elementet representerar x‑koordinaten för den första vertexen i en bana. |
+| [getY()](#getY--) | Y‑elementet representerar y‑koordinaten för den första vertexen i en bana. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relmoveto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relmoveto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relmoveto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relmoveto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelMoveTo() {#RelMoveTo--}
+```
+public RelMoveTo()
+```
+
+
+Skapar en instans av klassen [MoveTo](../../com.aspose.diagram/moveto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X‑elementet representerar x‑koordinaten för den första vertexen i en bana. Om MoveTo‑elementet visas mellan två element, representerar X‑elementet x‑koordinaten för den första vertexen efter avbrottet i banan
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y‑elementet representerar y‑koordinaten för den första vertexen i en bana. Om MoveTo‑elementet visas mellan två element, representerar Y‑elementet y‑koordinaten för den första vertexen efter avbrottet i banan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relmoveto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relmoveto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relmoveto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relmoveto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relmovetocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/relmovetocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelMoveToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RelMoveTo-samling.
+type: docs
+weight: 323
+url: /sv/java/com.aspose.diagram/relmovetocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelMoveToCollection extends Collection
+```
+
+RelMoveTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelMoveTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RelMoveTo](../../com.aspose.diagram/relmoveto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relquadbezto/_index.md
+++ b/swedish/java/com.aspose.diagram/relquadbezto/_index.md
@@ -1,0 +1,299 @@
+---
+title: RelQuadBezTo
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för en RelQuadBezTos-punkt.
+type: docs
+weight: 324
+url: /sv/java/com.aspose.diagram/relquadbezto/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class RelQuadBezTo extends Coordinate
+```
+
+Innehåller x- och y-koordinater för en RelQuadBezTo:s punkter.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RelQuadBezTo()](#RelQuadBezTo--) | Skapar en instans av klassen [RelCubBezTo](../../com.aspose.diagram/relcubbezto). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | X-koordinaten för kontrollpunkten i relativa koordinater. |
+| [getB()](#getB--) | Y-koordinaten för kontrollpunkten i relativa koordinater. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X-koordinaten för slutpunkten i relativa koordinater. |
+| [getY()](#getY--) | Y-koordinaten för slutpunkten i relativa koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relquadbezto\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relquadbezto\#getB--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relquadbezto\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relquadbezto\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RelQuadBezTo() {#RelQuadBezTo--}
+```
+public RelQuadBezTo()
+```
+
+
+Skapar en instans av klassen [RelCubBezTo](../../com.aspose.diagram/relcubbezto).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+X-koordinaten för kontrollpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Y-koordinaten för kontrollpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten för slutpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten för slutpunkten i relativa koordinater.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/relquadbezto\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getB()](../../com.aspose.diagram/relquadbezto\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/relquadbezto\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/relquadbezto\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/relquadbezto\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/relquadbezto\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/relquadbeztocollection/_index.md
+++ b/swedish/java/com.aspose.diagram/relquadbeztocollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: RelQuadBezToCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RelQuadBezTo-samling.
+type: docs
+weight: 325
+url: /sv/java/com.aspose.diagram/relquadbeztocollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RelQuadBezToCollection extends Collection
+```
+
+RelQuadBezTo-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RelQuadBezTo get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RelQuadBezTo](../../com.aspose.diagram/relquadbezto) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/removehiddeninfoitem/_index.md
+++ b/swedish/java/com.aspose.diagram/removehiddeninfoitem/_index.md
@@ -1,0 +1,183 @@
+---
+title: RemoveHiddenInfoItem
+second_title: Aspose.Diagram för Java API-referens
+description: Anger borttagning av dold information för diagrammet.
+type: docs
+weight: 326
+url: /sv/java/com.aspose.diagram/removehiddeninfoitem/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RemoveHiddenInfoItem
+```
+
+Anger borttagning av dold information för diagrammet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DATA_RECORD_SETS](#DATA-RECORD-SETS) | DataRecordSets. |
+| [MASTERS](#MASTERS) | Masters. |
+| [PERSONAL_INFO](#PERSONAL-INFO) | PersonalInfo. |
+| [SHAPES](#SHAPES) | Shapes. |
+| [STYLES](#STYLES) | Styles. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DATA_RECORD_SETS {#DATA-RECORD-SETS}
+```
+public static final int DATA_RECORD_SETS
+```
+
+
+DataRecordSets.
+
+### MASTERS {#MASTERS}
+```
+public static final int MASTERS
+```
+
+
+Masters.
+
+### PERSONAL_INFO {#PERSONAL-INFO}
+```
+public static final int PERSONAL_INFO
+```
+
+
+PersonalInfo.
+
+### SHAPES {#SHAPES}
+```
+public static final int SHAPES
+```
+
+
+Shapes.
+
+### STYLES {#STYLES}
+```
+public static final int STYLES
+```
+
+
+Styles.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/renderingsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/renderingsaveoptions/_index.md
@@ -1,0 +1,366 @@
+---
+title: RenderingSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Detta är en abstrakt basklass för klasser som låter användaren ange ytterligare alternativ när ett diagram sparas i ett specifikt format.
+type: docs
+weight: 327
+url: /sv/java/com.aspose.diagram/renderingsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public abstract class RenderingSaveOptions extends SaveOptions
+```
+
+Detta är en abstrakt basklass för klasser som låter användaren ange ytterligare alternativ när ett diagram sparas i ett specifikt format.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getSaveFormat()](#getSaveFormat--) | Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/resizemode/_index.md
+++ b/swedish/java/com.aspose.diagram/resizemode/_index.md
@@ -1,0 +1,204 @@
+---
+title: ResizeMode
+second_title: Aspose.Diagram för Java API-referens
+description: Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+type: docs
+weight: 328
+url: /sv/java/com.aspose.diagram/resizemode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ResizeMode
+```
+
+Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ResizeMode(int value)](#ResizeMode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/resizemode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResizeMode(int value) {#ResizeMode-int-}
+```
+public ResizeMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/resizemode\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/resizemode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/resizemodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/resizemodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ResizeModeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+type: docs
+weight: 329
+url: /sv/java/com.aspose.diagram/resizemodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ResizeModeValue
+```
+
+Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [REPOSITION_ONLY](#REPOSITION-ONLY) | Endast omplacering. |
+| [SCALE_WITH_GROUP](#SCALE-WITH-GROUP) | Skala med grupp. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [USE_GROUP_SETTING](#USE-GROUP-SETTING) | Använd gruppens inställning |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### REPOSITION_ONLY {#REPOSITION-ONLY}
+```
+public static final int REPOSITION_ONLY
+```
+
+
+Endast omplacering.
+
+### SCALE_WITH_GROUP {#SCALE-WITH-GROUP}
+```
+public static final int SCALE_WITH_GROUP
+```
+
+
+Skala med grupp.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### USE_GROUP_SETTING {#USE-GROUP-SETTING}
+```
+public static final int USE_GROUP_SETTING
+```
+
+
+Använd gruppens inställning
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/reviewer/_index.md
+++ b/swedish/java/com.aspose.diagram/reviewer/_index.md
@@ -1,0 +1,243 @@
+---
+title: Granskare
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som innehåller identifierande information om en dokumentgranskare.
+type: docs
+weight: 330
+url: /sv/java/com.aspose.diagram/reviewer/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Reviewer
+```
+
+Innehåller element som innehåller identifierande information om en dokumentgranskare.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Reviewer()](#Reviewer--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | Färgelementet anger ett RGB‑värde som representerar färgen som tilldelas en dokumentgranskares markering. |
+| [getCurrentIndex()](#getCurrentIndex--) | Anger värdet för MarkerIndex‑elementet som kommer att läggas till när den aktuella granskaren lägger till en annan kommentar i dokumentet. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getInitials()](#getInitials--) | Innehåller initialerna för en dokumentgranskare. |
+| [getName()](#getName--) | Name‑elementet anger namnet på en dokumentgranskare. |
+| [getReviewerID()](#getReviewerID--) | Innehåller ID‑numret för granskaren som lägger till markup i dokumentet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/reviewer\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/reviewer\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reviewer() {#Reviewer--}
+```
+public Reviewer()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public ColorValue getColor()
+```
+
+
+Färgelementet anger ett RGB‑värde som representerar färgen som tilldelas en dokumentgranskares markering.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getCurrentIndex() {#getCurrentIndex--}
+```
+public IntValue getCurrentIndex()
+```
+
+
+Anger värdet för MarkerIndex‑elementet som kommer att läggas till när den aktuella granskaren lägger till en annan kommentar i dokumentet.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getInitials() {#getInitials--}
+```
+public Str2Value getInitials()
+```
+
+
+Innehåller initialerna för en dokumentgranskare.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getName() {#getName--}
+```
+public Str2Value getName()
+```
+
+
+Name‑elementet anger namnet på en dokumentgranskare.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getReviewerID() {#getReviewerID--}
+```
+public IntValue getReviewerID()
+```
+
+
+Innehåller ID‑numret för granskaren som lägger till markup i dokumentet.
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/reviewer\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/reviewer\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/reviewercollection/_index.md
+++ b/swedish/java/com.aspose.diagram/reviewercollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ReviewerCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Granskare-samling.
+type: docs
+weight: 331
+url: /sv/java/com.aspose.diagram/reviewercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ReviewerCollection extends Collection
+```
+
+Granskare-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Reviewer item)](#add-com.aspose.diagram.Reviewer-) | Lägg till Reviewer-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Reviewer item)](#remove-com.aspose.diagram.Reviewer-) | Ta bort Reviewer-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Reviewer item) {#add-com.aspose.diagram.Reviewer-}
+```
+public int add(Reviewer item)
+```
+
+
+Lägg till Reviewer-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Reviewer get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Reviewer](../../com.aspose.diagram/reviewer) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Reviewer item) {#remove-com.aspose.diagram.Reviewer-}
+```
+public void remove(Reviewer item)
+```
+
+
+Ta bort Reviewer-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Reviewer](../../com.aspose.diagram/reviewer) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rotationtype/_index.md
+++ b/swedish/java/com.aspose.diagram/rotationtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: RotationType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 332
+url: /sv/java/com.aspose.diagram/rotationtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RotationType
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RotationType(int value)](#RotationType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av fasning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rotationtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RotationType(int value) {#RotationType-int-}
+```
+public RotationType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av fasning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rotationtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rotationtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/rotationtypevalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: RotationTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av projektion av effekt‑egenskaperna för en form
+type: docs
+weight: 333
+url: /sv/java/com.aspose.diagram/rotationtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RotationTypeValue
+```
+
+Anger typen av projektion av effekt‑egenskaperna för en form
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [NONE](#NONE) | Anger ingen 3D‑effektsrotation. |
+| [OBLIQUE_FROM_BOTTOM_LEFT](#OBLIQUE-FROM-BOTTOM-LEFT) | Anger att formen roterar i sned projektion från det nedre vänstra hörnet av formens omgivningsruta. |
+| [OBLIQUE_FROM_BOTTOM_RIGHT](#OBLIQUE-FROM-BOTTOM-RIGHT) | Anger att formen roterar i sned projektion från det nedre högra hörnet av formens omgivningsruta. |
+| [OBLIQUE_FROM_TOP_LEFT](#OBLIQUE-FROM-TOP-LEFT) | Anger att formen roterar i sned projektion från det övre vänstra hörnet av formens omgivningsruta. |
+| [OBLIQUE_FROM_TOP_RIGHT](#OBLIQUE-FROM-TOP-RIGHT) | Anger att formen roterar i sned projektion från det övre högra hörnet av formens omgivningsruta. |
+| [PARALLEL](#PARALLEL) | Anger att en parallell projektion tillämpas på 3D‑effektegenskaperna. |
+| [PERSPECTIVE](#PERSPECTIVE) | Anger att formen roterar i perspektivprojektion. |
+| [UNDEFINED](#UNDEFINED) | Ingen ljusrigg. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Anger ingen 3D‑effektsrotation.
+
+### OBLIQUE_FROM_BOTTOM_LEFT {#OBLIQUE-FROM-BOTTOM-LEFT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_LEFT
+```
+
+
+Anger att formen roterar i sned projektion från det nedre vänstra hörnet av formens omgivningsruta.
+
+### OBLIQUE_FROM_BOTTOM_RIGHT {#OBLIQUE-FROM-BOTTOM-RIGHT}
+```
+public static final int OBLIQUE_FROM_BOTTOM_RIGHT
+```
+
+
+Anger att formen roterar i sned projektion från det nedre högra hörnet av formens omgivningsruta.
+
+### OBLIQUE_FROM_TOP_LEFT {#OBLIQUE-FROM-TOP-LEFT}
+```
+public static final int OBLIQUE_FROM_TOP_LEFT
+```
+
+
+Anger att formen roterar i sned projektion från det övre vänstra hörnet av formens omgivningsruta.
+
+### OBLIQUE_FROM_TOP_RIGHT {#OBLIQUE-FROM-TOP-RIGHT}
+```
+public static final int OBLIQUE_FROM_TOP_RIGHT
+```
+
+
+Anger att formen roterar i sned projektion från det övre högra hörnet av formens omgivningsruta.
+
+### PARALLEL {#PARALLEL}
+```
+public static final int PARALLEL
+```
+
+
+Anger att en parallell projektion tillämpas på 3D‑effektegenskaperna.
+
+### PERSPECTIVE {#PERSPECTIVE}
+```
+public static final int PERSPECTIVE
+```
+
+
+Anger att formen roterar i perspektivprojektion.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Ingen ljusrigg.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/routestyle/_index.md
+++ b/swedish/java/com.aspose.diagram/routestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: RouteStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+type: docs
+weight: 334
+url: /sv/java/com.aspose.diagram/routestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RouteStyle
+```
+
+Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RouteStyle(int value)](#RouteStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/routestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RouteStyle(int value) {#RouteStyle-int-}
+```
+public RouteStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/routestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/routestylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/routestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: RouteStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+type: docs
+weight: 335
+url: /sv/java/com.aspose.diagram/routestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RouteStyleValue
+```
+
+Anger routningsstil och riktning för alla dynamiska anslutningar på ritningssidan som inte har en lokal routningsstil.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centrum till centrum. |
+| [DEFAULT_RIGHT_ANGLE](#DEFAULT-RIGHT-ANGLE) | Standard. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Flödesschema nedifrån och upp. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Flödesschema från vänster till höger. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Flödesschema från höger till vänster. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Flödesschema från topp till botten. |
+| [NETWORK](#NETWORK) | Nätverk. |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organisationsschema nedifrån och upp. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organisationsschema från vänster till höger. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organisationsschema från höger till vänster. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organisationsschema uppifrån och ner. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Rät vinkel. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Enkel botten till topp. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Enkel horisontell vertikal. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Enkel från vänster till höger. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Enkel från höger till vänster. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Enkel från topp till botten. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Enkel vertikal horisontell. |
+| [STRAIGHT](#STRAIGHT) | Rak. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Träd botten till topp. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Träd från vänster till höger. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Träd från höger till vänster. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Träd från topp till botten. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centrum till centrum.
+
+### DEFAULT_RIGHT_ANGLE {#DEFAULT-RIGHT-ANGLE}
+```
+public static final int DEFAULT_RIGHT_ANGLE
+```
+
+
+Standard. Rätt vinkel.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Flödesschema nedifrån och upp.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Flödesschema från vänster till höger.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Flödesschema från höger till vänster.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Flödesschema från topp till botten.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Nätverk.
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organisationsschema nedifrån och upp.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organisationsschema från vänster till höger.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organisationsschema från höger till vänster.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organisationsschema uppifrån och ner.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Rät vinkel.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Enkel botten till topp.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Enkel horisontell vertikal.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Enkel från vänster till höger.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Enkel från höger till vänster.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Enkel från topp till botten.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Enkel vertikal horisontell.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Rak.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Träd botten till topp.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Träd från vänster till höger.
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Träd från höger till vänster.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Träd från topp till botten.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/row/_index.md
+++ b/swedish/java/com.aspose.diagram/row/_index.md
@@ -1,0 +1,213 @@
+---
+title: Row
+second_title: Aspose.Diagram för Java API-referens
+description: Indikerar en rad i dataresultatuppsättningen.
+type: docs
+weight: 336
+url: /sv/java/com.aspose.diagram/row/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Row
+```
+
+Indikerar en rad i dataresultatuppsättningen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Row()](#Row--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPageID()](#getPageID--) | Sid-ID för formen. |
+| [getRowID()](#getRowID--) | Det ursprungliga rad-ID:t. |
+| [getShapeID()](#getShapeID--) | Form-ID för formen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setPageID(long value)](#setPageID-long-) | För beskrivningen av den här egenskapen, se [getPageID()](../../com.aspose.diagram/row\#getPageID--) |
+| [setRowID(long value)](#setRowID-long-) | För beskrivningen av den här egenskapen, se [getRowID()](../../com.aspose.diagram/row\#getRowID--) |
+| [setShapeID(long value)](#setShapeID-long-) | För beskrivningen av den här egenskapen, se [getShapeID()](../../com.aspose.diagram/row\#getShapeID--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Row() {#Row--}
+```
+public Row()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPageID() {#getPageID--}
+```
+public long getPageID()
+```
+
+
+Sid-ID för formen.
+
+**Returns:**
+long
+### getRowID() {#getRowID--}
+```
+public long getRowID()
+```
+
+
+Det ursprungliga rad-ID:t.
+
+**Returns:**
+long
+### getShapeID() {#getShapeID--}
+```
+public long getShapeID()
+```
+
+
+Form-ID för formen.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setPageID(long value) {#setPageID-long-}
+```
+public void setPageID(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageID()](../../com.aspose.diagram/row\#getPageID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setRowID(long value) {#setRowID-long-}
+```
+public void setRowID(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRowID()](../../com.aspose.diagram/row\#getRowID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setShapeID(long value) {#setShapeID-long-}
+```
+public void setShapeID(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapeID()](../../com.aspose.diagram/row\#getShapeID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rowcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/rowcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RowCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Rad-samling.
+type: docs
+weight: 337
+url: /sv/java/com.aspose.diagram/rowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RowCollection extends Collection
+```
+
+Rad-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Row row)](#add-com.aspose.diagram.Row-) | Lägg till raden i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Row row)](#remove-com.aspose.diagram.Row-) | Ta bort raden från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Row row) {#add-com.aspose.diagram.Row-}
+```
+public int add(Row row)
+```
+
+
+Lägg till raden i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Row get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Row](../../com.aspose.diagram/row) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Row row) {#remove-com.aspose.diagram.Row-}
+```
+public void remove(Row row)
+```
+
+
+Ta bort raden från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| row | [Row](../../com.aspose.diagram/row) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rule/_index.md
+++ b/swedish/java/com.aspose.diagram/rule/_index.md
@@ -1,0 +1,338 @@
+---
+title: Rule
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en enskild valideringsregel i en diagramvalideringsregeluppsättning.
+type: docs
+weight: 338
+url: /sv/java/com.aspose.diagram/rule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Rule
+```
+
+Representerar en enskild valideringsregel i en diagramvalideringsregeluppsättning.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Rule()](#Rule--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCategory()](#getCategory--) | Anger texten som visas i kolumnen Kategori i fönstret Problem. |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | beskrivningen av valideringsregeln som visas i användargränssnittet. |
+| [getID()](#getID--) | Anger det unika identifieraren för valideringsregeln. |
+| [getIgnored()](#getIgnored--) | Anger om valideringsregeln för närvarande ignoreras. |
+| [getNameU()](#getNameU--) | Anger det universella namnet på valideringsregeln. |
+| [getRuleFilter()](#getRuleFilter--) | Anger det logiska uttrycket som avgör om valideringsregeln ska tillämpas på ett målobjekt. |
+| [getRuleTarget()](#getRuleTarget--) | Anger typen av objekt som valideringsregeln gäller för. |
+| [getRuleTest()](#getRuleTest--) | Anger det logiska uttrycket som avgör om målobjektet uppfyller valideringsregeln |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCategory(String value)](#setCategory-java.lang.String-) | För beskrivningen av denna egenskap, se [getCategory()](../../com.aspose.diagram/rule\#getCategory--) |
+| [setDescription(String value)](#setDescription-java.lang.String-) | För beskrivningen av denna egenskap, se [getDescription()](../../com.aspose.diagram/rule\#getDescription--) |
+| [setID(long value)](#setID-long-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/rule\#getID--) |
+| [setIgnored(int value)](#setIgnored-int-) | För beskrivningen av denna egenskap, se [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/rule\#getNameU--) |
+| [setRuleFilter(RuleValue value)](#setRuleFilter-com.aspose.diagram.RuleValue-) | För beskrivningen av denna egenskap, se [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--) |
+| [setRuleTarget(int value)](#setRuleTarget-int-) | För beskrivningen av denna egenskap, se [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--) |
+| [setRuleTest(RuleValue value)](#setRuleTest-com.aspose.diagram.RuleValue-) | För beskrivningen av denna egenskap, se [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Rule() {#Rule--}
+```
+public Rule()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCategory() {#getCategory--}
+```
+public String getCategory()
+```
+
+
+Anger texten som visas i kolumnen Kategori i fönstret Problem. Standard är en tom sträng.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+beskrivningen av valideringsregeln som visas i användargränssnittet. Standard är "Unknown".
+
+**Returns:**
+java.lang.String
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Anger det unika identifieraren för valideringsregeln.
+
+**Returns:**
+long
+### getIgnored() {#getIgnored--}
+```
+public int getIgnored()
+```
+
+
+Anger om valideringsregeln för närvarande ignoreras. Standard är False.
+
+**Returns:**
+int
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Anger det universella namnet på valideringsregeln.
+
+**Returns:**
+java.lang.String
+### getRuleFilter() {#getRuleFilter--}
+```
+public RuleValue getRuleFilter()
+```
+
+
+Anger det logiska uttrycket som avgör om valideringsregeln ska tillämpas på ett målobjekt.
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### getRuleTarget() {#getRuleTarget--}
+```
+public int getRuleTarget()
+```
+
+
+Anger typen av objekt som valideringsregeln gäller för.
+
+**Returns:**
+int
+### getRuleTest() {#getRuleTest--}
+```
+public RuleValue getRuleTest()
+```
+
+
+Anger det logiska uttrycket som avgör om målobjektet uppfyller valideringsregeln
+
+**Returns:**
+[RuleValue](../../com.aspose.diagram/rulevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCategory(String value) {#setCategory-java.lang.String-}
+```
+public void setCategory(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCategory()](../../com.aspose.diagram/rule\#getCategory--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDescription()](../../com.aspose.diagram/rule\#getDescription--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/rule\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setIgnored(int value) {#setIgnored-int-}
+```
+public void setIgnored(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIgnored()](../../com.aspose.diagram/rule\#getIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/rule\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setRuleFilter(RuleValue value) {#setRuleFilter-com.aspose.diagram.RuleValue-}
+```
+public void setRuleFilter(RuleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRuleFilter()](../../com.aspose.diagram/rule\#getRuleFilter--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### setRuleTarget(int value) {#setRuleTarget-int-}
+```
+public void setRuleTarget(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRuleTarget()](../../com.aspose.diagram/rule\#getRuleTarget--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setRuleTest(RuleValue value) {#setRuleTest-com.aspose.diagram.RuleValue-}
+```
+public void setRuleTest(RuleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRuleTest()](../../com.aspose.diagram/rule\#getRuleTest--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [RuleValue](../../com.aspose.diagram/rulevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/rulecollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Regel-samling.
+type: docs
+weight: 339
+url: /sv/java/com.aspose.diagram/rulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleCollection extends Collection
+```
+
+Regel-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Rule rule)](#add-com.aspose.diagram.Rule-) | Lägg till regeln i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Rule rule)](#remove-com.aspose.diagram.Rule-) | Ta bort regeln från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Rule rule) {#add-com.aspose.diagram.Rule-}
+```
+public int add(Rule rule)
+```
+
+
+Lägg till regeln i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Rule get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Rule](../../com.aspose.diagram/rule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Rule rule) {#remove-com.aspose.diagram.Rule-}
+```
+public void remove(Rule rule)
+```
+
+
+Ta bort regeln från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| rule | [Rule](../../com.aspose.diagram/rule) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ruleinfo/_index.md
+++ b/swedish/java/com.aspose.diagram/ruleinfo/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleInfo
+second_title: Aspose.Diagram för Java API-referens
+description: Anger information om valideringsregeln som det överordnade valideringsproblemet avser.
+type: docs
+weight: 340
+url: /sv/java/com.aspose.diagram/ruleinfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleInfo
+```
+
+Anger information om valideringsregeln som det överordnade valideringsproblemet avser.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RuleInfo(long ruleSetID, long ruleID)](#RuleInfo-long-long-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getRuleId()](#getRuleId--) | Anger den unika identifieraren för valideringsregeln som det överordnade problemet avser. |
+| [getRuleSetId()](#getRuleSetId--) | Anger den unika identifieraren för valideringsregeluppsättningen som det överordnade problemet avser. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setRuleId(long value)](#setRuleId-long-) | För beskrivningen av denna egenskap, se [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--) |
+| [setRuleSetId(long value)](#setRuleSetId-long-) | För beskrivningen av denna egenskap, se [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleInfo(long ruleSetID, long ruleID) {#RuleInfo-long-long-}
+```
+public RuleInfo(long ruleSetID, long ruleID)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ruleSetID | long |  |
+| ruleID | long |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getRuleId() {#getRuleId--}
+```
+public long getRuleId()
+```
+
+
+Anger den unika identifieraren för valideringsregeln som det överordnade problemet avser.
+
+**Returns:**
+long
+### getRuleSetId() {#getRuleSetId--}
+```
+public long getRuleSetId()
+```
+
+
+Anger den unika identifieraren för valideringsregeluppsättningen som det överordnade problemet avser.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setRuleId(long value) {#setRuleId-long-}
+```
+public void setRuleId(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRuleId()](../../com.aspose.diagram/ruleinfo\#getRuleId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setRuleSetId(long value) {#setRuleSetId-long-}
+```
+public void setRuleSetId(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRuleSetId()](../../com.aspose.diagram/ruleinfo\#getRuleSetId--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulerdensity/_index.md
+++ b/swedish/java/com.aspose.diagram/rulerdensity/_index.md
@@ -1,0 +1,179 @@
+---
+title: RulerDensity
+second_title: Aspose.Diagram för Java API-referens
+description: Anger de horisontella indelningarna på linjalen för sidan.
+type: docs
+weight: 344
+url: /sv/java/com.aspose.diagram/rulerdensity/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerDensity
+```
+
+Anger de horisontella indelningarna på linjalen för sidan.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RulerDensity(int value)](#RulerDensity-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger de horisontella indelningarna på linjalen för sidan. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RulerDensity(int value) {#RulerDensity-int-}
+```
+public RulerDensity(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger de horisontella indelningarna på linjalen för sidan.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rulerdensity\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulerdensityvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/rulerdensityvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: RulerDensityValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger de horisontella indelningarna på linjalen för sidan.
+type: docs
+weight: 345
+url: /sv/java/com.aspose.diagram/rulerdensityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class RulerDensityValue
+```
+
+Anger de horisontella indelningarna på linjalen för sidan.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [COARSE](#COARSE) | Grov. |
+| [FINE](#FINE) | Fint. |
+| [NORMAL](#NORMAL) | Normal. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### COARSE {#COARSE}
+```
+public static final int COARSE
+```
+
+
+Grov.
+
+### FINE {#FINE}
+```
+public static final int FINE
+```
+
+
+Fint.
+
+### NORMAL {#NORMAL}
+```
+public static final int NORMAL
+```
+
+
+Normal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulergrid/_index.md
+++ b/swedish/java/com.aspose.diagram/rulergrid/_index.md
@@ -1,0 +1,260 @@
+---
+title: RulerGrid
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar inställningarna för sidornas linjaler och rutnät.
+type: docs
+weight: 346
+url: /sv/java/com.aspose.diagram/rulergrid/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RulerGrid
+```
+
+Innehåller element som specificerar inställningarna för sidans linjaler och rutnät.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getXGridDensity()](#getXGridDensity--) | Anger nollpunkten på y‑axelns (vertikala) linjal för sidan. |
+| [getXGridOrigin()](#getXGridOrigin--) | Anger den horisontella koordinaten för rutnätets ursprung för en sida. |
+| [getXGridSpacing()](#getXGridSpacing--) | Anger avståndet mellan horisontella linjer i ett fast rutnät (det vill säga ett RulerGrid‑element där XGridDensity‑elementet är satt till 0). |
+| [getXRulerDensity()](#getXRulerDensity--) | Anger de horisontella indelningarna på linjalen för sidan. |
+| [getXRulerOrigin()](#getXRulerOrigin--) | Anger nollpunkten på x‑axelns (horisontella) linjal för sidan. |
+| [getYGridDensity()](#getYGridDensity--) | Anger typen av vertikalt rutnät som ska användas för en sida. |
+| [getYGridOrigin()](#getYGridOrigin--) | Anger det vertikala ursprunget för rutnätet på sidan. |
+| [getYGridSpacing()](#getYGridSpacing--) | Anger avståndet mellan vertikala linjer i ett fast rutnät (det vill säga ett RulerGrid‑element där YGridDensity‑elementet är satt till 0). |
+| [getYRulerDensity()](#getYRulerDensity--) | Anger de vertikala indelningarna på linjalen för sidan. |
+| [getYRulerOrigin()](#getYRulerOrigin--) | Anger nollpunkten på y‑axelns (vertikala) linjal för sidan. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/rulergrid\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getXGridDensity() {#getXGridDensity--}
+```
+public GridDensity getXGridDensity()
+```
+
+
+Anger nollpunkten på y‑axelns (vertikala) linjal för sidan.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getXGridOrigin() {#getXGridOrigin--}
+```
+public DoubleValue getXGridOrigin()
+```
+
+
+Anger den horisontella koordinaten för rutnätets ursprung för en sida.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXGridSpacing() {#getXGridSpacing--}
+```
+public DoubleValue getXGridSpacing()
+```
+
+
+Anger avståndet mellan horisontella linjer i ett fast rutnät (det vill säga ett RulerGrid‑element där XGridDensity‑elementet är satt till 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXRulerDensity() {#getXRulerDensity--}
+```
+public RulerDensity getXRulerDensity()
+```
+
+
+Anger de horisontella indelningarna på linjalen för sidan.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getXRulerOrigin() {#getXRulerOrigin--}
+```
+public DoubleValue getXRulerOrigin()
+```
+
+
+Anger nollpunkten på x‑axelns (horisontella) linjal för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridDensity() {#getYGridDensity--}
+```
+public GridDensity getYGridDensity()
+```
+
+
+Anger typen av vertikalt rutnät som ska användas för en sida.
+
+**Returns:**
+[GridDensity](../../com.aspose.diagram/griddensity)
+### getYGridOrigin() {#getYGridOrigin--}
+```
+public DoubleValue getYGridOrigin()
+```
+
+
+Anger det vertikala ursprunget för rutnätet på sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYGridSpacing() {#getYGridSpacing--}
+```
+public DoubleValue getYGridSpacing()
+```
+
+
+Anger avståndet mellan vertikala linjer i ett fast rutnät (det vill säga ett RulerGrid‑element där YGridDensity‑elementet är satt till 0).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYRulerDensity() {#getYRulerDensity--}
+```
+public RulerDensity getYRulerDensity()
+```
+
+
+Anger de vertikala indelningarna på linjalen för sidan.
+
+**Returns:**
+[RulerDensity](../../com.aspose.diagram/rulerdensity)
+### getYRulerOrigin() {#getYRulerOrigin--}
+```
+public DoubleValue getYRulerOrigin()
+```
+
+
+Anger nollpunkten på y‑axelns (vertikala) linjal för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/rulergrid\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/ruleset/_index.md
+++ b/swedish/java/com.aspose.diagram/ruleset/_index.md
@@ -1,0 +1,299 @@
+---
+title: RuleSet
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en uppsättning diagramvalideringsregler.
+type: docs
+weight: 341
+url: /sv/java/com.aspose.diagram/ruleset/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleSet
+```
+
+Representerar en uppsättning diagramvalideringsregler.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RuleSet()](#RuleSet--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Anger beskrivningen av valideringsregeluppsättningen som visas i användargränssnittet. |
+| [getEnabled()](#getEnabled--) | Anger om reglerna i den angivna valideringsregeluppsättningen kontrolleras när validering utlöses för det aktuella dokumentet. |
+| [getID()](#getID--) | Anger den unika identifieraren för valideringsregeluppsättningen. |
+| [getName()](#getName--) | Anger det lokala namnet på valideringsregeluppsättningen. |
+| [getNameU()](#getNameU--) | Anger det universella namnet på valideringsregeluppsättningen. |
+| [getRuleSetFlags()](#getRuleSetFlags--) | Anger om regeluppsättningen visas i listan Regler att kontrollera. |
+| [getRules()](#getRules--) | Regel-samling. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDescription(String value)](#setDescription-java.lang.String-) | För beskrivningen av denna egenskap, se [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--) |
+| [setEnabled(int value)](#setEnabled-int-) | För beskrivningen av denna egenskap, se [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--) |
+| [setID(long value)](#setID-long-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/ruleset\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/ruleset\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--) |
+| [setRuleSetFlags(int value)](#setRuleSetFlags-int-) | För beskrivningen av den här egenskapen, se [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleSet() {#RuleSet--}
+```
+public RuleSet()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Anger beskrivningen av valideringsregeluppsättningen som visas i användargränssnittet. Standard är en tom sträng.
+
+**Returns:**
+java.lang.String
+### getEnabled() {#getEnabled--}
+```
+public int getEnabled()
+```
+
+
+Anger om reglerna i den angivna valideringsregeluppsättningen kontrolleras när validering utlöses för det aktuella dokumentet. Standard är Sant.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Anger den unika identifieraren för valideringsregeluppsättningen.
+
+**Returns:**
+long
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Anger det lokala namnet på valideringsregeluppsättningen. Standard är värdet för NameU-attributet.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Anger det universella namnet på valideringsregeluppsättningen.
+
+**Returns:**
+java.lang.String
+### getRuleSetFlags() {#getRuleSetFlags--}
+```
+public int getRuleSetFlags()
+```
+
+
+Anger om regeluppsättningen visas i listan Regler att kontrollera.
+
+**Returns:**
+int
+### getRules() {#getRules--}
+```
+public RuleCollection getRules()
+```
+
+
+Regel-samling.
+
+**Returns:**
+[RuleCollection](../../com.aspose.diagram/rulecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDescription(String value) {#setDescription-java.lang.String-}
+```
+public void setDescription(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDescription()](../../com.aspose.diagram/ruleset\#getDescription--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEnabled(int value) {#setEnabled-int-}
+```
+public void setEnabled(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEnabled()](../../com.aspose.diagram/ruleset\#getEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/ruleset\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/ruleset\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getNameU()](../../com.aspose.diagram/ruleset\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setRuleSetFlags(int value) {#setRuleSetFlags-int-}
+```
+public void setRuleSetFlags(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRuleSetFlags()](../../com.aspose.diagram/ruleset\#getRuleSetFlags--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulesetcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/rulesetcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: RuleSetCollection
+second_title: Aspose.Diagram för Java API-referens
+description: RuleSet-samling.
+type: docs
+weight: 342
+url: /sv/java/com.aspose.diagram/rulesetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class RuleSetCollection extends Collection
+```
+
+RuleSet-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(RuleSet ruleSet)](#add-com.aspose.diagram.RuleSet-) | Lägg till ruleSet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(RuleSet ruleSet)](#remove-com.aspose.diagram.RuleSet-) | Ta bort ruleSet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(RuleSet ruleSet) {#add-com.aspose.diagram.RuleSet-}
+```
+public int add(RuleSet ruleSet)
+```
+
+
+Lägg till ruleSet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public RuleSet get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[RuleSet](../../com.aspose.diagram/ruleset) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(RuleSet ruleSet) {#remove-com.aspose.diagram.RuleSet-}
+```
+public void remove(RuleSet ruleSet)
+```
+
+
+Ta bort ruleSet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ruleSet | [RuleSet](../../com.aspose.diagram/ruleset) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/rulevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/rulevalue/_index.md
@@ -1,0 +1,194 @@
+---
+title: RuleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Regelvärde.
+type: docs
+weight: 343
+url: /sv/java/com.aspose.diagram/rulevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class RuleValue
+```
+
+Regelvärde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [RuleValue(String formula, String value)](#RuleValue-java.lang.String-java.lang.String-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getFormula()](#getFormula--) | Representerar elementets formel. |
+| [getValue()](#getValue--) | Regelvärde. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFormula(String value)](#setFormula-java.lang.String-) | För beskrivningen av denna egenskap, se [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rulevalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RuleValue(String formula, String value) {#RuleValue-java.lang.String-java.lang.String-}
+```
+public RuleValue(String formula, String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| formel | java.lang.String |  |
+| värde | java.lang.String |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFormula() {#getFormula--}
+```
+public String getFormula()
+```
+
+
+Representerar elementets formel. Detta attribut kan innehålla en av följande strängar: \"someFormula\" om formeln finns lokalt, \"No Formula\" om formeln är lokalt raderad eller blockeras, eller \"Inh\" om formeln är ärvd. Om attributet inte finns, är elementets formel en enkel konstant.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Regelvärde.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFormula(String value) {#setFormula-java.lang.String-}
+```
+public void setFormula(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFormula()](../../com.aspose.diagram/rulevalue\#getFormula--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/rulevalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/savefileformat/_index.md
+++ b/swedish/java/com.aspose.diagram/savefileformat/_index.md
@@ -1,0 +1,309 @@
+---
+title: SaveFileFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Enumeration för att spara diagramformatval.
+type: docs
+weight: 348
+url: /sv/java/com.aspose.diagram/savefileformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SaveFileFormat
+```
+
+Enumeration för att spara diagramformatval.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BMP](#BMP) | Bmp bildformat. |
+| [EMF](#EMF) | EMF bildformat. |
+| [GIF](#GIF) | Gif-format. |
+| [HTML](#HTML) | Html-format. |
+| [JPEG](#JPEG) | Jpeg bildformat. |
+| [PDF](#PDF) | Pdf-format. |
+| [PNG](#PNG) | Png bildformat. |
+| [SVG](#SVG) | Svg-format. |
+| [TIFF](#TIFF) | Tiff-bildformat. |
+| [VDX](#VDX) | MS Visio Vdx xml-format. |
+| [VSDM](#VSDM) | MS Visio Vsdm-filformat som möjliggör makron. |
+| [VSDX](#VSDX) | MS Visio 2013 Vsdx-filformat. |
+| [VSSM](#VSSM) | MS Visio Vssm-filformat som möjliggör makron. |
+| [VSSX](#VSSX) | MS Visio 2013 Vssx-filformat |
+| [VSTM](#VSTM) | MS Visio Vstm-filformat som möjliggör makron. |
+| [VSTX](#VSTX) | MS Visio 2013 Vstx-filformat, mallfil. |
+| [VSX](#VSX) | MS Visio Vsx xml-stencilformat. |
+| [VTX](#VTX) | MS Visio Vst xml-mallformat. |
+| [XAML](#XAML) | Xaml-format. |
+| [XPS](#XPS) | Xps-format. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final int BMP
+```
+
+
+Bmp bildformat.
+
+### EMF {#EMF}
+```
+public static final int EMF
+```
+
+
+EMF bildformat.
+
+### GIF {#GIF}
+```
+public static final int GIF
+```
+
+
+Gif-format.
+
+### HTML {#HTML}
+```
+public static final int HTML
+```
+
+
+Html-format.
+
+### JPEG {#JPEG}
+```
+public static final int JPEG
+```
+
+
+Jpeg bildformat.
+
+### PDF {#PDF}
+```
+public static final int PDF
+```
+
+
+Pdf-format.
+
+### PNG {#PNG}
+```
+public static final int PNG
+```
+
+
+Png bildformat.
+
+### SVG {#SVG}
+```
+public static final int SVG
+```
+
+
+Svg-format.
+
+### TIFF {#TIFF}
+```
+public static final int TIFF
+```
+
+
+Tiff-bildformat.
+
+### VDX {#VDX}
+```
+public static final int VDX
+```
+
+
+MS Visio Vdx xml-format.
+
+### VSDM {#VSDM}
+```
+public static final int VSDM
+```
+
+
+MS Visio Vsdm-filformat som möjliggör makron.
+
+### VSDX {#VSDX}
+```
+public static final int VSDX
+```
+
+
+MS Visio 2013 Vsdx-filformat.
+
+### VSSM {#VSSM}
+```
+public static final int VSSM
+```
+
+
+MS Visio Vssm-filformat som möjliggör makron.
+
+### VSSX {#VSSX}
+```
+public static final int VSSX
+```
+
+
+MS Visio 2013 Vssx-filformat
+
+### VSTM {#VSTM}
+```
+public static final int VSTM
+```
+
+
+MS Visio Vstm-filformat som möjliggör makron.
+
+### VSTX {#VSTX}
+```
+public static final int VSTX
+```
+
+
+MS Visio 2013 Vstx-filformat, mallfil.
+
+### VSX {#VSX}
+```
+public static final int VSX
+```
+
+
+MS Visio Vsx xml-stencilformat.
+
+### VTX {#VTX}
+```
+public static final int VTX
+```
+
+
+MS Visio Vst xml-mallformat.
+
+### XAML {#XAML}
+```
+public static final int XAML
+```
+
+
+Xaml-format.
+
+### XPS {#XPS}
+```
+public static final int XPS
+```
+
+
+Xps-format.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/saveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/saveoptions/_index.md
@@ -1,0 +1,216 @@
+---
+title: SaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Detta är en abstrakt basklass för klasser som låter användaren ange ytterligare alternativ när ett diagram sparas i ett specifikt format.
+type: docs
+weight: 349
+url: /sv/java/com.aspose.diagram/saveoptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public abstract class SaveOptions
+```
+
+Detta är en abstrakt basklass för klasser som tillåter användaren att ange ytterligare alternativ när ett diagram sparas i ett specifikt format. En instans av SaveOptions‑klassen eller någon avledd klass skickas till stream Save‑ eller string Save‑överladdningar så att användaren kan definiera anpassade alternativ vid sparande av ett dokument.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getSaveFormat()](#getSaveFormat--) | Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/scratch/_index.md
+++ b/swedish/java/com.aspose.diagram/scratch/_index.md
@@ -1,0 +1,349 @@
+---
+title: Scratch
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller ett arbetsområde för att ange och testa formler som refereras till av andra element.
+type: docs
+weight: 350
+url: /sv/java/com.aspose.diagram/scratch/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Scratch
+```
+
+Innehåller ett arbetsområde för att ange och testa formler som refereras till av andra element. Detta element används vanligtvis för att isolera upprepade komplexa beräkningar.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Scratch()](#Scratch--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Ett allmänt ändamåls‑element. |
+| [getB()](#getB--) | Ett allmänt ändamåls‑scratch‑element. |
+| [getC()](#getC--) | Ett allmänt ändamåls‑element. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Ett allmänt ändamåls‑element. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | Anger en x‑koordinat på en form i lokala koordinater. |
+| [getY()](#getY--) | Anger en y‑koordinat på en form i lokala koordinater. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(Value value)](#setA-com.aspose.diagram.Value-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/scratch\#getA--) |
+| [setB(Value value)](#setB-com.aspose.diagram.Value-) | För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/scratch\#getB--) |
+| [setC(Value value)](#setC-com.aspose.diagram.Value-) | För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/scratch\#getC--) |
+| [setD(Value value)](#setD-com.aspose.diagram.Value-) | För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/scratch\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/scratch\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/scratch\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/scratch\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/scratch\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Scratch() {#Scratch--}
+```
+public Scratch()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public Value getA()
+```
+
+
+Ett allmänt ändamåls‑element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getB() {#getB--}
+```
+public Value getB()
+```
+
+
+Ett allmänt ändamåls‑scratch‑element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getC() {#getC--}
+```
+public Value getC()
+```
+
+
+Ett allmänt ändamåls‑element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public Value getD()
+```
+
+
+Ett allmänt ändamåls‑element.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+Anger en x-koordinat på en form i lokala koordinater. Följande tabell beskriver X‑elementet baserat på det element som innehåller det.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Anger en y-koordinat på en form i lokala koordinater. Lokala koordinater är de vars referensram är formen, istället för sidan.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(Value value) {#setA-com.aspose.diagram.Value-}
+```
+public void setA(Value value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/scratch\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setB(Value value) {#setB-com.aspose.diagram.Value-}
+```
+public void setB(Value value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/scratch\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setC(Value value) {#setC-com.aspose.diagram.Value-}
+```
+public void setC(Value value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/scratch\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setD(Value value) {#setD-com.aspose.diagram.Value-}
+```
+public void setD(Value value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/scratch\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/scratch\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/scratch\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/scratch\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/scratch\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/scratchcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/scratchcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: ScratchCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Scratch-samling.
+type: docs
+weight: 351
+url: /sv/java/com.aspose.diagram/scratchcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ScratchCollection extends Collection
+```
+
+Scratch-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Scratch item)](#add-com.aspose.diagram.Scratch-) | Lägg till Scratch-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Scratch item)](#remove-com.aspose.diagram.Scratch-) | Ta bort Scratch-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Scratch item) {#add-com.aspose.diagram.Scratch-}
+```
+public int add(Scratch item)
+```
+
+
+Lägg till Scratch-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Scratch get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Scratch](../../com.aspose.diagram/scratch) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Scratch item) {#remove-com.aspose.diagram.Scratch-}
+```
+public void remove(Scratch item)
+```
+
+
+Ta bort Scratch-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Scratch](../../com.aspose.diagram/scratch) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/scrollbaractivexcontrol/_index.md
@@ -1,0 +1,572 @@
+---
+title: ScrollBarActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ScrollBar-kontrollen.
+type: docs
+weight: 352
+url: /sv/java/com.aspose.diagram/scrollbaractivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol), [com.aspose.diagram.SpinButtonActiveXControl](../../com.aspose.diagram/spinbuttonactivexcontrol)
+```
+public class ScrollBarActiveXControl extends SpinButtonActiveXControl
+```
+
+Representerar ScrollBar-kontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getLargeChange()](#getLargeChange--) | det belopp med vilket Position-egenskapen ändras |
+| [getMax()](#getMax--) | det maximala acceptabla värdet. |
+| [getMin()](#getMin--) | det minsta acceptabla värdet. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getOrientation()](#getOrientation--) | om SpinButton eller ScrollBar är orienterad vertikalt eller horisontellt. |
+| [getPosition()](#getPosition--) | värdet. |
+| [getSmallChange()](#getSmallChange--) | det belopp med vilket Position-egenskapen ändras |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLargeChange(int value)](#setLargeChange-int-) | För beskrivningen av den här egenskapen, se [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | För beskrivningen av den här egenskapen, se [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | För beskrivningen av den här egenskapen, se [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | För beskrivningen av den här egenskapen, se [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | För beskrivningen av den här egenskapen, se [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getLargeChange() {#getLargeChange--}
+```
+public int getLargeChange()
+```
+
+
+det belopp med vilket Position-egenskapen ändras
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+det maximala acceptabla värdet.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+det minsta acceptabla värdet.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+om SpinButton eller ScrollBar är orienterad vertikalt eller horisontellt.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+värdet.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+det belopp med vilket Position-egenskapen ändras
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLargeChange(int value) {#setLargeChange-int-}
+```
+public void setLargeChange(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLargeChange()](../../com.aspose.diagram/scrollbaractivexcontrol\#getLargeChange--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/selectmode/_index.md
+++ b/swedish/java/com.aspose.diagram/selectmode/_index.md
@@ -1,0 +1,179 @@
+---
+title: SelectMode
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar hur användaren väljer en gruppform och dess medlemmar.
+type: docs
+weight: 353
+url: /sv/java/com.aspose.diagram/selectmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SelectMode
+```
+
+Specificerar hur användaren väljer en gruppform och dess medlemmar.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SelectMode(int value)](#SelectMode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar hur användaren väljer en gruppform och dess medlemmar. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/selectmode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SelectMode(int value) {#SelectMode-int-}
+```
+public SelectMode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar hur användaren väljer en gruppform och dess medlemmar.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/selectmode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/selectmodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/selectmodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: SelectModeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar hur användaren väljer en gruppform och dess medlemmar.
+type: docs
+weight: 354
+url: /sv/java/com.aspose.diagram/selectmodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SelectModeValue
+```
+
+Specificerar hur användaren väljer en gruppform och dess medlemmar.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [GROUP_SHAPE_FIRST](#GROUP-SHAPE-FIRST) | Välj gruppformen först. |
+| [GROUP_SHAPE_ONLY](#GROUP-SHAPE-ONLY) | Välj endast gruppformen. |
+| [MEMBERS_GROUP_FIRST](#MEMBERS-GROUP-FIRST) | Välj medlemmarna i gruppen först. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### GROUP_SHAPE_FIRST {#GROUP-SHAPE-FIRST}
+```
+public static final int GROUP_SHAPE_FIRST
+```
+
+
+Välj gruppformen först.
+
+### GROUP_SHAPE_ONLY {#GROUP-SHAPE-ONLY}
+```
+public static final int GROUP_SHAPE_ONLY
+```
+
+
+Välj endast gruppformen.
+
+### MEMBERS_GROUP_FIRST {#MEMBERS-GROUP-FIRST}
+```
+public static final int MEMBERS_GROUP_FIRST
+```
+
+
+Välj medlemmarna i gruppen först.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shape/_index.md
+++ b/swedish/java/com.aspose.diagram/shape/_index.md
@@ -1,0 +1,1760 @@
+---
+title: Shape
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som definierar en form i en Master Page eller gruppformselement.
+type: docs
+weight: 355
+url: /sv/java/com.aspose.diagram/shape/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Shape
+```
+
+Innehåller element som definierar en form i ett Master-, Page- eller gruppformselement.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Shape()](#Shape--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [bringForward()](#bringForward--) | Flyttar formen fram ett steg i z-ordningen. |
+| [bringToFront()](#bringToFront--) | Flyttar formen till framkanten av z-ordningen. |
+| [centerDrawing()](#centerDrawing--) | Centrera formen i förhållande till sidans omfång |
+| [connectedShapes(int flag, String categoryFilter)](#connectedShapes-int-java.lang.String-) | Returnerar en array som innehåller identifierarna (ID:n) för de former som är anslutna till formen. |
+| [copy(Shape source)](#copy-com.aspose.diagram.Shape-) |  |
+| [dependsOnShapes()](#dependsOnShapes--) | Returnerar en array som innehåller identifierarna för de former som beror på en form. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveXControl()](#getActiveXControl--) | Hämtar ActiveX-kontrollen. |
+| [getActs()](#getActs--) | Innehåller en samling av Act-element. |
+| [getAlign()](#getAlign--) | Anger justeringen av en form i förhållande till guiden eller guidepunkten som formen är fäst vid. |
+| [getChars()](#getChars--) | Innehåller en samling av Char-element. |
+| [getClass()](#getClass--) |  |
+| [getClippingPath()](#getClippingPath--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Innehåller en samling av ConnectionABCD-element. |
+| [getConnections()](#getConnections--) | Innehåller en samling av Connection-element. |
+| [getConnectorRule()](#getConnectorRule--) | Returnerar en connectorRule som innehåller formens ID och anslutningen som är kopplad till formen. |
+| [getConnectorsType()](#getConnectorsType--) | Hämta anslutningstyp |
+| [getControlData()](#getControlData--) | Hämtar data för kontrollen. |
+| [getControls()](#getControls--) | Innehåller en samling av Control-element. |
+| [getData1()](#getData1--) | Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form. |
+| [getData2()](#getData2--) | Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form. |
+| [getData3()](#getData3--) | Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDiagram()](#getDiagram--) | Rot-element för Visio-objekthierarkin. |
+| [getDisplayText()](#getDisplayText--) | Hämta texten som visas i gränssnittet |
+| [getEvent()](#getEvent--) | Innehåller element som specificerar formler som styr formhändelser. |
+| [getFields()](#getFields--) | Innehåller en samling av Field-element. |
+| [getFill()](#getFill--) | Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg. |
+| [getFillStyle()](#getFillStyle--) | Stilmall som denna form ärver fyllningsformatering från. |
+| [getForeign()](#getForeign--) | Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. |
+| [getForeignData()](#getForeignData--) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [getGeoms()](#getGeoms--) | Innehåller en samling av Geom-element. |
+| [getGroup()](#getGroup--) | Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper. |
+| [getHelp()](#getHelp--) | Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation. |
+| [getHyperlinks()](#getHyperlinks--) | Innehåller en samling Hyperlink-element. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getImage()](#getImage--) | Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap. |
+| [getInheritChars()](#getInheritChars--) | Innehåller teckenvärdena för formen som ärvs av masternformen. |
+| [getInheritFill()](#getInheritFill--) | Innehåller fyllningsformateringsvärdena för formen som ärvs av förälderstilen och masternformen. |
+| [getInheritGeoms()](#getInheritGeoms--) | Innehåller Geoms‑värdena för formen som ärvs av masterformen. |
+| [getInheritLine()](#getInheritLine--) | Innehåller radformateringsvärdena för formen som ärvs av förälderstilen och masterformen. |
+| [getInheritParas()](#getInheritParas--) | Innehåller paras för formen som ärvs av förälderstilen och masterformen. |
+| [getInheritProps()](#getInheritProps--) | Innehåller egenskaperna för formen som ärvs av masterformen. |
+| [getInheritTextBlock()](#getInheritTextBlock--) | Innehåller textblockvärdena för formen som ärvs av förälderstilen och masterformen. |
+| [getInheritUsers()](#getInheritUsers--) | Innehåller användarna för formen som ärvs av masterformen. |
+| [getLayerMem()](#getLayerMem--) | Innehåller LayerMember‑elementet, som specificerar varje lager som formen tilldelas. |
+| [getLayout()](#getLayout--) | Innehåller element som styr formplacering och inställningar för anslutningsruttning. |
+| [getLine()](#getLine--) | Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. |
+| [getLineStyle()](#getLineStyle--) | Stilmall som denna form ärver radformatering från. |
+| [getMaster()](#getMaster--) | Mastern som formen ärver sina data från. |
+| [getMasterShape()](#getMasterShape--) | Detta attribut får endast finnas i former som är medlemmar i en gruppform, och gruppen är en instans av en master. |
+| [getMisc()](#getMisc--) | Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getOneD()](#getOneD--) | Bestämmer om formen beter sig som ett endimensionellt (1‑D) objekt. |
+| [getPage()](#getPage--) | Rot-element för Visio-objekthierarkin. |
+| [getParas()](#getParas--) | Innehåller en samling av Para-element. |
+| [getParentShape()](#getParentShape--) | Formens förälder. |
+| [getProps()](#getProps--) | Innehåller en samling Prop-element. |
+| [getProtection()](#getProtection--) | Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. |
+| [getPureText()](#getPureText--) | Hämta textsträngen. |
+| [getRootShape()](#getRootShape--) | Returnerar top‑nivåformen för en instans om denna form är en del av en masterinstans. |
+| [getScratchs()](#getScratchs--) | Innehåller en samling Scratch-element. |
+| [getShapes()](#getShapes--) | Innehåller en samling av Shape‑element. |
+| [getSmartTagDefs()](#getSmartTagDefs--) | Innehåller en samling av SmartTagDef-element. |
+| [getTabsCollection()](#getTabsCollection--) | Innehåller en samling av Tab‑element. |
+| [getText()](#getText--) | Innehåller texten för en figur. |
+| [getTextBlock()](#getTextBlock--) | Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock. |
+| [getTextStyle()](#getTextStyle--) | Stilmall som denna form ärver textformatering från. |
+| [getTextXForm()](#getTextXForm--) | Innehåller element som specificerar placeringsinformation om en figurs textblock. |
+| [getThreeDFormat()](#getThreeDFormat--) | Hämtar ThreeDFormat. |
+| [getTwoD()](#getTwoD--) | Bestämmer om formen beter sig som ett tvådimensionellt (2‑D) objekt. |
+| [getType()](#getType--) | Typen av en form. |
+| [getUniqueID()](#getUniqueID--) | En GUID (globalt unikt identifierare) tilldelad formen. |
+| [getUsers()](#getUsers--) | Innehåller en samling User-element. |
+| [getXForm()](#getXForm--) | Innehåller element som specificerar generell placeringsinformation om en form. |
+| [getXForm1D()](#getXForm1D--) | Innehåller x- och y-koordinater för startpunkten och slutpunkten av en 1‑D-form. |
+| [getZOrderIndex()](#getZOrderIndex--) | Returnerar indexet för en form i z‑ordningen förutom guideformen. |
+| [gluedShapes(int flag, String categoryFilter, Shape otherShape)](#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-) | Returnerar en array som innehåller identifierarna för de former som är limmade till en form. |
+| [hashCode()](#hashCode--) |  |
+| [isConnected(Shape shape)](#isConnected-com.aspose.diagram.Shape-) | Indikerar om dessa två former är anslutna. |
+| [isContain(Shape shape)](#isContain-com.aspose.diagram.Shape-) | Indikerar om denna form innehåller en annan form. |
+| [isGlued(Shape shape)](#isGlued-com.aspose.diagram.Shape-) | Indikerar om dessa två former är limmade. |
+| [isInGroup()](#isInGroup--) | Indikerar om denna form är i en gruppform. |
+| [isIntersect(Shape shape)](#isIntersect-com.aspose.diagram.Shape-) | Anger om den här formen intersectar en annan form. |
+| [isTextEmpty()](#isTextEmpty--) | Indikerar om formen har text och om texten är tom eller inte. |
+| [move(double dX, double dY)](#move-double-double-) | Flyttar formen med dX och dY tum från den aktuella positionen. |
+| [moveTo(double newPinX, double newPinY)](#moveTo-double-double-) | Flyttar formen till en ny absolut position på sidan. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshData()](#refreshData--) | Uppdaterar formens position inklusive xform, connection och geom när formens text eller annan ändras. |
+| [replaceText(String text, String replaceText)](#replaceText-java.lang.String-java.lang.String-) | Ersätt textsträngen för en form. |
+| [sendBackward()](#sendBackward--) | Flyttar formen ett steg bakåt i z-ordningen. |
+| [sendToBack()](#sendToBack--) | Flyttar formen längst bak i z-ordningen. |
+| [setAngle(double angle)](#setAngle-double-) | Ställer in ny vinkel för formen. |
+| [setClippingPath(String value)](#setClippingPath-java.lang.String-) | För beskrivningen av denna egenskap, se [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--) |
+| [setConnectorsType(int type)](#setConnectorsType-int-) | Ange anslutningstyp. |
+| [setData1(String value)](#setData1-java.lang.String-) | För beskrivningen av denna egenskap, se [getData1()](../../com.aspose.diagram/shape\#getData1--) |
+| [setData2(String value)](#setData2-java.lang.String-) | För beskrivningen av denna egenskap, se [getData2()](../../com.aspose.diagram/shape\#getData2--) |
+| [setData3(String value)](#setData3-java.lang.String-) | För beskrivningen av denna egenskap, se [getData3()](../../com.aspose.diagram/shape\#getData3--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/shape\#getDel--) |
+| [setDiagram(Diagram value)](#setDiagram-com.aspose.diagram.Diagram-) | För beskrivningen av denna egenskap, se [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--) |
+| [setEvent(Event value)](#setEvent-com.aspose.diagram.Event-) | För beskrivningen av denna egenskap, se [getEvent()](../../com.aspose.diagram/shape\#getEvent--) |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--) |
+| [setHeight(double height)](#setHeight-double-) | Ställer in ny höjd för formen. |
+| [setID(long value)](#setID-long-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/shape\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | För beskrivningen av denna egenskap, se [getMaster()](../../com.aspose.diagram/shape\#getMaster--) |
+| [setMasterShape(Shape value)](#setMasterShape-com.aspose.diagram.Shape-) | För beskrivningen av denna egenskap, se [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/shape\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/shape\#getNameU--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | För beskrivningen av denna egenskap, se [getPage()](../../com.aspose.diagram/shape\#getPage--) |
+| [setParentShape(Shape value)](#setParentShape-com.aspose.diagram.Shape-) | För beskrivningen av denna egenskap, se [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--) |
+| [setPresetTheme(int value)](#setPresetTheme-int-) | Tillämpa ett förinställt tema på den här formen |
+| [setPresetThemeQuickStyle(int value)](#setPresetThemeQuickStyle-int-) | Tillämpa en förinställd temavariant snabbstil på den här formen |
+| [setPresetThemeStyleMatrics(int styleIndex, int colorIndex)](#setPresetThemeStyleMatrics-int-int-) | Tillämpa en förinställd temavariant snabbstil på den här formen, som temastilsalternativ i rullgardinsmenyn för formstilar |
+| [setPresetThemeVariant(int value)](#setPresetThemeVariant-int-) | Tillämpa en förinställd temavariant på den här formen |
+| [setProps(PropCollection value)](#setProps-com.aspose.diagram.PropCollection-) | För beskrivningen av denna egenskap, se [getProps()](../../com.aspose.diagram/shape\#getProps--) |
+| [setText(Text value)](#setText-com.aspose.diagram.Text-) | För beskrivningen av denna egenskap, se [getText()](../../com.aspose.diagram/shape\#getText--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--) |
+| [setTwoD(boolean value)](#setTwoD-boolean-) | För beskrivningen av denna egenskap, se [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--) |
+| [setType(int value)](#setType-int-) | För beskrivningen av denna egenskap, se [getType()](../../com.aspose.diagram/shape\#getType--) |
+| [setUniqueID(UUID value)](#setUniqueID-java.util.UUID-) | För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--) |
+| [setWidth(double width)](#setWidth-double-) | Ställer in ny bredd på formen. |
+| [setXForm(XForm value)](#setXForm-com.aspose.diagram.XForm-) | För beskrivningen av denna egenskap, se [getXForm()](../../com.aspose.diagram/shape\#getXForm--) |
+| [setXForm1D(XForm1D value)](#setXForm1D-com.aspose.diagram.XForm1D-) | För beskrivningen av denna egenskap, se [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--) |
+| [toHTML(InputStream stream, HTMLSaveOptions options)](#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-) | Skapar formens HTML och sparar den till en ström i angivet format. |
+| [toHTML(OutputStream stream, HTMLSaveOptions options)](#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-) | Skapar formens HTML och sparar den till en ström i angivet format. |
+| [toHTML(String fileName, HTMLSaveOptions options)](#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-) | Skapar HTML och sparar den till en fil. |
+| [toImage(InputStream stream, ImageSaveOptions options)](#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-) | Skapar formens bild och sparar den till en ström i angivet format. |
+| [toImage(OutputStream stream, ImageSaveOptions options)](#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-) | Skapar formens bild och sparar den till en ström i angivet format. |
+| [toImage(String imageFile, ImageSaveOptions options)](#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-) | Skapar formens bild och sparar den till en fil. |
+| [toPdf(InputStream stream)](#toPdf-java.io.InputStream-) | Skapar formens PDF och sparar den till en ström. |
+| [toPdf(OutputStream stream)](#toPdf-java.io.OutputStream-) | Skapar formens PDF och sparar den till en ström. |
+| [toPdf(String fileName)](#toPdf-java.lang.String-) | Sparar formen till en PDF-fil. |
+| [toString()](#toString--) |  |
+| [toSvg(String imageFile, SVGSaveOptions options)](#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-) | Sparar formen till en SVG-fil. |
+| [ungroup()](#ungroup--) | Avgruppera form |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Shape() {#Shape--}
+```
+public Shape()
+```
+
+
+Konstruktor.
+
+### bringForward() {#bringForward--}
+```
+public void bringForward()
+```
+
+
+Flyttar formen fram ett steg i z-ordningen.
+
+### bringToFront() {#bringToFront--}
+```
+public void bringToFront()
+```
+
+
+Flyttar formen till framkanten av z-ordningen.
+
+### centerDrawing() {#centerDrawing--}
+```
+public void centerDrawing()
+```
+
+
+Centrera formen i förhållande till sidans omfång
+
+### connectedShapes(int flag, String categoryFilter) {#connectedShapes-int-java.lang.String-}
+```
+public long[] connectedShapes(int flag, String categoryFilter)
+```
+
+
+Returnerar en array som innehåller identifierarna (ID:n) för de former som är anslutna till formen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flagga | int | Filtrerar arrayen av returnerade form-ID:n efter anslutarnas riktning. Se Kommentarer för möjliga värdenAspose.Diagram.ConnectedShapesFlags. |
+| categoryFilter | java.lang.String | Filtrerar arrayen av returnerade form-ID:n genom att begränsa den till ID:n för former som matchar den angivna categoryString. |
+
+**Returns:**
+long[] - ID-array av typen long.
+### copy(Shape source) {#copy-com.aspose.diagram.Shape-}
+```
+public void copy(Shape source)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| source | [Shape](../../com.aspose.diagram/shape) |  |
+
+### dependsOnShapes() {#dependsOnShapes--}
+```
+public long[] dependsOnShapes()
+```
+
+
+Returnerar en array som innehåller identifierarna för de former som beror på en form.
+
+**Returns:**
+long[] - ID-array av typen long.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveXControl() {#getActiveXControl--}
+```
+public ActiveXControl getActiveXControl()
+```
+
+
+Hämtar ActiveX-kontrollen.
+
+**Returns:**
+[ActiveXControl](../../com.aspose.diagram/activexcontrol)
+### getActs() {#getActs--}
+```
+public ActCollection getActs()
+```
+
+
+Innehåller en samling av Act-element.
+
+**Returns:**
+[ActCollection](../../com.aspose.diagram/actcollection)
+### getAlign() {#getAlign--}
+```
+public Align getAlign()
+```
+
+
+Anger justeringen av en form i förhållande till guiden eller guidepunkten som formen är fäst vid. Align-elementet visas endast för former som är fästa vid guider eller guidepunkter.
+
+**Returns:**
+[Align](../../com.aspose.diagram/align)
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Innehåller en samling av Char-element.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClippingPath() {#getClippingPath--}
+```
+public String getClippingPath()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Innehåller en samling av ConnectionABCD-element.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Innehåller en samling av Connection-element.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getConnectorRule() {#getConnectorRule--}
+```
+public ConnectorRule getConnectorRule()
+```
+
+
+Returnerar en connectorRule som innehåller formens ID och anslutningen som är kopplad till formen.
+
+**Returns:**
+[ConnectorRule](../../com.aspose.diagram/connectorrule) - ConnectorRule.
+### getConnectorsType() {#getConnectorsType--}
+```
+public int getConnectorsType()
+```
+
+
+Hämta anslutningstyp
+
+**Returns:**
+int
+### getControlData() {#getControlData--}
+```
+public byte[] getControlData()
+```
+
+
+Hämtar data för kontrollen.
+
+**Returns:**
+byte[]
+### getControls() {#getControls--}
+```
+public ControlCollection getControls()
+```
+
+
+Innehåller en samling av Control-element.
+
+**Returns:**
+[ControlCollection](../../com.aspose.diagram/controlcollection)
+### getData1() {#getData1--}
+```
+public String getData1()
+```
+
+
+Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form.
+
+**Returns:**
+java.lang.String
+### getData2() {#getData2--}
+```
+public String getData2()
+```
+
+
+Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form.
+
+**Returns:**
+java.lang.String
+### getData3() {#getData3--}
+```
+public String getData3()
+```
+
+
+Innehåller ett godtyckligt strängvärde som används för att tillhandahålla ytterligare information om en form.
+
+**Returns:**
+java.lang.String
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet är raderat lokalt. Ett värde på 1 indikerar att elementet är raderat lokalt.
+
+**Returns:**
+int
+### getDiagram() {#getDiagram--}
+```
+public Diagram getDiagram()
+```
+
+
+Rot-element för Visio-objekthierarkin.
+
+**Returns:**
+[Diagram](../../com.aspose.diagram/diagram)
+### getDisplayText() {#getDisplayText--}
+```
+public String getDisplayText()
+```
+
+
+Hämta texten som visas i gränssnittet
+
+**Returns:**
+java.lang.String
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Innehåller element som specificerar formler som styr formhändelser.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFields() {#getFields--}
+```
+public FieldCollection getFields()
+```
+
+
+Innehåller en samling av Field-element.
+
+**Returns:**
+[FieldCollection](../../com.aspose.diagram/fieldcollection)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+Stilmall som denna form ärver fyllningsformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. Inkluderar också element som specificerar avståndet som objektets bild förskjuts inom dess kanter.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGeoms() {#getGeoms--}
+```
+public GeomCollection getGeoms()
+```
+
+
+Innehåller en samling av Geom-element.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getHyperlinks() {#getHyperlinks--}
+```
+public HyperlinkCollection getHyperlinks()
+```
+
+
+Innehåller en samling Hyperlink-element.
+
+**Returns:**
+[HyperlinkCollection](../../com.aspose.diagram/hyperlinkcollection)
+### getID() {#getID--}
+```
+public long getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+long
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getInheritChars() {#getInheritChars--}
+```
+public CharCollection getInheritChars()
+```
+
+
+Innehåller teckenvärdena för formen som ärvs av masternformen.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getInheritFill() {#getInheritFill--}
+```
+public Fill getInheritFill()
+```
+
+
+Innehåller fyllningsformateringsvärdena för formen som ärvs av förälderstilen och masternformen.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getInheritGeoms() {#getInheritGeoms--}
+```
+public GeomCollection getInheritGeoms()
+```
+
+
+Innehåller Geoms‑värdena för formen som ärvs av masterformen.
+
+**Returns:**
+[GeomCollection](../../com.aspose.diagram/geomcollection)
+### getInheritLine() {#getInheritLine--}
+```
+public Line getInheritLine()
+```
+
+
+Innehåller radformateringsvärdena för formen som ärvs av förälderstilen och masterformen.
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getInheritParas() {#getInheritParas--}
+```
+public ParaCollection getInheritParas()
+```
+
+
+Innehåller paras för formen som ärvs av förälderstilen och masterformen.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getInheritProps() {#getInheritProps--}
+```
+public PropCollection getInheritProps()
+```
+
+
+Innehåller egenskaperna för formen som ärvs av masterformen.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getInheritTextBlock() {#getInheritTextBlock--}
+```
+public TextBlock getInheritTextBlock()
+```
+
+
+Innehåller textblockvärdena för formen som ärvs av förälderstilen och masterformen.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getInheritUsers() {#getInheritUsers--}
+```
+public UserCollection getInheritUsers()
+```
+
+
+Innehåller användarna för formen som ärvs av masterformen.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getLayerMem() {#getLayerMem--}
+```
+public LayerMem getLayerMem()
+```
+
+
+Innehåller LayerMember‑elementet, som specificerar varje lager som formen tilldelas.
+
+**Returns:**
+[LayerMem](../../com.aspose.diagram/layermem)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Innehåller element som styr formplacering och inställningar för anslutningsruttning.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. Dessa element bestämmer om linjeändarna är formaterade (till exempel med en pilspets), storleken på linjeändformat, radien på den avrundade cirkeln som tillämpas på linjen och linjeändstil (rund eller fyrkantig).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+Stilmall som denna form ärver radformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+Mastern som formen ärver sina data från.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getMasterShape() {#getMasterShape--}
+```
+public Shape getMasterShape()
+```
+
+
+Detta attribut kan endast finnas i former som är medlemmar i en gruppform, och gruppen är en instans av en master. Attributet innehåller ett ID som refererar till motsvarande delform i mastern.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getOneD() {#getOneD--}
+```
+public boolean getOneD()
+```
+
+
+Bestämmer om formen beter sig som ett endimensionellt (1-D) objekt. Skrivskyddad.
+
+**Returns:**
+boolean
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Rot-element för Visio-objekthierarkin.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Innehåller en samling av Para-element.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getParentShape() {#getParentShape--}
+```
+public Shape getParentShape()
+```
+
+
+Formens förälder.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getProps() {#getProps--}
+```
+public PropCollection getProps()
+```
+
+
+Innehåller en samling Prop-element.
+
+**Returns:**
+[PropCollection](../../com.aspose.diagram/propcollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. Det skyddar inte heller mot ändringar som görs i ShapeSheet-fönstret.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getPureText() {#getPureText--}
+```
+public String getPureText()
+```
+
+
+Hämta textsträngen.
+
+**Returns:**
+java.lang.String
+### getRootShape() {#getRootShape--}
+```
+public Shape getRootShape()
+```
+
+
+Returnerar top-nivåformen för en instans om denna form är en del av en masterinstans. Skrivskyddad.
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape)
+### getScratchs() {#getScratchs--}
+```
+public ScratchCollection getScratchs()
+```
+
+
+Innehåller en samling Scratch-element.
+
+**Returns:**
+[ScratchCollection](../../com.aspose.diagram/scratchcollection)
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+Innehåller en samling av Shape‑element.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getSmartTagDefs() {#getSmartTagDefs--}
+```
+public SmartTagDefCollection getSmartTagDefs()
+```
+
+
+Innehåller en samling av SmartTagDef-element.
+
+**Returns:**
+[SmartTagDefCollection](../../com.aspose.diagram/smarttagdefcollection)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Innehåller en samling av Tab‑element.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getText() {#getText--}
+```
+public Text getText()
+```
+
+
+Innehåller texten för en figur.
+
+**Returns:**
+[Text](../../com.aspose.diagram/text)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+Stilmall som denna form ärver textformatering från.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getTextXForm() {#getTextXForm--}
+```
+public TextXForm getTextXForm()
+```
+
+
+Innehåller element som specificerar placeringsinformation om en figurs textblock.
+
+**Returns:**
+[TextXForm](../../com.aspose.diagram/textxform)
+### getThreeDFormat() {#getThreeDFormat--}
+```
+public ThreeDFormat getThreeDFormat()
+```
+
+
+Hämtar ThreeDFormat.
+
+**Returns:**
+[ThreeDFormat](../../com.aspose.diagram/threedformat)
+### getTwoD() {#getTwoD--}
+```
+public boolean getTwoD()
+```
+
+
+Bestämmer om formen beter sig som ett tvådimensionellt (2‑D) objekt.
+
+**Returns:**
+boolean
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Typen av en form. Den kan vara ett av följande värden: Group, Shape, Guide eller Foreign.
+
+**Returns:**
+int
+### getUniqueID() {#getUniqueID--}
+```
+public UUID getUniqueID()
+```
+
+
+En GUID (globalt unikt identifierare) tilldelad formen.
+
+**Returns:**
+java.util.UUID
+### getUsers() {#getUsers--}
+```
+public UserCollection getUsers()
+```
+
+
+Innehåller en samling User-element.
+
+**Returns:**
+[UserCollection](../../com.aspose.diagram/usercollection)
+### getXForm() {#getXForm--}
+```
+public XForm getXForm()
+```
+
+
+Innehåller element som specificerar generell placeringsinformation om en form.
+
+**Returns:**
+[XForm](../../com.aspose.diagram/xform)
+### getXForm1D() {#getXForm1D--}
+```
+public XForm1D getXForm1D()
+```
+
+
+Innehåller x- och y-koordinater för startpunkten och slutpunkten för en 1‑D-form. Detta element visas endast för 1‑D-former.
+
+**Returns:**
+[XForm1D](../../com.aspose.diagram/xform1d)
+### getZOrderIndex() {#getZOrderIndex--}
+```
+public int getZOrderIndex()
+```
+
+
+Returnerar indexet för en form i z‑ordningen förutom guideformen.
+
+**Returns:**
+int
+### gluedShapes(int flag, String categoryFilter, Shape otherShape) {#gluedShapes-int-java.lang.String-com.aspose.diagram.Shape-}
+```
+public long[] gluedShapes(int flag, String categoryFilter, Shape otherShape)
+```
+
+
+Returnerar en array som innehåller identifierarna för de former som är limmade till en form.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| flagga | int | Dimensionaliteten och riktningen för anslutningspunkterna på formerna som ska returneras. Se Kommentarer för möjliga värden Aspose.Diagram.GluedShapesFlags. |
+| categoryFilter | java.lang.String | Filtrerar arrayen av returnerade form-ID:n genom att begränsa den till ID:n för former som matchar den angivna categoryString. |
+| otherShape | [Shape](../../com.aspose.diagram/shape) | Valfritt: ytterligare form som de returnerade formerna också måste fästas vid, kan vara [Shape](../../com.aspose.diagram/shape) eller null. |
+
+**Returns:**
+long[] - ID-array av typen long.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isConnected(Shape shape) {#isConnected-com.aspose.diagram.Shape-}
+```
+public boolean isConnected(Shape shape)
+```
+
+
+Indikerar om dessa två former är anslutna.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | form |
+
+**Returns:**
+boolean
+### isContain(Shape shape) {#isContain-com.aspose.diagram.Shape-}
+```
+public boolean isContain(Shape shape)
+```
+
+
+Indikerar om denna form innehåller en annan form.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isGlued(Shape shape) {#isGlued-com.aspose.diagram.Shape-}
+```
+public boolean isGlued(Shape shape)
+```
+
+
+Indikerar om dessa två former är limmade.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) | form |
+
+**Returns:**
+boolean
+### isInGroup() {#isInGroup--}
+```
+public boolean isInGroup()
+```
+
+
+Indikerar om denna form är i en gruppform.
+
+**Returns:**
+boolean
+### isIntersect(Shape shape) {#isIntersect-com.aspose.diagram.Shape-}
+```
+public boolean isIntersect(Shape shape)
+```
+
+
+Anger om den här formen intersectar en annan form.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+boolean
+### isTextEmpty() {#isTextEmpty--}
+```
+public boolean isTextEmpty()
+```
+
+
+Indikerar om formen har text och om texten är tom eller inte.
+
+**Returns:**
+boolean
+### move(double dX, double dY) {#move-double-double-}
+```
+public void move(double dX, double dY)
+```
+
+
+Flyttar formen med dX och dY tum från den aktuella positionen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dX | double | X-förskjutning double. |
+| dY | double | Y-förskjutning double. |
+
+### moveTo(double newPinX, double newPinY) {#moveTo-double-double-}
+```
+public void moveTo(double newPinX, double newPinY)
+```
+
+
+Flyttar formen till en ny absolut position på sidan.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| newPinX | double | Ny x-koordinat för formens pin (rotationscentrum) i förhållande till förälderns ursprung. double. |
+| newPinY | double | Ny y-koordinat för formens pin (rotationscentrum) i förhållande till förälderns ursprung. double. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshData() {#refreshData--}
+```
+public void refreshData()
+```
+
+
+Uppdaterar formens position inklusive xform, anslutning och geom när formens text eller annan ändras. Vi samlar in formens data såsom formens text och beräknar sedan formens position. Denna metod används endast för att uppdatera formens data.
+
+### replaceText(String text, String replaceText) {#replaceText-java.lang.String-java.lang.String-}
+```
+public void replaceText(String text, String replaceText)
+```
+
+
+Ersätt textsträngen för en form.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| text | java.lang.String |  |
+| replaceText | java.lang.String |  |
+
+### sendBackward() {#sendBackward--}
+```
+public void sendBackward()
+```
+
+
+Flyttar formen ett steg bakåt i z-ordningen.
+
+### sendToBack() {#sendToBack--}
+```
+public void sendToBack()
+```
+
+
+Flyttar formen längst bak i z-ordningen.
+
+### setAngle(double angle) {#setAngle-double-}
+```
+public void setAngle(double angle)
+```
+
+
+Ställer in ny vinkel för formen. Vinkelns enhet är radian.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| angle | double | Ny vinkel vars enhet är radian, inte grad double. |
+
+### setClippingPath(String value) {#setClippingPath-java.lang.String-}
+```
+public void setClippingPath(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getClippingPath()](../../com.aspose.diagram/shape\#getClippingPath--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setConnectorsType(int type) {#setConnectorsType-int-}
+```
+public void setConnectorsType(int type)
+```
+
+
+Ange anslutningstyp.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | int |  |
+
+### setData1(String value) {#setData1-java.lang.String-}
+```
+public void setData1(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getData1()](../../com.aspose.diagram/shape\#getData1--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setData2(String value) {#setData2-java.lang.String-}
+```
+public void setData2(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getData2()](../../com.aspose.diagram/shape\#getData2--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setData3(String value) {#setData3-java.lang.String-}
+```
+public void setData3(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getData3()](../../com.aspose.diagram/shape\#getData3--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/shape\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDiagram(Diagram value) {#setDiagram-com.aspose.diagram.Diagram-}
+```
+public void setDiagram(Diagram value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDiagram()](../../com.aspose.diagram/shape\#getDiagram--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Diagram](../../com.aspose.diagram/diagram) |  |
+
+### setEvent(Event value) {#setEvent-com.aspose.diagram.Event-}
+```
+public void setEvent(Event value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEvent()](../../com.aspose.diagram/shape\#getEvent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Event](../../com.aspose.diagram/event) |  |
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/shape\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setHeight(double height) {#setHeight-double-}
+```
+public void setHeight(double height)
+```
+
+
+Ställer in ny höjd för formen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| höjd | double | Ny höjd double. |
+
+### setID(long value) {#setID-long-}
+```
+public void setID(long value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/shape\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/shape\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+För beskrivningen av denna egenskap, se [getMaster()](../../com.aspose.diagram/shape\#getMaster--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setMasterShape(Shape value) {#setMasterShape-com.aspose.diagram.Shape-}
+```
+public void setMasterShape(Shape value)
+```
+
+
+För beskrivningen av denna egenskap, se [getMasterShape()](../../com.aspose.diagram/shape\#getMasterShape--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/shape\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/shape\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPage()](../../com.aspose.diagram/shape\#getPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentShape(Shape value) {#setParentShape-com.aspose.diagram.Shape-}
+```
+public void setParentShape(Shape value)
+```
+
+
+För beskrivningen av denna egenskap, se [getParentShape()](../../com.aspose.diagram/shape\#getParentShape--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Shape](../../com.aspose.diagram/shape) |  |
+
+### setPresetTheme(int value) {#setPresetTheme-int-}
+```
+public void setPresetTheme(int value)
+```
+
+
+Tillämpa ett förinställt tema på den här formen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPresetThemeQuickStyle(int value) {#setPresetThemeQuickStyle-int-}
+```
+public void setPresetThemeQuickStyle(int value)
+```
+
+
+Tillämpa en förinställd temavariant snabbstil på den här formen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPresetThemeStyleMatrics(int styleIndex, int colorIndex) {#setPresetThemeStyleMatrics-int-int-}
+```
+public void setPresetThemeStyleMatrics(int styleIndex, int colorIndex)
+```
+
+
+Tillämpa en förinställd temavariant snabbstil på den här formen, som temastilsalternativ i rullgardinsmenyn för formstilar
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| styleIndex | int | raden i stilmatriser |
+| colorIndex | int | kolumnen i stilmatriser |
+
+### setPresetThemeVariant(int value) {#setPresetThemeVariant-int-}
+```
+public void setPresetThemeVariant(int value)
+```
+
+
+Tillämpa en förinställd temavariant på den här formen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setProps(PropCollection value) {#setProps-com.aspose.diagram.PropCollection-}
+```
+public void setProps(PropCollection value)
+```
+
+
+För beskrivningen av denna egenskap, se [getProps()](../../com.aspose.diagram/shape\#getProps--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PropCollection](../../com.aspose.diagram/propcollection) |  |
+
+### setText(Text value) {#setText-com.aspose.diagram.Text-}
+```
+public void setText(Text value)
+```
+
+
+För beskrivningen av denna egenskap, se [getText()](../../com.aspose.diagram/shape\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Text](../../com.aspose.diagram/text) |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/shape\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setTwoD(boolean value) {#setTwoD-boolean-}
+```
+public void setTwoD(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTwoD()](../../com.aspose.diagram/shape\#getTwoD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setType(int value) {#setType-int-}
+```
+public void setType(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getType()](../../com.aspose.diagram/shape\#getType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setUniqueID(UUID value) {#setUniqueID-java.util.UUID-}
+```
+public void setUniqueID(UUID value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUniqueID()](../../com.aspose.diagram/shape\#getUniqueID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.util.UUID |  |
+
+### setWidth(double width) {#setWidth-double-}
+```
+public void setWidth(double width)
+```
+
+
+Ställer in ny bredd på formen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| bredd | double | Ny bredd double. |
+
+### setXForm(XForm value) {#setXForm-com.aspose.diagram.XForm-}
+```
+public void setXForm(XForm value)
+```
+
+
+För beskrivningen av denna egenskap, se [getXForm()](../../com.aspose.diagram/shape\#getXForm--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [XForm](../../com.aspose.diagram/xform) |  |
+
+### setXForm1D(XForm1D value) {#setXForm1D-com.aspose.diagram.XForm1D-}
+```
+public void setXForm1D(XForm1D value)
+```
+
+
+För beskrivningen av denna egenskap, se [getXForm1D()](../../com.aspose.diagram/shape\#getXForm1D--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [XForm1D](../../com.aspose.diagram/xform1d) |  |
+
+### toHTML(InputStream stream, HTMLSaveOptions options) {#toHTML-java.io.InputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(InputStream stream, HTMLSaveOptions options)
+```
+
+
+Skapar formens HTML och sparar den till en ström i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | Utdataflödet. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Ytterligare HTML-skapandealternativ |
+
+### toHTML(OutputStream stream, HTMLSaveOptions options) {#toHTML-java.io.OutputStream-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(OutputStream stream, HTMLSaveOptions options)
+```
+
+
+Skapar formens HTML och sparar den till en ström i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Utdataflödet. |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | Ytterligare HTML-skapandealternativ |
+
+### toHTML(String fileName, HTMLSaveOptions options) {#toHTML-java.lang.String-com.aspose.diagram.HTMLSaveOptions-}
+```
+public void toHTML(String fileName, HTMLSaveOptions options)
+```
+
+
+Skapar HTML och sparar den till en fil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String |  |
+| options | [HTMLSaveOptions](../../com.aspose.diagram/htmlsaveoptions) | html sparalternativ |
+
+### toImage(InputStream stream, ImageSaveOptions options) {#toImage-java.io.InputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(InputStream stream, ImageSaveOptions options)
+```
+
+
+Skapar formens bild och sparar den till en ström i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | Utdataflödet. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Ytterligare bildskapandealternativ |
+
+### toImage(OutputStream stream, ImageSaveOptions options) {#toImage-java.io.OutputStream-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(OutputStream stream, ImageSaveOptions options)
+```
+
+
+Skapar formens bild och sparar den till en ström i angivet format.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Utdataflödet. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Ytterligare bildskapandealternativ |
+
+### toImage(String imageFile, ImageSaveOptions options) {#toImage-java.lang.String-com.aspose.diagram.ImageSaveOptions-}
+```
+public void toImage(String imageFile, ImageSaveOptions options)
+```
+
+
+Skapar formbilden och sparar den till en fil. Filnamnets filändelse bestämmer bildens format.
+
+Bildens format anges genom att använda filnamnets filändelse. Till exempel, om du anger \"myfile.png\", sparas bilden i PNG-format. Följande filändelser känns igen: .bmp, .gif, .png, .jpg, .jpeg, .tiff, .tif, .emf.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| imageFile | java.lang.String | Bildfilens namn med fullständig sökväg. |
+| options | [ImageSaveOptions](../../com.aspose.diagram/imagesaveoptions) | Ytterligare bildskapandealternativ |
+
+### toPdf(InputStream stream) {#toPdf-java.io.InputStream-}
+```
+public void toPdf(InputStream stream)
+```
+
+
+Skapar formens PDF och sparar den till en ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.InputStream | Utdataflödet. |
+
+### toPdf(OutputStream stream) {#toPdf-java.io.OutputStream-}
+```
+public void toPdf(OutputStream stream)
+```
+
+
+Skapar formens PDF och sparar den till en ström.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ström | java.io.OutputStream | Utdataflödet. |
+
+### toPdf(String fileName) {#toPdf-java.lang.String-}
+```
+public void toPdf(String fileName)
+```
+
+
+Sparar formen till en PDF-fil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| fileName | java.lang.String | pdf-filens namn med fullständig sökväg |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### toSvg(String imageFile, SVGSaveOptions options) {#toSvg-java.lang.String-com.aspose.diagram.SVGSaveOptions-}
+```
+public void toSvg(String imageFile, SVGSaveOptions options)
+```
+
+
+Sparar formen till en SVG-fil.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| imageFile | java.lang.String |  |
+| options | [SVGSaveOptions](../../com.aspose.diagram/svgsaveoptions) |  |
+
+### ungroup() {#ungroup--}
+```
+public void ungroup()
+```
+
+
+Avgruppera form
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/shapecollection/_index.md
@@ -1,0 +1,326 @@
+---
+title: ShapeCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Samling av former.
+type: docs
+weight: 356
+url: /sv/java/com.aspose.diagram/shapecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class ShapeCollection extends Collection
+```
+
+Samling av former.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Shape item)](#add-com.aspose.diagram.Shape-) | Lägg till formen i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getShape(String name)](#getShape-java.lang.String-) | Hämtar elementet med angivet namn. |
+| [getShape(long ID)](#getShape-long-) | Hämtar elementet med angivet ID. |
+| [getShapeIncludingChild(int id)](#getShapeIncludingChild-int-) | Hämtar elementet inklusive dess underordnade form med angivet ID. |
+| [getShapeIncludingChild(String name)](#getShapeIncludingChild-java.lang.String-) | Hämtar elementet inklusive dess underordnade form med angivet namn. |
+| [group(Shape[] groupItems)](#group-com.aspose.diagram.Shape---) | Gruppera formerna. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Shape item)](#remove-com.aspose.diagram.Shape-) | Ta bort formen från samlingen. |
+| [removeDependsOn(Shape item)](#removeDependsOn-com.aspose.diagram.Shape-) | Ta bort formerna inklusive DEPENDSON-former från samlingen. |
+| [toString()](#toString--) |  |
+| [unGroup(Shape groupShape)](#unGroup-com.aspose.diagram.Shape-) | Avgruppera formen. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Shape item) {#add-com.aspose.diagram.Shape-}
+```
+public int add(Shape item)
+```
+
+
+Lägg till formen i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) |  |
+
+**Returns:**
+int - ID
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Shape get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getShape(String name) {#getShape-java.lang.String-}
+```
+public Shape getShape(String name)
+```
+
+
+Hämtar elementet med angivet namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShape(long ID) {#getShape-long-}
+```
+public Shape getShape(long ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | long |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(int id) {#getShapeIncludingChild-int-}
+```
+public Shape getShapeIncludingChild(int id)
+```
+
+
+Hämtar elementet inklusive dess underordnade form med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| id | int |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### getShapeIncludingChild(String name) {#getShapeIncludingChild-java.lang.String-}
+```
+public Shape getShapeIncludingChild(String name)
+```
+
+
+Hämtar elementet inklusive dess underordnade form med angivet namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - 
+### group(Shape[] groupItems) {#group-com.aspose.diagram.Shape---}
+```
+public Shape group(Shape[] groupItems)
+```
+
+
+Gruppera formerna. Formen i groupItems bör inte grupperas. Formen måste finnas i denna Shapes-samling.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| groupItems | [Shape\[\]](../../com.aspose.diagram/shape) | gruppobjekten. |
+
+**Returns:**
+[Shape](../../com.aspose.diagram/shape) - Return the group shape.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Shape item) {#remove-com.aspose.diagram.Shape-}
+```
+public void remove(Shape item)
+```
+
+
+Ta bort formen från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### removeDependsOn(Shape item) {#removeDependsOn-com.aspose.diagram.Shape-}
+```
+public void removeDependsOn(Shape item)
+```
+
+
+Ta bort formerna inklusive DEPENDSON-former från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Shape](../../com.aspose.diagram/shape) | Shape |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### unGroup(Shape groupShape) {#unGroup-com.aspose.diagram.Shape-}
+```
+public void unGroup(Shape groupShape)
+```
+
+
+Avgruppera formen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| groupShape | [Shape](../../com.aspose.diagram/shape) | gruppformen. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapefixedcode/_index.md
+++ b/swedish/java/com.aspose.diagram/shapefixedcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeFixedCode
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar placeringsbeteende för en placerbar form.
+type: docs
+weight: 357
+url: /sv/java/com.aspose.diagram/shapefixedcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeFixedCode
+```
+
+Specificerar placeringsbeteende för en placerbar form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapeFixedCode(int value)](#ShapeFixedCode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar placeringsbeteende för en placerbar form. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeFixedCode(int value) {#ShapeFixedCode-int-}
+```
+public ShapeFixedCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar placeringsbeteende för en placerbar form.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapefixedcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapefixedcodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapefixedcodevalue/_index.md
@@ -1,0 +1,192 @@
+---
+title: ShapeFixedCodeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar placeringsbeteende för en placerbar form.
+type: docs
+weight: 358
+url: /sv/java/com.aspose.diagram/shapefixedcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeFixedCodeValue
+```
+
+Specificerar placeringsbeteende för en placerbar form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS](#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS) | Tillåt endast routning till sidor med anslutningspunkter. |
+| [IGNORE_CONNECTION_POINT](#IGNORE-CONNECTION-POINT) | Ignorera anslutningspunkternas positioner när du routas till. |
+| [NO_GLUE_TO_PERIMETER](#NO-GLUE-TO-PERIMETER) | Klistra inte fast i omkretsen av den här formen. |
+| [NO_MOVE_ALLOW_SHAPES_PLACED](#NO-MOVE-ALLOW-SHAPES-PLACED) | Flytta inte den här formen men tillåt att andra placerbara former placeras på den. |
+| [NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED](#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED) | Flytta inte den här formen och tillåt inte att andra placerbara former placeras på den. |
+| [NO_MOVE_USING_LAY_OUT_SHAPES](#NO-MOVE-USING-LAY-OUT-SHAPES) | Flytta inte den här formen när du använder kommandot Lay Out Shapes i Microsoft Visio. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS {#ALLOW-ROUTING-TO-SIDES-WITH-CONNECTION-POINTS}
+```
+public static final int ALLOW_ROUTING_TO_SIDES_WITH_CONNECTION_POINTS
+```
+
+
+Tillåt endast routning till sidor med anslutningspunkter.
+
+### IGNORE_CONNECTION_POINT {#IGNORE-CONNECTION-POINT}
+```
+public static final int IGNORE_CONNECTION_POINT
+```
+
+
+Ignorera anslutningspunkternas positioner när du routas till.
+
+### NO_GLUE_TO_PERIMETER {#NO-GLUE-TO-PERIMETER}
+```
+public static final int NO_GLUE_TO_PERIMETER
+```
+
+
+Klistra inte fast i omkretsen av den här formen. Klistra fast i formens justeringsruta istället.
+
+### NO_MOVE_ALLOW_SHAPES_PLACED {#NO-MOVE-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_ALLOW_SHAPES_PLACED
+```
+
+
+Flytta inte den här formen men tillåt att andra placerbara former placeras på den.
+
+### NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED {#NO-MOVE-AND-NO-ALLOW-SHAPES-PLACED}
+```
+public static final int NO_MOVE_AND_NO_ALLOW_SHAPES_PLACED
+```
+
+
+Flytta inte den här formen och tillåt inte att andra placerbara former placeras på den.
+
+### NO_MOVE_USING_LAY_OUT_SHAPES {#NO-MOVE-USING-LAY-OUT-SHAPES}
+```
+public static final int NO_MOVE_USING_LAY_OUT_SHAPES
+```
+
+
+Flytta inte den här formen när du använder kommandot Lay Out Shapes i Microsoft Visio.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplaceflip/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplaceflip/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceFlip
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur en placerbar form vänds och/eller roteras på sidan när en användare väljer menyn Lay Out Shapes Shapes.
+type: docs
+weight: 359
+url: /sv/java/com.aspose.diagram/shapeplaceflip/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceFlip
+```
+
+Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn).
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapePlaceFlip(int value)](#ShapePlaceFlip-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn). |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceFlip(int value) {#ShapePlaceFlip-int-}
+```
+public ShapePlaceFlip(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeplaceflip\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplaceflipvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: ShapePlaceFlipValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger hur en placerbar form vänds och/eller roteras på sidan när en användare väljer menyn Lay Out Shapes Shapes.
+type: docs
+weight: 360
+url: /sv/java/com.aspose.diagram/shapeplaceflipvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceFlipValue
+```
+
+Specificerar hur en placerbar form vänds och/eller roteras på sidan när en användare väljer Lay Out Shapes (Shapes-menyn).
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270](#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270) | Vänd i steg om 90 grader mellan 0 och 270. |
+| [FLIP_HORIZONTAL](#FLIP-HORIZONTAL) | Vänd horisontellt. |
+| [FLIP_VERTICAL](#FLIP-VERTICAL) | Vänd vertikalt. |
+| [NO_FLIP](#NO-FLIP) | Ingen vändning. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Använd sidans standard. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270 {#FLIP-90-DEGREE-INCREMENT-BETWEEN-0-AND-270}
+```
+public static final int FLIP_90_DEGREE_INCREMENT_BETWEEN_0_AND_270
+```
+
+
+Vänd i steg om 90 grader mellan 0 och 270.
+
+### FLIP_HORIZONTAL {#FLIP-HORIZONTAL}
+```
+public static final int FLIP_HORIZONTAL
+```
+
+
+Vänd horisontellt.
+
+### FLIP_VERTICAL {#FLIP-VERTICAL}
+```
+public static final int FLIP_VERTICAL
+```
+
+
+Vänd vertikalt.
+
+### NO_FLIP {#NO-FLIP}
+```
+public static final int NO_FLIP
+```
+
+
+Ingen vändning.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Använd sidans standard.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplacestyle/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplacestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlaceStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer placeringsstil för underordnade.
+type: docs
+weight: 361
+url: /sv/java/com.aspose.diagram/shapeplacestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlaceStyle
+```
+
+Bestämmer placeringsstil för underordnade.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapePlaceStyle(int value)](#ShapePlaceStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Bestämmer utseendet på en anslutning. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlaceStyle(int value) {#ShapePlaceStyle-int-}
+```
+public ShapePlaceStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Bestämmer utseendet på en anslutning.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shapeplacestyle\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplacestylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplacestylevalue/_index.md
@@ -1,0 +1,390 @@
+---
+title: ShapePlaceStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Bestämmer placeringsstil för underordnade.
+type: docs
+weight: 362
+url: /sv/java/com.aspose.diagram/shapeplacestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlaceStyleValue
+```
+
+Bestämmer placeringsstil för underordnade.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [PLACE_BOTTOM_TO_TOP](#PLACE-BOTTOM-TO-TOP) | Placera botten till toppen. |
+| [PLACE_CIRCULAR](#PLACE-CIRCULAR) | Placera cirkulärt. |
+| [PLACE_COMPACT_DOWN_LEFT](#PLACE-COMPACT-DOWN-LEFT) | Placera kompakt ner vänster. |
+| [PLACE_COMPACT_DOWN_RIGHT](#PLACE-COMPACT-DOWN-RIGHT) | Placera kompakt ner höger. |
+| [PLACE_COMPACT_LEFT_DOWN](#PLACE-COMPACT-LEFT-DOWN) | Placera kompakt vänster ner. |
+| [PLACE_COMPACT_LEFT_UP](#PLACE-COMPACT-LEFT-UP) | Placera kompakt vänster upp. |
+| [PLACE_COMPACT_RIGHT_DOWN](#PLACE-COMPACT-RIGHT-DOWN) | Placera kompakt höger ner. |
+| [PLACE_COMPACT_RIGHT_UP](#PLACE-COMPACT-RIGHT-UP) | Placera kompakt höger upp. |
+| [PLACE_COMPACT_UP_LEFT](#PLACE-COMPACT-UP-LEFT) | Placera kompakt upp vänster. |
+| [PLACE_COMPACT_UP_RIGHT](#PLACE-COMPACT-UP-RIGHT) | Placera kompakt upp höger. |
+| [PLACE_DEFAULT](#PLACE-DEFAULT) | Placera standard. |
+| [PLACE_HIERARCHY_BOTTOM_TO_CENTER](#PLACE-HIERARCHY-BOTTOM-TO-CENTER) | Placera hierarkin botten till mitten. |
+| [PLACE_HIERARCHY_BOTTOM_TO_LEFT](#PLACE-HIERARCHY-BOTTOM-TO-LEFT) | Placera hierarkin botten till vänster. |
+| [PLACE_HIERARCHY_BOTTOM_TO_RIGHT](#PLACE-HIERARCHY-BOTTOM-TO-RIGHT) | Placera hierarkin botten till höger. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM](#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM) | placera hierarkin vänster till höger botten. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE](#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE) | Placera hierarkin vänster till höger mitten. |
+| [PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP](#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP) | Placera hierarkin vänster till höger topp. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM](#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM) | Placera hierarkin höger till vänster botten. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE](#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE) | Placera hierarkin höger till vänster topp. |
+| [PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP](#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP) | Placera hierarkin höger till vänster topp. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER](#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER) | Placera hierarkin topp till botten mitten. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT) | Placera hierarkin topp till botten vänster. |
+| [PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT](#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT) | Placera hierarkin topp till botten höger. |
+| [PLACE_PARENT_DEFAULT](#PLACE-PARENT-DEFAULT) | Placera förälderns standard. |
+| [PLACE_RADIAL](#PLACE-RADIAL) | Placera radiell. |
+| [PLACE_RIGHT_TO_LEFT](#PLACE-RIGHT-TO-LEFT) | Placera höger till vänster. |
+| [PLACE_TOP_TO_BOTTOM](#PLACE-TOP-TO-BOTTOM) | Placera topp till botten. |
+| [PLACE_TO_RIGHT](#PLACE-TO-RIGHT) | Placera till höger. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PLACE_BOTTOM_TO_TOP {#PLACE-BOTTOM-TO-TOP}
+```
+public static final int PLACE_BOTTOM_TO_TOP
+```
+
+
+Placera botten till toppen.
+
+### PLACE_CIRCULAR {#PLACE-CIRCULAR}
+```
+public static final int PLACE_CIRCULAR
+```
+
+
+Placera cirkulärt.
+
+### PLACE_COMPACT_DOWN_LEFT {#PLACE-COMPACT-DOWN-LEFT}
+```
+public static final int PLACE_COMPACT_DOWN_LEFT
+```
+
+
+Placera kompakt ner vänster.
+
+### PLACE_COMPACT_DOWN_RIGHT {#PLACE-COMPACT-DOWN-RIGHT}
+```
+public static final int PLACE_COMPACT_DOWN_RIGHT
+```
+
+
+Placera kompakt ner höger.
+
+### PLACE_COMPACT_LEFT_DOWN {#PLACE-COMPACT-LEFT-DOWN}
+```
+public static final int PLACE_COMPACT_LEFT_DOWN
+```
+
+
+Placera kompakt vänster ner.
+
+### PLACE_COMPACT_LEFT_UP {#PLACE-COMPACT-LEFT-UP}
+```
+public static final int PLACE_COMPACT_LEFT_UP
+```
+
+
+Placera kompakt vänster upp.
+
+### PLACE_COMPACT_RIGHT_DOWN {#PLACE-COMPACT-RIGHT-DOWN}
+```
+public static final int PLACE_COMPACT_RIGHT_DOWN
+```
+
+
+Placera kompakt höger ner.
+
+### PLACE_COMPACT_RIGHT_UP {#PLACE-COMPACT-RIGHT-UP}
+```
+public static final int PLACE_COMPACT_RIGHT_UP
+```
+
+
+Placera kompakt höger upp.
+
+### PLACE_COMPACT_UP_LEFT {#PLACE-COMPACT-UP-LEFT}
+```
+public static final int PLACE_COMPACT_UP_LEFT
+```
+
+
+Placera kompakt upp vänster.
+
+### PLACE_COMPACT_UP_RIGHT {#PLACE-COMPACT-UP-RIGHT}
+```
+public static final int PLACE_COMPACT_UP_RIGHT
+```
+
+
+Placera kompakt upp höger.
+
+### PLACE_DEFAULT {#PLACE-DEFAULT}
+```
+public static final int PLACE_DEFAULT
+```
+
+
+Placera standard.
+
+### PLACE_HIERARCHY_BOTTOM_TO_CENTER {#PLACE-HIERARCHY-BOTTOM-TO-CENTER}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_CENTER
+```
+
+
+Placera hierarkin botten till mitten.
+
+### PLACE_HIERARCHY_BOTTOM_TO_LEFT {#PLACE-HIERARCHY-BOTTOM-TO-LEFT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_LEFT
+```
+
+
+Placera hierarkin botten till vänster.
+
+### PLACE_HIERARCHY_BOTTOM_TO_RIGHT {#PLACE-HIERARCHY-BOTTOM-TO-RIGHT}
+```
+public static final int PLACE_HIERARCHY_BOTTOM_TO_RIGHT
+```
+
+
+Placera hierarkin botten till höger.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM {#PLACE-HIERARCHY-LEFT-TO-RIGHT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_BOTTOM
+```
+
+
+placera hierarkin vänster till höger botten.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE {#PLACE-HIERARCHY-LEFT-TO-RIGHT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_MIDDLE
+```
+
+
+Placera hierarkin vänster till höger mitten.
+
+### PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP {#PLACE-HIERARCHY-LEFT-TO-RIGHT-TOP}
+```
+public static final int PLACE_HIERARCHY_LEFT_TO_RIGHT_TOP
+```
+
+
+Placera hierarkin vänster till höger topp.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM {#PLACE-HIERARCHY-RIGHT-TO-LEFT-BOTTOM}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_BOTTOM
+```
+
+
+Placera hierarkin höger till vänster botten.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE {#PLACE-HIERARCHY-RIGHT-TO-LEFT-MIDDLE}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_MIDDLE
+```
+
+
+Placera hierarkin höger till vänster topp.
+
+### PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP {#PLACE-HIERARCHY-RIGHT-TO-LEFT-TOP}
+```
+public static final int PLACE_HIERARCHY_RIGHT_TO_LEFT_TOP
+```
+
+
+Placera hierarkin höger till vänster topp.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER {#PLACE-HIERARCHY-TOP-TO-BOTTOM-CENTER}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_CENTER
+```
+
+
+Placera hierarkin topp till botten mitten.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-LEFT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_LEFT
+```
+
+
+Placera hierarkin topp till botten vänster.
+
+### PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT {#PLACE-HIERARCHY-TOP-TO-BOTTOM-RIGHT}
+```
+public static final int PLACE_HIERARCHY_TOP_TO_BOTTOM_RIGHT
+```
+
+
+Placera hierarkin topp till botten höger.
+
+### PLACE_PARENT_DEFAULT {#PLACE-PARENT-DEFAULT}
+```
+public static final int PLACE_PARENT_DEFAULT
+```
+
+
+Placera förälderns standard.
+
+### PLACE_RADIAL {#PLACE-RADIAL}
+```
+public static final int PLACE_RADIAL
+```
+
+
+Placera radiell.
+
+### PLACE_RIGHT_TO_LEFT {#PLACE-RIGHT-TO-LEFT}
+```
+public static final int PLACE_RIGHT_TO_LEFT
+```
+
+
+Placera höger till vänster.
+
+### PLACE_TOP_TO_BOTTOM {#PLACE-TOP-TO-BOTTOM}
+```
+public static final int PLACE_TOP_TO_BOTTOM
+```
+
+
+Placera topp till botten.
+
+### PLACE_TO_RIGHT {#PLACE-TO-RIGHT}
+```
+public static final int PLACE_TO_RIGHT
+```
+
+
+Placera till höger.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplowcode/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplowcode/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapePlowCode
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+type: docs
+weight: 363
+url: /sv/java/com.aspose.diagram/shapeplowcode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapePlowCode
+```
+
+Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapePlowCode(int value)](#ShapePlowCode-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapePlowCode(int value) {#ShapePlowCode-int-}
+```
+public ShapePlowCode(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeplowcode\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeplowcodevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeplowcodevalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapePlowCodeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+type: docs
+weight: 364
+url: /sv/java/com.aspose.diagram/shapeplowcodevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapePlowCodeValue
+```
+
+Specificerar om en placerbar form flyttar sig när du drar en annan placerbar form nära formen på ritningssidan.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [MOVE_SHAPE](#MOVE-SHAPE) | Flytta form. |
+| [NOMOVE_SHAPE](#NOMOVE-SHAPE) | Flytta inte form. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [USE_PAGE_DEFAULT](#USE-PAGE-DEFAULT) | Använd sidans standard. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MOVE_SHAPE {#MOVE-SHAPE}
+```
+public static final int MOVE_SHAPE
+```
+
+
+Flytta form.
+
+### NOMOVE_SHAPE {#NOMOVE-SHAPE}
+```
+public static final int NOMOVE_SHAPE
+```
+
+
+Flytta inte form.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### USE_PAGE_DEFAULT {#USE-PAGE-DEFAULT}
+```
+public static final int USE_PAGE_DEFAULT
+```
+
+
+Använd sidans standard.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shaperoutestyle/_index.md
+++ b/swedish/java/com.aspose.diagram/shaperoutestyle/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeRouteStyle
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+type: docs
+weight: 365
+url: /sv/java/com.aspose.diagram/shaperoutestyle/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeRouteStyle
+```
+
+Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapeRouteStyle(int value)](#ShapeRouteStyle-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Specificerar routningsstil och riktning för en anslutning på ritningssidan. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeRouteStyle(int value) {#ShapeRouteStyle-int-}
+```
+public ShapeRouteStyle(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shaperoutestyle\\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shaperoutestylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shaperoutestylevalue/_index.md
@@ -1,0 +1,345 @@
+---
+title: ShapeRouteStyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+type: docs
+weight: 366
+url: /sv/java/com.aspose.diagram/shaperoutestylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeRouteStyleValue
+```
+
+Specificerar routningsstil och riktning för en anslutning på ritningssidan.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CENTER_TO_CENTER](#CENTER-TO-CENTER) | Centrum till centrum. |
+| [FLOWCHART_BOTTOM_TO_TOP](#FLOWCHART-BOTTOM-TO-TOP) | Flödesschema. |
+| [FLOWCHART_LEFT_TO_RIGHT](#FLOWCHART-LEFT-TO-RIGHT) | Flödesschema. |
+| [FLOWCHART_RIGHT_TO_LEFT](#FLOWCHART-RIGHT-TO-LEFT) | Flödesschema. |
+| [FLOWCHART_TOP_TO_BOTTOM](#FLOWCHART-TOP-TO-BOTTOM) | Flödesschema. |
+| [NETWORK](#NETWORK) | Nätverk |
+| [ORGANIZATION_CHART_BOTTOM_TO_TOP](#ORGANIZATION-CHART-BOTTOM-TO-TOP) | Organisationsschema. |
+| [ORGANIZATION_CHART_LEFT_TO_RIGHT](#ORGANIZATION-CHART-LEFT-TO-RIGHT) | Organisationsschema. |
+| [ORGANIZATION_CHART_RIGHT_TO_LEFT](#ORGANIZATION-CHART-RIGHT-TO-LEFT) | Organisationsschema. |
+| [ORGANIZATION_CHART_TOP_TO_BOTTOM](#ORGANIZATION-CHART-TOP-TO-BOTTOM) | Organisationsschema. |
+| [PAGE_DEFAULT](#PAGE-DEFAULT) | Sidstandard. |
+| [RIGHT_ANGLE](#RIGHT-ANGLE) | Rät vinkel. |
+| [SIMPLE_BOTTOM_TO_TOP](#SIMPLE-BOTTOM-TO-TOP) | Enkel. |
+| [SIMPLE_HORIZONTAL_VERTICAL](#SIMPLE-HORIZONTAL-VERTICAL) | Enkel horisontell-vertikal. |
+| [SIMPLE_LEFT_TO_RIGHT](#SIMPLE-LEFT-TO-RIGHT) | Enkel. |
+| [SIMPLE_RIGHT_TO_LEFT](#SIMPLE-RIGHT-TO-LEFT) | Enkel. |
+| [SIMPLE_TOP_TO_BOTTOM](#SIMPLE-TOP-TO-BOTTOM) | Enkel. |
+| [SIMPLE_VERTICAL_HORIZONTAL](#SIMPLE-VERTICAL-HORIZONTAL) | Enkel vertikal-horisontell. |
+| [STRAIGHT](#STRAIGHT) | Rak. |
+| [TREE_BOTTOM_TO_TOP](#TREE-BOTTOM-TO-TOP) | Träd. |
+| [TREE_LEFT_TO_RIGHT](#TREE-LEFT-TO-RIGHT) | Träd. |
+| [TREE_RIGHT_TO_LEFT](#TREE-RIGHT-TO-LEFT) | Träd. |
+| [TREE_TOP_TO_BOTTOM](#TREE-TOP-TO-BOTTOM) | Träd. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTER_TO_CENTER {#CENTER-TO-CENTER}
+```
+public static final int CENTER_TO_CENTER
+```
+
+
+Centrum till centrum.
+
+### FLOWCHART_BOTTOM_TO_TOP {#FLOWCHART-BOTTOM-TO-TOP}
+```
+public static final int FLOWCHART_BOTTOM_TO_TOP
+```
+
+
+Flödesschema. Botten till toppen.
+
+### FLOWCHART_LEFT_TO_RIGHT {#FLOWCHART-LEFT-TO-RIGHT}
+```
+public static final int FLOWCHART_LEFT_TO_RIGHT
+```
+
+
+Flödesschema. Vänster till höger.
+
+### FLOWCHART_RIGHT_TO_LEFT {#FLOWCHART-RIGHT-TO-LEFT}
+```
+public static final int FLOWCHART_RIGHT_TO_LEFT
+```
+
+
+Flödesschema. Höger till vänster.
+
+### FLOWCHART_TOP_TO_BOTTOM {#FLOWCHART-TOP-TO-BOTTOM}
+```
+public static final int FLOWCHART_TOP_TO_BOTTOM
+```
+
+
+Flödesschema. Toppen till botten.
+
+### NETWORK {#NETWORK}
+```
+public static final int NETWORK
+```
+
+
+Nätverk
+
+### ORGANIZATION_CHART_BOTTOM_TO_TOP {#ORGANIZATION-CHART-BOTTOM-TO-TOP}
+```
+public static final int ORGANIZATION_CHART_BOTTOM_TO_TOP
+```
+
+
+Organisationsschema. Botten till toppen.
+
+### ORGANIZATION_CHART_LEFT_TO_RIGHT {#ORGANIZATION-CHART-LEFT-TO-RIGHT}
+```
+public static final int ORGANIZATION_CHART_LEFT_TO_RIGHT
+```
+
+
+Organisationsschema. Vänster till höger.
+
+### ORGANIZATION_CHART_RIGHT_TO_LEFT {#ORGANIZATION-CHART-RIGHT-TO-LEFT}
+```
+public static final int ORGANIZATION_CHART_RIGHT_TO_LEFT
+```
+
+
+Organisationsschema. Höger till vänster.
+
+### ORGANIZATION_CHART_TOP_TO_BOTTOM {#ORGANIZATION-CHART-TOP-TO-BOTTOM}
+```
+public static final int ORGANIZATION_CHART_TOP_TO_BOTTOM
+```
+
+
+Organisationsschema. Riktning topp till botten.
+
+### PAGE_DEFAULT {#PAGE-DEFAULT}
+```
+public static final int PAGE_DEFAULT
+```
+
+
+Sidstandard.
+
+### RIGHT_ANGLE {#RIGHT-ANGLE}
+```
+public static final int RIGHT_ANGLE
+```
+
+
+Rät vinkel.
+
+### SIMPLE_BOTTOM_TO_TOP {#SIMPLE-BOTTOM-TO-TOP}
+```
+public static final int SIMPLE_BOTTOM_TO_TOP
+```
+
+
+Enkel. Botten till toppen.
+
+### SIMPLE_HORIZONTAL_VERTICAL {#SIMPLE-HORIZONTAL-VERTICAL}
+```
+public static final int SIMPLE_HORIZONTAL_VERTICAL
+```
+
+
+Enkel horisontell-vertikal.
+
+### SIMPLE_LEFT_TO_RIGHT {#SIMPLE-LEFT-TO-RIGHT}
+```
+public static final int SIMPLE_LEFT_TO_RIGHT
+```
+
+
+Enkel. Vänster till höger.
+
+### SIMPLE_RIGHT_TO_LEFT {#SIMPLE-RIGHT-TO-LEFT}
+```
+public static final int SIMPLE_RIGHT_TO_LEFT
+```
+
+
+Enkel. Höger till vänster.
+
+### SIMPLE_TOP_TO_BOTTOM {#SIMPLE-TOP-TO-BOTTOM}
+```
+public static final int SIMPLE_TOP_TO_BOTTOM
+```
+
+
+Enkel. Uppifrån och ner.
+
+### SIMPLE_VERTICAL_HORIZONTAL {#SIMPLE-VERTICAL-HORIZONTAL}
+```
+public static final int SIMPLE_VERTICAL_HORIZONTAL
+```
+
+
+Enkel vertikal-horisontell.
+
+### STRAIGHT {#STRAIGHT}
+```
+public static final int STRAIGHT
+```
+
+
+Rak.
+
+### TREE_BOTTOM_TO_TOP {#TREE-BOTTOM-TO-TOP}
+```
+public static final int TREE_BOTTOM_TO_TOP
+```
+
+
+Träd. Botten till toppen.
+
+### TREE_LEFT_TO_RIGHT {#TREE-LEFT-TO-RIGHT}
+```
+public static final int TREE_LEFT_TO_RIGHT
+```
+
+
+Träd. Vänster till höger
+
+### TREE_RIGHT_TO_LEFT {#TREE-RIGHT-TO-LEFT}
+```
+public static final int TREE_RIGHT_TO_LEFT
+```
+
+
+Träd. Höger till vänster.
+
+### TREE_TOP_TO_BOTTOM {#TREE-TOP-TO-BOTTOM}
+```
+public static final int TREE_TOP_TO_BOTTOM
+```
+
+
+Träd. Uppifrån och ner.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeshdwshow/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeshdwshow/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwShow
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 367
+url: /sv/java/com.aspose.diagram/shapeshdwshow/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwShow
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapeShdwShow(int value)](#ShapeShdwShow-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av skugga för en form. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwShow(int value) {#ShapeShdwShow-int-}
+```
+public ShapeShdwShow(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av skugga för en form.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeshdwshow\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeshdwshowvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: ShapeShdwShowValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 368
+url: /sv/java/com.aspose.diagram/shapeshdwshowvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwShowValue
+```
+
+Anger typen av skugga för en form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALWAYS_SHOW](#ALWAYS-SHOW) | Specificerar att skuggeffektsatsen alltid visas. |
+| [HAS_GEOM_SHOW](#HAS-GEOM-SHOW) | Specificerar att skuggeffektsatsen visas endast om formen har en Geometry Section\_Type. |
+| [TOP_LEVEL_SHOW](#TOP-LEVEL-SHOW) | Specificerar att skuggeffektsatsen visas endast om formen har en Geometry Section\_Type och formen är en top‑nivåform. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS_SHOW {#ALWAYS-SHOW}
+```
+public static final int ALWAYS_SHOW
+```
+
+
+Specificerar att skuggeffektsatsen alltid visas.
+
+### HAS_GEOM_SHOW {#HAS-GEOM-SHOW}
+```
+public static final int HAS_GEOM_SHOW
+```
+
+
+Specificerar att skuggeffektsatsen visas endast om formen har en Geometry Section\_Type.
+
+### TOP_LEVEL_SHOW {#TOP-LEVEL-SHOW}
+```
+public static final int TOP_LEVEL_SHOW
+```
+
+
+Specificerar att skuggeffektsatsen visas endast om formen har en Geometry Section\_Type och formen är en top‑nivåform.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeshdwtype/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeshdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShapeShdwType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 369
+url: /sv/java/com.aspose.diagram/shapeshdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShapeShdwType
+```
+
+Anger typen av skugga för en form.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShapeShdwType(int value)](#ShapeShdwType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger typen av skugga för en form. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShapeShdwType(int value) {#ShapeShdwType-int-}
+```
+public ShapeShdwType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger typen av skugga för en form.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/shapeshdwtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shapeshdwtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: ShapeShdwTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger typen av skugga för en form.
+type: docs
+weight: 370
+url: /sv/java/com.aspose.diagram/shapeshdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShapeShdwTypeValue
+```
+
+Anger typen av skugga för en form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [INNER](#INNER) | Inre |
+| [OBLIQUE](#OBLIQUE) | Sned. |
+| [SIMPLE](#SIMPLE) | Enkel. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [USE_PAGE](#USE-PAGE) | Använd sidans standard (standard). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INNER {#INNER}
+```
+public static final int INNER
+```
+
+
+Inre
+
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Sned.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Enkel.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### USE_PAGE {#USE-PAGE}
+```
+public static final int USE_PAGE
+```
+
+
+Använd sidans standard (standard).
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shdwtype/_index.md
+++ b/swedish/java/com.aspose.diagram/shdwtype/_index.md
@@ -1,0 +1,179 @@
+---
+title: ShdwType
+second_title: Aspose.Diagram för Java API-referens
+description: Anger standardskuggtyp för en sida.
+type: docs
+weight: 371
+url: /sv/java/com.aspose.diagram/shdwtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ShdwType
+```
+
+Anger standardskuggtyp för en sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ShdwType(int value)](#ShdwType-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger standardskuggtyp för en sida. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shdwtype\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ShdwType(int value) {#ShdwType-int-}
+```
+public ShdwType(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger standardskuggtyp för en sida.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/shdwtype\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/shdwtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/shdwtypevalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: ShdwTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger standardskuggtyp för en sida.
+type: docs
+weight: 372
+url: /sv/java/com.aspose.diagram/shdwtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShdwTypeValue
+```
+
+Anger standardskuggtyp för en sida.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [OBLIQUE](#OBLIQUE) | Sned. |
+| [SIMPLE](#SIMPLE) | Enkel. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OBLIQUE {#OBLIQUE}
+```
+public static final int OBLIQUE
+```
+
+
+Sned.
+
+### SIMPLE {#SIMPLE}
+```
+public static final int SIMPLE
+```
+
+
+Enkel.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/showdropbuttontype/_index.md
+++ b/swedish/java/com.aspose.diagram/showdropbuttontype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VisaNedrullningsknappTyp
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar när droppknappen ska visas
+type: docs
+weight: 373
+url: /sv/java/com.aspose.diagram/showdropbuttontype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ShowDropButtonType
+```
+
+Specificerar när droppknappen ska visas
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALWAYS](#ALWAYS) | Visa alltid nedrullningsknappen. |
+| [FOCUS](#FOCUS) | Visa nedrullningsknappen när kontrollen har fokus. |
+| [NEVER](#NEVER) | Visa aldrig nedrullningsknappen. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALWAYS {#ALWAYS}
+```
+public static final int ALWAYS
+```
+
+
+Visa alltid nedrullningsknappen.
+
+### FOCUS {#FOCUS}
+```
+public static final int FOCUS
+```
+
+
+Visa nedrullningsknappen när kontrollen har fokus.
+
+### NEVER {#NEVER}
+```
+public static final int NEVER
+```
+
+
+Visa aldrig nedrullningsknappen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/smarttagdef/_index.md
+++ b/swedish/java/com.aspose.diagram/smarttagdef/_index.md
@@ -1,0 +1,337 @@
+---
+title: SmartTagDef
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som innehåller information för varje smart tag som definierats för en form eller sida.
+type: docs
+weight: 374
+url: /sv/java/com.aspose.diagram/smarttagdef/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SmartTagDef
+```
+
+Innehåller element som innehåller information för varje smart tag som definierats för en form eller sida.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SmartTagDef()](#SmartTagDef--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getButtonFace()](#getButtonFace--) | Den innehåller ID:t för knappens bild som visas på smarttag‑knappen. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getDescription()](#getDescription--) | Beskrivningselementet innehåller en sträng som beskriver smarttaggen, som visas som ett verktygstips när användaren håller musen över taggen. |
+| [getDisabled()](#getDisabled--) | Inaktiverat element bestämmer om smarttaggen visas i ritfönstret. |
+| [getDisplayMode()](#getDisplayMode--) | DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getTagName()](#getTagName--) | Den innehåller namnet på smarttaggen som används som nyckel för att associera smarttaggen med dess åtgärder. |
+| [getX()](#getX--) | x‑koordinatpositionen i figurens lokala koordinater runt vilken smarttag‑knappen placeras. |
+| [getXJustify()](#getXJustify--) | X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [getY()](#getY--) | y‑koordinatpositionen i figurens lokala koordinater runt vilken smarttag‑knappen placeras. |
+| [getYJustify()](#getYJustify--) | Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/smarttagdef\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/smarttagdef\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SmartTagDef() {#SmartTagDef--}
+```
+public SmartTagDef()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getButtonFace() {#getButtonFace--}
+```
+public Str2Value getButtonFace()
+```
+
+
+Den innehåller ID:t för knappens bild som visas på smarttag‑knappen.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getDescription() {#getDescription--}
+```
+public Str2Value getDescription()
+```
+
+
+Beskrivningselementet innehåller en sträng som beskriver smarttaggen, som visas som ett verktygstips när användaren håller musen över taggen.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getDisabled() {#getDisabled--}
+```
+public BoolValue getDisabled()
+```
+
+
+Inaktiverat element bestämmer om smarttaggen visas i ritfönstret.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getDisplayMode() {#getDisplayMode--}
+```
+public DisplayModeSmartTagDef getDisplayMode()
+```
+
+
+DisplayMode-elementet bestämmer om smart-taggen visas när användaren håller musen över taggen, när formen är markerad eller hela tiden.
+
+**Returns:**
+[DisplayModeSmartTagDef](../../com.aspose.diagram/displaymodesmarttagdef)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getTagName() {#getTagName--}
+```
+public Str2Value getTagName()
+```
+
+
+Den innehåller namnet på smarttaggen som används som nyckel för att associera smarttaggen med dess åtgärder.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x‑koordinatpositionen i figurens lokala koordinater runt vilken smarttag‑knappen placeras.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getXJustify() {#getXJustify--}
+```
+public XJustify getXJustify()
+```
+
+
+X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+
+**Returns:**
+[XJustify](../../com.aspose.diagram/xjustify)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y‑koordinatpositionen i figurens lokala koordinater runt vilken smarttag‑knappen placeras.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getYJustify() {#getYJustify--}
+```
+public YJustify getYJustify()
+```
+
+
+Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+
+**Returns:**
+[YJustify](../../com.aspose.diagram/yjustify)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/smarttagdef\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/smarttagdef\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/smarttagdef\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/smarttagdef\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/smarttagdefcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/smarttagdefcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: SmartTagDefCollection
+second_title: Aspose.Diagram för Java API-referens
+description: SmartTagDef-samling.
+type: docs
+weight: 375
+url: /sv/java/com.aspose.diagram/smarttagdefcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SmartTagDefCollection extends Collection
+```
+
+SmartTagDef-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(SmartTagDef item)](#add-com.aspose.diagram.SmartTagDef-) | Lägg till SmartTagDef‑objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SmartTagDef item)](#remove-com.aspose.diagram.SmartTagDef-) | Ta bort SmartTagDef‑objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SmartTagDef item) {#add-com.aspose.diagram.SmartTagDef-}
+```
+public int add(SmartTagDef item)
+```
+
+
+Lägg till SmartTagDef‑objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SmartTagDef get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[SmartTagDef](../../com.aspose.diagram/smarttagdef) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SmartTagDef item) {#remove-com.aspose.diagram.SmartTagDef-}
+```
+public void remove(SmartTagDef item)
+```
+
+
+Ta bort SmartTagDef‑objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [SmartTagDef](../../com.aspose.diagram/smarttagdef) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/smoothingmode/_index.md
+++ b/swedish/java/com.aspose.diagram/smoothingmode/_index.md
@@ -1,0 +1,183 @@
+---
+title: SmoothingMode
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om jämnande antialiasing tillämpas på linjer och kurvor samt kanterna på fyllda områden.
+type: docs
+weight: 376
+url: /sv/java/com.aspose.diagram/smoothingmode/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SmoothingMode
+```
+
+Specificerar om jämning (antialiasing) tillämpas på linjer och kurvor samt kanterna på fyllda områden.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ANTI_ALIAS](#ANTI-ALIAS) | Anger antialiasad rendering. |
+| [DEFAULT](#DEFAULT) | Anger ingen kantutjämning. |
+| [HIGH_QUALITY](#HIGH-QUALITY) | Anger antialiasad rendering. |
+| [HIGH_SPEED](#HIGH-SPEED) | Anger ingen kantutjämning. |
+| [INVALID](#INVALID) | Anger ett ogiltigt läge. |
+| [NONE](#NONE) | Anger ingen kantutjämning. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTI_ALIAS {#ANTI-ALIAS}
+```
+public static final int ANTI_ALIAS
+```
+
+
+Anger antialiasad rendering.
+
+### DEFAULT {#DEFAULT}
+```
+public static final int DEFAULT
+```
+
+
+Anger ingen kantutjämning.
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final int HIGH_QUALITY
+```
+
+
+Anger antialiasad rendering.
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final int HIGH_SPEED
+```
+
+
+Anger ingen kantutjämning.
+
+### INVALID {#INVALID}
+```
+public static final int INVALID
+```
+
+
+Anger ett ogiltigt läge.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Anger ingen kantutjämning.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/snapextensions/_index.md
+++ b/swedish/java/com.aspose.diagram/snapextensions/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensions
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret.
+type: docs
+weight: 377
+url: /sv/java/com.aspose.diagram/snapextensions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensions
+```
+
+Anger om en specifik snap‑inställning är aktiverad eller inaktiverad för det aktiva fönstret. Värdet kan vara en summa av värdena.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALIGNMENT_BOX_EXTENSION](#ALIGNMENT-BOX-EXTENSION) | Fäst till justeringsrutans förlängning. |
+| [CENTER_AXES](#CENTER-AXES) | Fäst till mittaxelns förlängning. |
+| [CURVE_EXTENSION](#CURVE-EXTENSION) | Fäst till kurvans förlängning. |
+| [CURVE_TANGENT](#CURVE-TANGENT) | Fäst till kurvtangentens förlängning. |
+| [ELLIPSE_CENTER](#ELLIPSE-CENTER) | Fäst till ellipsens centrumförlängning. |
+| [ENDPOINT](#ENDPOINT) | Fäst till slutpunktsförlängning. |
+| [ENDPOINT_HORIZONTAL](#ENDPOINT-HORIZONTAL) | Fäst till slutpunkts horisontella förlängning. |
+| [ENDPOINT_PERPENDICULAR](#ENDPOINT-PERPENDICULAR) | Fäst till slutpunkts vinkelräta förlängning. |
+| [ENDPOINT_VERTICAL](#ENDPOINT-VERTICAL) | Fäst till slutpunkts vertikala förlängning. |
+| [ISOMETRIC_ANGLES](#ISOMETRIC-ANGLES) | Fäst till isometriska vinkelförlängning. |
+| [LINEAR_EXTENSION](#LINEAR-EXTENSION) | Fäst till linjär förlängning. |
+| [MIDPOINT](#MIDPOINT) | Fäst till mittpunktsförlängning. |
+| [MIDPOINT_PERPENDICULAR](#MIDPOINT-PERPENDICULAR) | Fäst till mittpunkts vinkelräta förlängning. |
+| [NONE](#NONE) | Fäst mot ingenting. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX_EXTENSION {#ALIGNMENT-BOX-EXTENSION}
+```
+public static final int ALIGNMENT_BOX_EXTENSION
+```
+
+
+Fäst till justeringsrutans förlängning.
+
+### CENTER_AXES {#CENTER-AXES}
+```
+public static final int CENTER_AXES
+```
+
+
+Fäst till mittaxelns förlängning.
+
+### CURVE_EXTENSION {#CURVE-EXTENSION}
+```
+public static final int CURVE_EXTENSION
+```
+
+
+Fäst till kurvans förlängning.
+
+### CURVE_TANGENT {#CURVE-TANGENT}
+```
+public static final int CURVE_TANGENT
+```
+
+
+Fäst till kurvtangentens förlängning.
+
+### ELLIPSE_CENTER {#ELLIPSE-CENTER}
+```
+public static final int ELLIPSE_CENTER
+```
+
+
+Fäst till ellipsens centrumförlängning.
+
+### ENDPOINT {#ENDPOINT}
+```
+public static final int ENDPOINT
+```
+
+
+Fäst till slutpunktsförlängning.
+
+### ENDPOINT_HORIZONTAL {#ENDPOINT-HORIZONTAL}
+```
+public static final int ENDPOINT_HORIZONTAL
+```
+
+
+Fäst till slutpunkts horisontella förlängning.
+
+### ENDPOINT_PERPENDICULAR {#ENDPOINT-PERPENDICULAR}
+```
+public static final int ENDPOINT_PERPENDICULAR
+```
+
+
+Fäst till slutpunkts vinkelräta förlängning.
+
+### ENDPOINT_VERTICAL {#ENDPOINT-VERTICAL}
+```
+public static final int ENDPOINT_VERTICAL
+```
+
+
+Fäst till slutpunkts vertikala förlängning.
+
+### ISOMETRIC_ANGLES {#ISOMETRIC-ANGLES}
+```
+public static final int ISOMETRIC_ANGLES
+```
+
+
+Fäst till isometriska vinkelförlängning.
+
+### LINEAR_EXTENSION {#LINEAR-EXTENSION}
+```
+public static final int LINEAR_EXTENSION
+```
+
+
+Fäst till linjär förlängning.
+
+### MIDPOINT {#MIDPOINT}
+```
+public static final int MIDPOINT
+```
+
+
+Fäst till mittpunktsförlängning.
+
+### MIDPOINT_PERPENDICULAR {#MIDPOINT-PERPENDICULAR}
+```
+public static final int MIDPOINT_PERPENDICULAR
+```
+
+
+Fäst till mittpunkts vinkelräta förlängning.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Fäst mot ingenting.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/snapextensionsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/snapextensionsvalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: SnapExtensionsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret.
+type: docs
+weight: 378
+url: /sv/java/com.aspose.diagram/snapextensionsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapExtensionsValue
+```
+
+Anger om en specifik snap‑utökninginställning är aktiverad eller inaktiverad för det aktiva fönstret. Värdet kan vara en summa av värdena i följande tabell.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [SNAP_TO_ALIGNMENT_BOX_EXTENSION](#SNAP-TO-ALIGNMENT-BOX-EXTENSION) | Fäst till justeringsrutans förlängning. |
+| [SNAP_TO_CENTER_AXIS_EXTENSION](#SNAP-TO-CENTER-AXIS-EXTENSION) | Fäst till mittaxelns förlängning. |
+| [SNAP_TO_CURVE_EXTENSION](#SNAP-TO-CURVE-EXTENSION) | Fäst till kurvans förlängning. |
+| [SNAP_TO_CURVE_TANGENT_EXTENSION](#SNAP-TO-CURVE-TANGENT-EXTENSION) | Fäst till kurvtangentens förlängning. |
+| [SNAP_TO_ELLIPSE_CENTER_EXTENSION](#SNAP-TO-ELLIPSE-CENTER-EXTENSION) | Fäst till ellipsens centrumförlängning. |
+| [SNAP_TO_END_POINT_EXTENSION](#SNAP-TO-END-POINT-EXTENSION) | Fäst till slutpunktsförlängning. |
+| [SNAP_TO_END_POINT_HORIZONTAL_EXTENSION](#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION) | Fäst till slutpunkts horisontella förlängning. |
+| [SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION) | Fäst till slutpunkts vinkelräta förlängning. |
+| [SNAP_TO_END_POINT_VERTICAL_EXTENSION](#SNAP-TO-END-POINT-VERTICAL-EXTENSION) | Fäst till slutpunkts vertikala förlängning. |
+| [SNAP_TO_ISOMETRIC_ANGLES_EXTENSION](#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION) | Fäst till isometriska vinkelförlängning. |
+| [SNAP_TO_LINEAR_EXTENSION](#SNAP-TO-LINEAR-EXTENSION) | Fäst till linjär förlängning. |
+| [SNAP_TO_MID_POINT_EXTENSION](#SNAP-TO-MID-POINT-EXTENSION) | Fäst till mittpunktsförlängning. |
+| [SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION](#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION) | Fäst till mittpunkts vinkelräta förlängning. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Fäst mot ingenting. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_TO_ALIGNMENT_BOX_EXTENSION {#SNAP-TO-ALIGNMENT-BOX-EXTENSION}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX_EXTENSION
+```
+
+
+Fäst till justeringsrutans förlängning.
+
+### SNAP_TO_CENTER_AXIS_EXTENSION {#SNAP-TO-CENTER-AXIS-EXTENSION}
+```
+public static final int SNAP_TO_CENTER_AXIS_EXTENSION
+```
+
+
+Fäst till mittaxelns förlängning.
+
+### SNAP_TO_CURVE_EXTENSION {#SNAP-TO-CURVE-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_EXTENSION
+```
+
+
+Fäst till kurvans förlängning.
+
+### SNAP_TO_CURVE_TANGENT_EXTENSION {#SNAP-TO-CURVE-TANGENT-EXTENSION}
+```
+public static final int SNAP_TO_CURVE_TANGENT_EXTENSION
+```
+
+
+Fäst till kurvtangentens förlängning.
+
+### SNAP_TO_ELLIPSE_CENTER_EXTENSION {#SNAP-TO-ELLIPSE-CENTER-EXTENSION}
+```
+public static final int SNAP_TO_ELLIPSE_CENTER_EXTENSION
+```
+
+
+Fäst till ellipsens centrumförlängning.
+
+### SNAP_TO_END_POINT_EXTENSION {#SNAP-TO-END-POINT-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_EXTENSION
+```
+
+
+Fäst till slutpunktsförlängning.
+
+### SNAP_TO_END_POINT_HORIZONTAL_EXTENSION {#SNAP-TO-END-POINT-HORIZONTAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_HORIZONTAL_EXTENSION
+```
+
+
+Fäst till slutpunkts horisontella förlängning.
+
+### SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-END-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Fäst till slutpunkts vinkelräta förlängning.
+
+### SNAP_TO_END_POINT_VERTICAL_EXTENSION {#SNAP-TO-END-POINT-VERTICAL-EXTENSION}
+```
+public static final int SNAP_TO_END_POINT_VERTICAL_EXTENSION
+```
+
+
+Fäst till slutpunkts vertikala förlängning.
+
+### SNAP_TO_ISOMETRIC_ANGLES_EXTENSION {#SNAP-TO-ISOMETRIC-ANGLES-EXTENSION}
+```
+public static final int SNAP_TO_ISOMETRIC_ANGLES_EXTENSION
+```
+
+
+Fäst till isometriska vinkelförlängning.
+
+### SNAP_TO_LINEAR_EXTENSION {#SNAP-TO-LINEAR-EXTENSION}
+```
+public static final int SNAP_TO_LINEAR_EXTENSION
+```
+
+
+Fäst till linjär förlängning.
+
+### SNAP_TO_MID_POINT_EXTENSION {#SNAP-TO-MID-POINT-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_EXTENSION
+```
+
+
+Fäst till mittpunktsförlängning.
+
+### SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION {#SNAP-TO-MID-POINT-PERPENDICULAR-EXTENSION}
+```
+public static final int SNAP_TO_MID_POINT_PERPENDICULAR_EXTENSION
+```
+
+
+Fäst till mittpunkts vinkelräta förlängning.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Fäst mot ingenting.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/snapsettings/_index.md
+++ b/swedish/java/com.aspose.diagram/snapsettings/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettings
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret.
+type: docs
+weight: 379
+url: /sv/java/com.aspose.diagram/snapsettings/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettings
+```
+
+Specifies the objects that shapes snap to when snap is active in the window. The value may be a sum of the values.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ALIGNMENT_BOX](#ALIGNMENT-BOX) | Fäst mot justeringsruta. |
+| [CONNECTION_POINTS](#CONNECTION-POINTS) | Fäst mot anslutningspunkter. |
+| [DISABLED](#DISABLED) | Fästning inaktiverad. |
+| [EXTENSIONS](#EXTENSIONS) | Fäst mot alternativ för formutökningar. |
+| [GEOMETRY](#GEOMETRY) | Fäst mot de synliga kanterna på former. |
+| [GRID](#GRID) | Fäst mot rutnät. |
+| [GUIDES](#GUIDES) | Fäst mot hjälplinjer. |
+| [HANDLES](#HANDLES) | Fäst mot markeringshandtag. |
+| [INTERSECTIONS](#INTERSECTIONS) | Fäst mot korsningar. |
+| [NONE](#NONE) | Fäst mot ingenting. |
+| [RULER_SUBDIVISIONS](#RULER-SUBDIVISIONS) | Fäst mot linjalens delningar. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VERTICES](#VERTICES) | Fäst mot hörn. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ALIGNMENT_BOX {#ALIGNMENT-BOX}
+```
+public static final int ALIGNMENT_BOX
+```
+
+
+Fäst mot justeringsruta.
+
+### CONNECTION_POINTS {#CONNECTION-POINTS}
+```
+public static final int CONNECTION_POINTS
+```
+
+
+Fäst mot anslutningspunkter.
+
+### DISABLED {#DISABLED}
+```
+public static final int DISABLED
+```
+
+
+Fästning inaktiverad.
+
+### EXTENSIONS {#EXTENSIONS}
+```
+public static final int EXTENSIONS
+```
+
+
+Fäst mot alternativ för formutökningar.
+
+### GEOMETRY {#GEOMETRY}
+```
+public static final int GEOMETRY
+```
+
+
+Fäst mot de synliga kanterna på former.
+
+### GRID {#GRID}
+```
+public static final int GRID
+```
+
+
+Fäst mot rutnät.
+
+### GUIDES {#GUIDES}
+```
+public static final int GUIDES
+```
+
+
+Fäst mot hjälplinjer.
+
+### HANDLES {#HANDLES}
+```
+public static final int HANDLES
+```
+
+
+Fäst mot markeringshandtag.
+
+### INTERSECTIONS {#INTERSECTIONS}
+```
+public static final int INTERSECTIONS
+```
+
+
+Fäst mot korsningar.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Fäst mot ingenting.
+
+### RULER_SUBDIVISIONS {#RULER-SUBDIVISIONS}
+```
+public static final int RULER_SUBDIVISIONS
+```
+
+
+Fäst mot linjalens delningar.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VERTICES {#VERTICES}
+```
+public static final int VERTICES
+```
+
+
+Fäst mot hörn.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/snapsettingsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/snapsettingsvalue/_index.md
@@ -1,0 +1,246 @@
+---
+title: SnapSettingsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret
+type: docs
+weight: 380
+url: /sv/java/com.aspose.diagram/snapsettingsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class SnapSettingsValue
+```
+
+Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [SNAP_DISABLED](#SNAP-DISABLED) | Fästning inaktiverad. |
+| [SNAP_TO_ALIGNMENT_BOX](#SNAP-TO-ALIGNMENT-BOX) | Fäst mot justeringsruta. |
+| [SNAP_TO_CONNECTION_POINTS](#SNAP-TO-CONNECTION-POINTS) | Fäst mot anslutningspunkter. |
+| [SNAP_TO_GRID](#SNAP-TO-GRID) | Fäst mot rutnät. |
+| [SNAP_TO_GUIDES](#SNAP-TO-GUIDES) | Fäst mot hjälplinjer. |
+| [SNAP_TO_INTERSECTIONS](#SNAP-TO-INTERSECTIONS) | Fäst mot korsningar. |
+| [SNAP_TO_NOTHING](#SNAP-TO-NOTHING) | Fäst mot ingenting. |
+| [SNAP_TO_RULER_SUBDIVISIONS](#SNAP-TO-RULER-SUBDIVISIONS) | Fäst mot linjalens delningar. |
+| [SNAP_TO_SELECTION_HANDLES](#SNAP-TO-SELECTION-HANDLES) | Fäst mot markeringshandtag. |
+| [SNAP_TO_SHAPE_EXTENSIONS_OPTIONS](#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS) | Fäst mot alternativ för formutökningar. |
+| [SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES](#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES) | Fäst mot de synliga kanterna på former. |
+| [SNAP_TO_VERTICES](#SNAP-TO-VERTICES) | Fäst mot hörn. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SNAP_DISABLED {#SNAP-DISABLED}
+```
+public static final int SNAP_DISABLED
+```
+
+
+Fästning inaktiverad.
+
+### SNAP_TO_ALIGNMENT_BOX {#SNAP-TO-ALIGNMENT-BOX}
+```
+public static final int SNAP_TO_ALIGNMENT_BOX
+```
+
+
+Fäst mot justeringsruta.
+
+### SNAP_TO_CONNECTION_POINTS {#SNAP-TO-CONNECTION-POINTS}
+```
+public static final int SNAP_TO_CONNECTION_POINTS
+```
+
+
+Fäst mot anslutningspunkter.
+
+### SNAP_TO_GRID {#SNAP-TO-GRID}
+```
+public static final int SNAP_TO_GRID
+```
+
+
+Fäst mot rutnät.
+
+### SNAP_TO_GUIDES {#SNAP-TO-GUIDES}
+```
+public static final int SNAP_TO_GUIDES
+```
+
+
+Fäst mot hjälplinjer.
+
+### SNAP_TO_INTERSECTIONS {#SNAP-TO-INTERSECTIONS}
+```
+public static final int SNAP_TO_INTERSECTIONS
+```
+
+
+Fäst mot korsningar.
+
+### SNAP_TO_NOTHING {#SNAP-TO-NOTHING}
+```
+public static final int SNAP_TO_NOTHING
+```
+
+
+Fäst mot ingenting.
+
+### SNAP_TO_RULER_SUBDIVISIONS {#SNAP-TO-RULER-SUBDIVISIONS}
+```
+public static final int SNAP_TO_RULER_SUBDIVISIONS
+```
+
+
+Fäst mot linjalens delningar.
+
+### SNAP_TO_SELECTION_HANDLES {#SNAP-TO-SELECTION-HANDLES}
+```
+public static final int SNAP_TO_SELECTION_HANDLES
+```
+
+
+Fäst mot markeringshandtag.
+
+### SNAP_TO_SHAPE_EXTENSIONS_OPTIONS {#SNAP-TO-SHAPE-EXTENSIONS-OPTIONS}
+```
+public static final int SNAP_TO_SHAPE_EXTENSIONS_OPTIONS
+```
+
+
+Fäst mot alternativ för formutökningar.
+
+### SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES {#SNAP-TO-THE-VISIBLE-EDGES-OF-SHAPES}
+```
+public static final int SNAP_TO_THE_VISIBLE_EDGES_OF_SHAPES
+```
+
+
+Fäst mot de synliga kanterna på former.
+
+### SNAP_TO_VERTICES {#SNAP-TO-VERTICES}
+```
+public static final int SNAP_TO_VERTICES
+```
+
+
+Fäst mot hörn.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/solutionxml/_index.md
+++ b/swedish/java/com.aspose.diagram/solutionxml/_index.md
@@ -1,0 +1,214 @@
+---
+title: SolutionXML
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller lösningsspecifik välformad XML-data som är prefixad i ett explicit namnrymd och lagras med ett dokument.
+type: docs
+weight: 381
+url: /sv/java/com.aspose.diagram/solutionxml/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class SolutionXML
+```
+
+Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SolutionXML(String name, String xmlValue)](#SolutionXML-java.lang.String-java.lang.String-) | Konstruktor. |
+| [SolutionXML()](#SolutionXML--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | Ett unikt namn för att identifiera XML-datasetet. |
+| [getXmlValue()](#getXmlValue--) | Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/solutionxml\#getName--) |
+| [setXmlValue(String value)](#setXmlValue-java.lang.String-) | För beskrivningen av den här egenskapen, se [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SolutionXML(String name, String xmlValue) {#SolutionXML-java.lang.String-java.lang.String-}
+```
+public SolutionXML(String name, String xmlValue)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+| xmlValue | java.lang.String |  |
+
+### SolutionXML() {#SolutionXML--}
+```
+public SolutionXML()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Ett unikt namn för att identifiera XML-datasetet.
+
+**Returns:**
+java.lang.String
+### getXmlValue() {#getXmlValue--}
+```
+public String getXmlValue()
+```
+
+
+Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/solutionxml\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setXmlValue(String value) {#setXmlValue-java.lang.String-}
+```
+public void setXmlValue(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getXmlValue()](../../com.aspose.diagram/solutionxml\#getXmlValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/solutionxmlcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/solutionxmlcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: SolutionXMLCollection
+second_title: Aspose.Diagram för Java API-referens
+description: SolutionXML-samling.
+type: docs
+weight: 382
+url: /sv/java/com.aspose.diagram/solutionxmlcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SolutionXMLCollection extends Collection
+```
+
+SolutionXML-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(SolutionXML solutionXml)](#add-com.aspose.diagram.SolutionXML-) | Lägg till SolutionXML i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [get(String name)](#get-java.lang.String-) | Hämtar elementet med det angivna attributet Name. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(SolutionXML solutionXml)](#remove-com.aspose.diagram.SolutionXML-) | Ta bort SolutionXML från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(SolutionXML solutionXml) {#add-com.aspose.diagram.SolutionXML-}
+```
+public int add(SolutionXML solutionXml)
+```
+
+
+Lägg till SolutionXML i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SolutionXML get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### get(String name) {#get-java.lang.String-}
+```
+public SolutionXML get(String name)
+```
+
+
+Hämtar elementet med det angivna attributet Name. Returnerar null om ett element inte finns.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(SolutionXML solutionXml) {#remove-com.aspose.diagram.SolutionXML-}
+```
+public void remove(SolutionXML solutionXml)
+```
+
+
+Ta bort SolutionXML från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| solutionXml | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/spinbuttonactivexcontrol/_index.md
@@ -1,0 +1,547 @@
+---
+title: SpinButtonActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar SpinButton-kontrollen.
+type: docs
+weight: 383
+url: /sv/java/com.aspose.diagram/spinbuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class SpinButtonActiveXControl extends ActiveXControl
+```
+
+Representerar SpinButton-kontrollen.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMax()](#getMax--) | det maximala acceptabla värdet. |
+| [getMin()](#getMin--) | det minsta acceptabla värdet. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getOrientation()](#getOrientation--) | om SpinButton eller ScrollBar är orienterad vertikalt eller horisontellt. |
+| [getPosition()](#getPosition--) | värdet. |
+| [getSmallChange()](#getSmallChange--) | det belopp med vilket Position-egenskapen ändras |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMax(int value)](#setMax-int-) | För beskrivningen av den här egenskapen, se [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--) |
+| [setMin(int value)](#setMin-int-) | För beskrivningen av den här egenskapen, se [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setOrientation(int value)](#setOrientation-int-) | För beskrivningen av den här egenskapen, se [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--) |
+| [setPosition(int value)](#setPosition-int-) | För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--) |
+| [setSmallChange(int value)](#setSmallChange-int-) | För beskrivningen av den här egenskapen, se [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMax() {#getMax--}
+```
+public int getMax()
+```
+
+
+det maximala acceptabla värdet.
+
+**Returns:**
+int
+### getMin() {#getMin--}
+```
+public int getMin()
+```
+
+
+det minsta acceptabla värdet.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getOrientation() {#getOrientation--}
+```
+public int getOrientation()
+```
+
+
+om SpinButton eller ScrollBar är orienterad vertikalt eller horisontellt.
+
+**Returns:**
+int
+### getPosition() {#getPosition--}
+```
+public int getPosition()
+```
+
+
+värdet.
+
+**Returns:**
+int
+### getSmallChange() {#getSmallChange--}
+```
+public int getSmallChange()
+```
+
+
+det belopp med vilket Position-egenskapen ändras
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMax(int value) {#setMax-int-}
+```
+public void setMax(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMax()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMax--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMin(int value) {#setMin-int-}
+```
+public void setMin(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMin()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getMin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setOrientation(int value) {#setOrientation-int-}
+```
+public void setOrientation(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getOrientation()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getOrientation--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPosition(int value) {#setPosition-int-}
+```
+public void setPosition(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSmallChange(int value) {#setSmallChange-int-}
+```
+public void setSmallChange(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSmallChange()](../../com.aspose.diagram/spinbuttonactivexcontrol\#getSmallChange--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/splineknot/_index.md
+++ b/swedish/java/com.aspose.diagram/splineknot/_index.md
@@ -1,0 +1,274 @@
+---
+title: SplineKnot
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för en splines kontrollpunkt och en splines knut som representeras av X-, Y- och A-elementen respektive.
+type: docs
+weight: 384
+url: /sv/java/com.aspose.diagram/splineknot/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineKnot extends Coordinate
+```
+
+Innehåller x- och y-koordinater för en splines kontrollpunkt och en splines knut, representerade av X-, Y- och A-elementen respektive.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SplineKnot()](#SplineKnot--) | Skapar en instans av klassen [SplineKnot](../../com.aspose.diagram/splineknot). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | En av spline‑knutarna (förutom den sista eller de två första). |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | X-koordinaten för en kontrollpunkt. |
+| [getY()](#getY--) | Y-koordinaten för en kontrollpunkt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/splineknot\#getA--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/splineknot\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/splineknot\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/splineknot\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/splineknot\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineKnot() {#SplineKnot--}
+```
+public SplineKnot()
+```
+
+
+Skapar en instans av klassen [SplineKnot](../../com.aspose.diagram/splineknot).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+En av spline‑knutarna (förutom den sista eller de två första).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+X-koordinaten för en kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+Y-koordinaten för en kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getA()](../../com.aspose.diagram/splineknot\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/splineknot\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/splineknot\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getX()](../../com.aspose.diagram/splineknot\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getY()](../../com.aspose.diagram/splineknot\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/splineknotcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/splineknotcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineKnotCollection
+second_title: Aspose.Diagram för Java API-referens
+description: SplineKnot-samling.
+type: docs
+weight: 385
+url: /sv/java/com.aspose.diagram/splineknotcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineKnotCollection extends Collection
+```
+
+SplineKnot-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineKnot get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[SplineKnot](../../com.aspose.diagram/splineknot) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/splinestart/_index.md
+++ b/swedish/java/com.aspose.diagram/splinestart/_index.md
@@ -1,0 +1,349 @@
+---
+title: SplineStart
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för en splines andra kontrollpunkt, dess andra knut, dess första knut, den sista knuten och graden av splinen.
+type: docs
+weight: 386
+url: /sv/java/com.aspose.diagram/splinestart/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Coordinate](../../com.aspose.diagram/coordinate)
+```
+public class SplineStart extends Coordinate
+```
+
+Innehåller x- och y-koordinater för en splines andra kontrollpunkt, dess andra knut, dess första knut, den sista knuten och graden av splinen. Denna information finns i elementen X, Y, A, B, C och D, respektive.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SplineStart()](#SplineStart--) | Skapar en instans av klassen [SplineStart](../../com.aspose.diagram/splinestart). |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getA()](#getA--) | Den andra knuten på splinen. |
+| [getB()](#getB--) | Den första knuten på en spline. |
+| [getC()](#getC--) | Den sista knuten på splinen. |
+| [getClass()](#getClass--) |  |
+| [getD()](#getD--) | Graden av splinen (ett heltal från 1 till 25). |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getX()](#getX--) | x-koordinaten för en splines andra kontrollpunkt. |
+| [getY()](#getY--) | y-koordinaten för en splines andra kontrollpunkt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setA(DoubleValue value)](#setA-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/splinestart\#getA--) |
+| [setB(DoubleValue value)](#setB-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/splinestart\#getB--) |
+| [setC(DoubleValue value)](#setC-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/splinestart\#getC--) |
+| [setD(IntValue value)](#setD-com.aspose.diagram.IntValue-) | För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/splinestart\#getD--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/splinestart\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/splinestart\#getIX--) |
+| [setX(DoubleValue value)](#setX-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/splinestart\#getX--) |
+| [setY(DoubleValue value)](#setY-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/splinestart\#getY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SplineStart() {#SplineStart--}
+```
+public SplineStart()
+```
+
+
+Skapar en instans av klassen [SplineStart](../../com.aspose.diagram/splinestart).
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getA() {#getA--}
+```
+public DoubleValue getA()
+```
+
+
+Den andra knuten på splinen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getB() {#getB--}
+```
+public DoubleValue getB()
+```
+
+
+Den första knuten på en spline.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getC() {#getC--}
+```
+public DoubleValue getC()
+```
+
+
+Den sista knuten på splinen.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getD() {#getD--}
+```
+public IntValue getD()
+```
+
+
+Graden av splinen (ett heltal från 1 till 25).
+
+**Returns:**
+[IntValue](../../com.aspose.diagram/intvalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getX() {#getX--}
+```
+public DoubleValue getX()
+```
+
+
+x-koordinaten för en splines andra kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getY() {#getY--}
+```
+public DoubleValue getY()
+```
+
+
+y-koordinaten för en splines andra kontrollpunkt.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setA(DoubleValue value) {#setA-com.aspose.diagram.DoubleValue-}
+```
+public void setA(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getA()](../../com.aspose.diagram/splinestart\#getA--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setB(DoubleValue value) {#setB-com.aspose.diagram.DoubleValue-}
+```
+public void setB(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getB()](../../com.aspose.diagram/splinestart\#getB--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setC(DoubleValue value) {#setC-com.aspose.diagram.DoubleValue-}
+```
+public void setC(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getC()](../../com.aspose.diagram/splinestart\#getC--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setD(IntValue value) {#setD-com.aspose.diagram.IntValue-}
+```
+public void setD(IntValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getD()](../../com.aspose.diagram/splinestart\#getD--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IntValue](../../com.aspose.diagram/intvalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/splinestart\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/splinestart\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setX(DoubleValue value) {#setX-com.aspose.diagram.DoubleValue-}
+```
+public void setX(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getX()](../../com.aspose.diagram/splinestart\#getX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setY(DoubleValue value) {#setY-com.aspose.diagram.DoubleValue-}
+```
+public void setY(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getY()](../../com.aspose.diagram/splinestart\#getY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/splinestartcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/splinestartcollection/_index.md
@@ -1,0 +1,188 @@
+---
+title: SplineStartCollection
+second_title: Aspose.Diagram för Java API-referens
+description: SplineStart-samling.
+type: docs
+weight: 387
+url: /sv/java/com.aspose.diagram/splinestartcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class SplineStartCollection extends Collection
+```
+
+SplineStart-samling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public SplineStart get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[SplineStart](../../com.aspose.diagram/splinestart) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/str2value/_index.md
+++ b/swedish/java/com.aspose.diagram/str2value/_index.md
@@ -1,0 +1,244 @@
+---
+title: Str2Value
+second_title: Aspose.Diagram för Java API-referens
+description: Strängvärde.
+type: docs
+weight: 388
+url: /sv/java/com.aspose.diagram/str2value/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.StrValue](../../com.aspose.diagram/strvalue)
+```
+public class Str2Value extends StrValue
+```
+
+Strängvärde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Str2Value(String value)](#Str2Value-java.lang.String-) | Konstruktor. |
+| [Str2Value(String value, UnitFormulaErrV ufev)](#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getUfev()](#getUfev--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Strängvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | För beskrivningen av den här egenskapen, se [getUfev()](../../com.aspose.diagram/str2value\#getUfev--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Str2Value(String value) {#Str2Value-java.lang.String-}
+```
+public Str2Value(String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### Str2Value(String value, UnitFormulaErrV ufev) {#Str2Value-java.lang.String-com.aspose.diagram.UnitFormulaErrV-}
+```
+public Str2Value(String value, UnitFormulaErrV ufev)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+| ufev | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Strängvärde.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfev()](../../com.aspose.diagram/str2value\#getUfev--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/streamprovideroptions/_index.md
+++ b/swedish/java/com.aspose.diagram/streamprovideroptions/_index.md
@@ -1,0 +1,186 @@
+---
+title: StreamProviderOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar strömalternativen.
+type: docs
+weight: 390
+url: /sv/java/com.aspose.diagram/streamprovideroptions/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StreamProviderOptions
+```
+
+Representerar strömalternativen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [StreamProviderOptions()](#StreamProviderOptions--) |  |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultPath()](#getDefaultPath--) | Den standardväg(URL) som sparas i den genererade html-filen för den refererade källan. |
+| [getStream()](#getStream--) | Hämtar/Anger utdataströmmen för att skriva sparad data |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomPath(String value)](#setCustomPath-java.lang.String-) | Den användardefinierade vägen(URL) som sparas i den genererade html-filen för den refererade källan. |
+| [setStream(OutputStream value)](#setStream-java.io.OutputStream-) | För beskrivningen av denna egenskap, se [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamProviderOptions() {#StreamProviderOptions--}
+```
+public StreamProviderOptions()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultPath() {#getDefaultPath--}
+```
+public String getDefaultPath()
+```
+
+
+Den standardväg(URL) som sparas i den genererade html-filen för den refererade källan. Till exempel, bladdata sparas i xxx\_files/sheet001.htm, URL:en som används i huvud‑html‑filen bör vara som "src=\"xxx\_files/sheet001.htm\""
+
+**Returns:**
+java.lang.String
+### getStream() {#getStream--}
+```
+public OutputStream getStream()
+```
+
+
+Hämtar/Anger utdataströmmen för att skriva sparad data
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomPath(String value) {#setCustomPath-java.lang.String-}
+```
+public void setCustomPath(String value)
+```
+
+
+Den användardefinierade vägen(URL) som sparas i den genererade html-filen för den refererade källan. Om den inte definieras av användaren, används DefaultPath. Till exempel, bladdata kommer att sparas av användaren till d:/sheet001.htm, URL:en som används i huvud‑html‑filen bör vara "d:/sheet001.htm" eller annan giltig relativ sökväg som kan nås från huvud‑html‑filen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setStream(OutputStream value) {#setStream-java.io.OutputStream-}
+```
+public void setStream(OutputStream value)
+```
+
+
+För beskrivningen av denna egenskap, se [getStream()](../../com.aspose.diagram/streamprovideroptions\#getStream--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.io.OutputStream |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/strvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/strvalue/_index.md
@@ -1,0 +1,234 @@
+---
+title: StrValue
+second_title: Aspose.Diagram för Java API-referens
+description: Strängvärde
+type: docs
+weight: 389
+url: /sv/java/com.aspose.diagram/strvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StrValue
+```
+
+Strängvärde
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [StrValue(String value)](#StrValue-java.lang.String-) | Konstruktor. |
+| [StrValue(String value, UnitFormulaErr ufe)](#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-) | Konstruktor. |
+| [StrValue(String value, int unit)](#StrValue-java.lang.String-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Attribut för ett element. |
+| [getValue()](#getValue--) | Strängvärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--) |
+| [setValue(String value)](#setValue-java.lang.String-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/strvalue\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StrValue(String value) {#StrValue-java.lang.String-}
+```
+public StrValue(String value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### StrValue(String value, UnitFormulaErr ufe) {#StrValue-java.lang.String-com.aspose.diagram.UnitFormulaErr-}
+```
+public StrValue(String value, UnitFormulaErr ufe)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+| ufe | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### StrValue(String value, int unit) {#StrValue-java.lang.String-int-}
+```
+public StrValue(String value, int unit)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+| enhet | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Strängvärde.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/strvalue\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(String value) {#setValue-java.lang.String-}
+```
+public void setValue(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/strvalue\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/style/_index.md
+++ b/swedish/java/com.aspose.diagram/style/_index.md
@@ -1,0 +1,204 @@
+---
+title: Stil
+second_title: Aspose.Diagram för Java API-referens
+description: Anger teckenformateringen som tillämpas på ett intervall av text i formens textblock.
+type: docs
+weight: 391
+url: /sv/java/com.aspose.diagram/style/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Style
+```
+
+Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Style(int value)](#Style-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/style\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/style\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Style(int value) {#Style-int-}
+```
+public Style(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getUfe()](../../com.aspose.diagram/style\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/style\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/styleprop/_index.md
+++ b/swedish/java/com.aspose.diagram/styleprop/_index.md
@@ -1,0 +1,194 @@
+---
+title: StyleProp
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr stilbeteende, såsom om en stil inkluderar textlinje‑ och fyllnadsattribut.
+type: docs
+weight: 392
+url: /sv/java/com.aspose.diagram/styleprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleProp
+```
+
+Innehåller element som styr stilbeteende, såsom om en stil inkluderar text-, linje- och fyllnadsattribut.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getEnableFillProps()](#getEnableFillProps--) | Anger om en stil inkluderar fyllningsegenskaper. |
+| [getEnableLineProps()](#getEnableLineProps--) | Anger om en stil inkluderar linjeegenskaper |
+| [getEnableTextProps()](#getEnableTextProps--) | Anger om en stil inkluderar textegenskaper. |
+| [getHideForApply()](#getHideForApply--) | Anger var en stil visas i Microsoft Visios användargränssnitt. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/styleprop\#getDel--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getEnableFillProps() {#getEnableFillProps--}
+```
+public BoolValue getEnableFillProps()
+```
+
+
+Anger om en stil inkluderar fyllningsegenskaper.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableLineProps() {#getEnableLineProps--}
+```
+public BoolValue getEnableLineProps()
+```
+
+
+Anger om en stil inkluderar linjeegenskaper
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getEnableTextProps() {#getEnableTextProps--}
+```
+public BoolValue getEnableTextProps()
+```
+
+
+Anger om en stil inkluderar textegenskaper.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHideForApply() {#getHideForApply--}
+```
+public BoolValue getHideForApply()
+```
+
+
+Anger var en stil visas i Microsoft Visios användargränssnitt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/styleprop\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/stylesheet/_index.md
+++ b/swedish/java/com.aspose.diagram/stylesheet/_index.md
@@ -1,0 +1,519 @@
+---
+title: StyleSheet
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en stil som definierats i ett dokument.
+type: docs
+weight: 393
+url: /sv/java/com.aspose.diagram/stylesheet/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class StyleSheet
+```
+
+Representerar en stil som definierats i ett dokument.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [StyleSheet()](#StyleSheet--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getChars()](#getChars--) | Innehåller en samling av Char-element. |
+| [getClass()](#getClass--) |  |
+| [getConnectionABCDs()](#getConnectionABCDs--) | Innehåller en samling av ConnectionABCD-element. |
+| [getConnections()](#getConnections--) | Innehåller en samling av Connection-element. |
+| [getEvent()](#getEvent--) | Innehåller element som specificerar formler som styr formhändelser. |
+| [getFill()](#getFill--) | Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg. |
+| [getFillStyle()](#getFillStyle--) | StyleSheet-element från vilket detta stil ärver fyllningsformatering. |
+| [getForeign()](#getForeign--) | Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. |
+| [getForeignData()](#getForeignData--) | Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data. |
+| [getGroup()](#getGroup--) | Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper. |
+| [getHelp()](#getHelp--) | Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getImage()](#getImage--) | Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap. |
+| [getLayout()](#getLayout--) | Innehåller element som styr formplacering och inställningar för anslutningsruttning. |
+| [getLine()](#getLine--) | Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. |
+| [getLineStyle()](#getLineStyle--) | StyleSheet-element från vilket detta stil ärver linjeformatering. |
+| [getMisc()](#getMisc--) | Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPageLayout()](#getPageLayout--) | Innehåller Diagram som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan. |
+| [getParas()](#getParas--) | Innehåller en samling av Para-element. |
+| [getProtection()](#getProtection--) | Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. |
+| [getRulerGrid()](#getRulerGrid--) | Innehåller element som specificerar inställningarna för sidans linjaler och rutnät. |
+| [getStyleProp()](#getStyleProp--) | Innehåller element som styr stilbeteende, såsom om en stil inkluderar text-, linje- och fyllnadsattribut. |
+| [getTabsCollection()](#getTabsCollection--) | Innehåller en samling av Tab‑element. |
+| [getTextBlock()](#getTextBlock--) | Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock. |
+| [getTextStyle()](#getTextStyle--) | StyleSheet-element från vilket detta stil ärver textformatering. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setFillStyle(StyleSheet value)](#setFillStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/stylesheet\#getID--) |
+| [setLineStyle(StyleSheet value)](#setLineStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/stylesheet\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--) |
+| [setTextStyle(StyleSheet value)](#setTextStyle-com.aspose.diagram.StyleSheet-) | För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StyleSheet() {#StyleSheet--}
+```
+public StyleSheet()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getChars() {#getChars--}
+```
+public CharCollection getChars()
+```
+
+
+Innehåller en samling av Char-element.
+
+**Returns:**
+[CharCollection](../../com.aspose.diagram/charcollection)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConnectionABCDs() {#getConnectionABCDs--}
+```
+public ConnectionABCDCollection getConnectionABCDs()
+```
+
+
+Innehåller en samling av ConnectionABCD-element.
+
+**Returns:**
+[ConnectionABCDCollection](../../com.aspose.diagram/connectionabcdcollection)
+### getConnections() {#getConnections--}
+```
+public ConnectionCollection getConnections()
+```
+
+
+Innehåller en samling av Connection-element.
+
+**Returns:**
+[ConnectionCollection](../../com.aspose.diagram/connectioncollection)
+### getEvent() {#getEvent--}
+```
+public Event getEvent()
+```
+
+
+Innehåller element som specificerar formler som styr formhändelser.
+
+**Returns:**
+[Event](../../com.aspose.diagram/event)
+### getFill() {#getFill--}
+```
+public Fill getFill()
+```
+
+
+Innehåller de aktuella fyllningsformateringsvärdena för formen och formens skuggning, inklusive mönster, förgrundsfärg och bakgrundsfärg.
+
+**Returns:**
+[Fill](../../com.aspose.diagram/fill)
+### getFillStyle() {#getFillStyle--}
+```
+public StyleSheet getFillStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver fyllningsformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getForeign() {#getForeign--}
+```
+public Foreign getForeign()
+```
+
+
+Innehåller element som specificerar bredd och höjd på ett objekt från ett annat program som används i ett Microsoft Visio-dokument. Inkluderar också element som specificerar avståndet som objektets bild förskjuts inom dess kanter.
+
+**Returns:**
+[Foreign](../../com.aspose.diagram/foreign)
+### getForeignData() {#getForeignData--}
+```
+public ForeignData getForeignData()
+```
+
+
+Innehåller en MIME (Multipurpose Internet Mail Extensions) kodad BLOB av bilddata, såsom Windows-metafil, bitmap eller OLE-data.
+
+**Returns:**
+[ForeignData](../../com.aspose.diagram/foreigndata)
+### getGroup() {#getGroup--}
+```
+public Group getGroup()
+```
+
+
+Innehåller element som styr hur du lägger till former i en grupp, flyttar medlemmar i en grupp och väljer grupper.
+
+**Returns:**
+[Group](../../com.aspose.diagram/group)
+### getHelp() {#getHelp--}
+```
+public Help getHelp()
+```
+
+
+Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation.
+
+**Returns:**
+[Help](../../com.aspose.diagram/help)
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getImage() {#getImage--}
+```
+public Image getImage()
+```
+
+
+Innehåller gamma-, ljus-, kontrast-, oskärpe-, skärpe-, brusreducerings- och transparensvärden för en bitmap.
+
+**Returns:**
+[Image](../../com.aspose.diagram/image)
+### getLayout() {#getLayout--}
+```
+public Layout getLayout()
+```
+
+
+Innehåller element som styr formplacering och inställningar för anslutningsruttning.
+
+**Returns:**
+[Layout](../../com.aspose.diagram/layout)
+### getLine() {#getLine--}
+```
+public Line getLine()
+```
+
+
+Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. Dessa element bestämmer om linjeändarna är formaterade (till exempel med en pilspets), storleken på linjeändformat, radien på den avrundade cirkeln som tillämpas på linjen och linjeändstil (rund eller fyrkantig).
+
+**Returns:**
+[Line](../../com.aspose.diagram/line)
+### getLineStyle() {#getLineStyle--}
+```
+public StyleSheet getLineStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver linjeformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### getMisc() {#getMisc--}
+```
+public Misc getMisc()
+```
+
+
+Innehåller element som specificerar Shape-elementets hjälpfilsämne och upphovsrättsinformation.
+
+**Returns:**
+[Misc](../../com.aspose.diagram/misc)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPageLayout() {#getPageLayout--}
+```
+public PageLayout getPageLayout()
+```
+
+
+Innehåller Diagram som styr sidlayoutinställningarna för former och anslutningar, såsom avstånd mellan alla former på sidan, avstånd mellan alla anslutningar på sidan och routningsstil för alla anslutningar på sidan.
+
+**Returns:**
+[PageLayout](../../com.aspose.diagram/pagelayout)
+### getParas() {#getParas--}
+```
+public ParaCollection getParas()
+```
+
+
+Innehåller en samling av Para-element.
+
+**Returns:**
+[ParaCollection](../../com.aspose.diagram/paracollection)
+### getProtection() {#getProtection--}
+```
+public Protection getProtection()
+```
+
+
+Låsning hjälper till att förhindra oavsiktliga ändringar av formen men hindrar inte Microsoft Visio från att återställa värden i andra situationer. Det skyddar inte heller mot ändringar som görs i ShapeSheet-fönstret.
+
+**Returns:**
+[Protection](../../com.aspose.diagram/protection)
+### getRulerGrid() {#getRulerGrid--}
+```
+public RulerGrid getRulerGrid()
+```
+
+
+Innehåller element som specificerar inställningarna för sidans linjaler och rutnät.
+
+**Returns:**
+[RulerGrid](../../com.aspose.diagram/rulergrid)
+### getStyleProp() {#getStyleProp--}
+```
+public StyleProp getStyleProp()
+```
+
+
+Innehåller element som styr stilbeteende, såsom om en stil inkluderar text-, linje- och fyllnadsattribut.
+
+**Returns:**
+[StyleProp](../../com.aspose.diagram/styleprop)
+### getTabsCollection() {#getTabsCollection--}
+```
+public TabsCollection getTabsCollection()
+```
+
+
+Innehåller en samling av Tab‑element.
+
+**Returns:**
+[TabsCollection](../../com.aspose.diagram/tabscollection)
+### getTextBlock() {#getTextBlock--}
+```
+public TextBlock getTextBlock()
+```
+
+
+Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock.
+
+**Returns:**
+[TextBlock](../../com.aspose.diagram/textblock)
+### getTextStyle() {#getTextStyle--}
+```
+public StyleSheet getTextStyle()
+```
+
+
+StyleSheet-element från vilket detta stil ärver textformatering.
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setFillStyle(StyleSheet value) {#setFillStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setFillStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFillStyle()](../../com.aspose.diagram/stylesheet\#getFillStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/stylesheet\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLineStyle(StyleSheet value) {#setLineStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setLineStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLineStyle()](../../com.aspose.diagram/stylesheet\#getLineStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/stylesheet\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/stylesheet\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTextStyle(StyleSheet value) {#setTextStyle-com.aspose.diagram.StyleSheet-}
+```
+public void setTextStyle(StyleSheet value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextStyle()](../../com.aspose.diagram/stylesheet\#getTextStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/stylesheetcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/stylesheetcollection/_index.md
@@ -1,0 +1,234 @@
+---
+title: StyleSheetCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Samling av stilmallar.
+type: docs
+weight: 394
+url: /sv/java/com.aspose.diagram/stylesheetcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class StyleSheetCollection extends Collection
+```
+
+Samling av stilmallar.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(StyleSheet item)](#add-com.aspose.diagram.StyleSheet-) | Lägg till StyleSheet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getStyleSheet(int ID)](#getStyleSheet-int-) | Hämtar elementet med angivet ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(StyleSheet item)](#remove-com.aspose.diagram.StyleSheet-) | Ta bort StyleSheet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(StyleSheet item) {#add-com.aspose.diagram.StyleSheet-}
+```
+public int add(StyleSheet item)
+```
+
+
+Lägg till StyleSheet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public StyleSheet get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getStyleSheet(int ID) {#getStyleSheet-int-}
+```
+public StyleSheet getStyleSheet(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[StyleSheet](../../com.aspose.diagram/stylesheet) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(StyleSheet item) {#remove-com.aspose.diagram.StyleSheet-}
+```
+public void remove(StyleSheet item)
+```
+
+
+Ta bort StyleSheet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [StyleSheet](../../com.aspose.diagram/stylesheet) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/stylevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/stylevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: StyleValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger teckenformateringen som tillämpas på ett intervall av text i formens textblock.
+type: docs
+weight: 395
+url: /sv/java/com.aspose.diagram/stylevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class StyleValue
+```
+
+Anger teckenformateringen som tillämpas på ett textintervall i figurens textblock.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOLD](#BOLD) | Fet. |
+| [ITALIC](#ITALIC) | Kursiv. |
+| [SMALL_CAPS](#SMALL-CAPS) | Små versaler. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [UNDERLINE](#UNDERLINE) | Understrykning. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOLD {#BOLD}
+```
+public static final int BOLD
+```
+
+
+Fet.
+
+### ITALIC {#ITALIC}
+```
+public static final int ITALIC
+```
+
+
+Kursiv.
+
+### SMALL_CAPS {#SMALL-CAPS}
+```
+public static final int SMALL_CAPS
+```
+
+
+Små versaler.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### UNDERLINE {#UNDERLINE}
+```
+public static final int UNDERLINE
+```
+
+
+Understrykning.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/svgsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/svgsaveoptions/_index.md
@@ -1,0 +1,604 @@
+---
+title: SVGSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när diagramssidor renderas till SVG.
+type: docs
+weight: 347
+url: /sv/java/com.aspose.diagram/svgsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions), [com.aspose.diagram.RenderingSaveOptions](../../com.aspose.diagram/renderingsaveoptions)
+```
+public class SVGSaveOptions extends RenderingSaveOptions
+```
+
+Tillåter att ange ytterligare alternativ när diagramssidor renderas till SVG.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [SVGSaveOptions()](#SVGSaveOptions--) | Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustomImagePath()](#getCustomImagePath--) | Den anpassade sökvägen (URL) som sparas i den genererade SVG-filen för bilden. |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getEmfRenderSetting()](#getEmfRenderSetting--) | Inställning för rendering av Emf-metafil. |
+| [getEnlargePage()](#getEnlargePage--) | Anger om sidan ska förstoras. |
+| [getExportElementAsRectTag()](#getExportElementAsRectTag--) | Definierar om rektangel-element ska exporteras som rect-tag eller inte. |
+| [getExportGuideShapes()](#getExportGuideShapes--) | Definierar om guideformer ska exporteras eller inte. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definierar om dolda sidor ska exporteras eller inte. |
+| [getPageIndex()](#getPageIndex--) | det 0-baserade indexet för sidan som ska renderas. |
+| [getPageSize()](#getPageSize--) | sidstorleken för de genererade bilderna. |
+| [getQuality()](#getQuality--) | ett värde som bestämmer kvaliteten på de genererade bilderna och endast tillämpas när sidor sparas i JPEG-format. |
+| [getSVGFitToViewPort()](#getSVGFitToViewPort--) | om denna egenskap är sann, kommer den genererade SVG:n att anpassas till visningsporten. |
+| [getSaveFormat()](#getSaveFormat--) | Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används. |
+| [getShapes()](#getShapes--) | former att rendera. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [isExportComments()](#isExportComments--) | Definierar om kommentarer ska exporteras eller inte. |
+| [isExportScaleInMatrix()](#isExportScaleInMatrix--) | Definierar om exportskala ska vara i matris eller inte. |
+| [isSavingCustomLinePattern()](#isSavingCustomLinePattern--) | Definierar om anpassat linjemönster ska sparas. |
+| [isSavingImageSeparately()](#isSavingImageSeparately--) | Definierar om bilden ska sparas separat. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCustomImagePath(String value)](#setCustomImagePath-java.lang.String-) | För beskrivningen av den här egenskapen, se [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--) |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setEmfRenderSetting(int value)](#setEmfRenderSetting-int-) | För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--) |
+| [setEnlargePage(boolean value)](#setEnlargePage-boolean-) | För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--) |
+| [setExportComments(boolean value)](#setExportComments-boolean-) | För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--) |
+| [setExportElementAsRectTag(boolean value)](#setExportElementAsRectTag-boolean-) | För beskrivningen av den här egenskapen, se [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--) |
+| [setExportGuideShapes(boolean value)](#setExportGuideShapes-boolean-) | För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--) |
+| [setExportScaleInMatrix(boolean value)](#setExportScaleInMatrix-boolean-) | För beskrivningen av den här egenskapen, se [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--) |
+| [setPageSize(PageSize value)](#setPageSize-com.aspose.diagram.PageSize-) | För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--) |
+| [setQuality(int value)](#setQuality-int-) | För beskrivningen av den här egenskapen, se [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--) |
+| [setSVGFitToViewPort(boolean value)](#setSVGFitToViewPort-boolean-) | För beskrivningen av den här egenskapen, se [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--) |
+| [setSavingCustomLinePattern(boolean value)](#setSavingCustomLinePattern-boolean-) | För beskrivningen av den här egenskapen, se [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--) |
+| [setSavingImageSeparately(boolean value)](#setSavingImageSeparately-boolean-) | För beskrivningen av den här egenskapen, se [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--) |
+| [setShapes(ShapeCollection value)](#setShapes-com.aspose.diagram.ShapeCollection-) | För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SVGSaveOptions() {#SVGSaveOptions--}
+```
+public SVGSaveOptions()
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustomImagePath() {#getCustomImagePath--}
+```
+public String getCustomImagePath()
+```
+
+
+Den användardefinierade sökvägen (URL) som sparas i den genererade svg-filen för bilden. Om den inte definieras av användaren används aktuell katalog.
+
+**Returns:**
+java.lang.String
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getEmfRenderSetting() {#getEmfRenderSetting--}
+```
+public int getEmfRenderSetting()
+```
+
+
+Inställning för rendering av EMF-metafil. EMF-metafiler identifierade som "EMF+ Dual" kan innehålla både EMF+-poster och EMF-poster. Båda typerna av poster kan användas för att rendera bilden, endast EMF+-poster, eller endast EMF-poster. När EmfPlusPrefer är satt, kommer EMF+-poster att parsas, annars kommer endast EMF-poster att parsas. Standardvärdet är EmfOnly"/>.
+
+**Returns:**
+int
+### getEnlargePage() {#getEnlargePage--}
+```
+public boolean getEnlargePage()
+```
+
+
+Anger om sidan ska förstoras. Om true - förstora sidan. Om false - förstora inte sidan. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportElementAsRectTag() {#getExportElementAsRectTag--}
+```
+public boolean getExportElementAsRectTag()
+```
+
+
+Definierar om rektangel-element ska exporteras som rect-tag eller inte. Standardvärdet är falskt.
+
+**Returns:**
+boolean
+### getExportGuideShapes() {#getExportGuideShapes--}
+```
+public boolean getExportGuideShapes()
+```
+
+
+Definierar om guideformer ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definierar om dolda sidor ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+Det 0-baserade indexet för sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getPageSize() {#getPageSize--}
+```
+public PageSize getPageSize()
+```
+
+
+sidstorleken för de genererade bilderna. Kan vara [PageSize](../../com.aspose.diagram/pagesize) eller null. Standardvärdet är null. Om PageSize är null hämtas sidstorleken för den genererade bilden från källdiagrammet.
+
+**Returns:**
+[PageSize](../../com.aspose.diagram/pagesize)
+### getQuality() {#getQuality--}
+```
+public int getQuality()
+```
+
+
+Ett värde som bestämmer kvaliteten på de genererade bilderna och endast tillämpas när sidor sparas i JPEG-format. Standardvärdet är 100. Påverkar endast vid sparande till JPEG. Värdet måste vara mellan 0 och 100. Standardvärdet är 100.
+
+**Returns:**
+int
+### getSVGFitToViewPort() {#getSVGFitToViewPort--}
+```
+public boolean getSVGFitToViewPort()
+```
+
+
+om denna egenskap är sann, kommer den genererade SVG:n att anpassas till visningsporten.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket dokumentet kommer att sparas om detta SaveOptions‑objekt används.
+
+**Returns:**
+int
+### getShapes() {#getShapes--}
+```
+public ShapeCollection getShapes()
+```
+
+
+former att rendera. Standardantalet är 0.
+
+**Returns:**
+[ShapeCollection](../../com.aspose.diagram/shapecollection)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExportComments() {#isExportComments--}
+```
+public boolean isExportComments()
+```
+
+
+Definierar om kommentarer ska exporteras eller inte. Standardvärdet är false.
+
+**Returns:**
+boolean
+### isExportScaleInMatrix() {#isExportScaleInMatrix--}
+```
+public boolean isExportScaleInMatrix()
+```
+
+
+Definierar om exportskala ska inkluderas i matrisen eller inte. Standardvärdet är sant.
+
+**Returns:**
+boolean
+### isSavingCustomLinePattern() {#isSavingCustomLinePattern--}
+```
+public boolean isSavingCustomLinePattern()
+```
+
+
+Definierar om anpassat linjemönster ska sparas.
+
+**Returns:**
+boolean
+### isSavingImageSeparately() {#isSavingImageSeparately--}
+```
+public boolean isSavingImageSeparately()
+```
+
+
+Definierar om bilden ska sparas separat.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCustomImagePath(String value) {#setCustomImagePath-java.lang.String-}
+```
+public void setCustomImagePath(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getCustomImagePath()](../../com.aspose.diagram/svgsaveoptions\#getCustomImagePath--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEmfRenderSetting(int value) {#setEmfRenderSetting-int-}
+```
+public void setEmfRenderSetting(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEmfRenderSetting()](../../com.aspose.diagram/renderingsaveoptions\#getEmfRenderSetting--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnlargePage(boolean value) {#setEnlargePage-boolean-}
+```
+public void setEnlargePage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getEnlargePage()](../../com.aspose.diagram/renderingsaveoptions\#getEnlargePage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportComments(boolean value) {#setExportComments-boolean-}
+```
+public void setExportComments(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportComments()](../../com.aspose.diagram/renderingsaveoptions\#isExportComments--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportElementAsRectTag(boolean value) {#setExportElementAsRectTag-boolean-}
+```
+public void setExportElementAsRectTag(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportElementAsRectTag()](../../com.aspose.diagram/svgsaveoptions\#getExportElementAsRectTag--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportGuideShapes(boolean value) {#setExportGuideShapes-boolean-}
+```
+public void setExportGuideShapes(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportGuideShapes()](../../com.aspose.diagram/renderingsaveoptions\#getExportGuideShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/svgsaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setExportScaleInMatrix(boolean value) {#setExportScaleInMatrix-boolean-}
+```
+public void setExportScaleInMatrix(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isExportScaleInMatrix()](../../com.aspose.diagram/svgsaveoptions\#isExportScaleInMatrix--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/svgsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageSize(PageSize value) {#setPageSize-com.aspose.diagram.PageSize-}
+```
+public void setPageSize(PageSize value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageSize()](../../com.aspose.diagram/renderingsaveoptions\#getPageSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [PageSize](../../com.aspose.diagram/pagesize) |  |
+
+### setQuality(int value) {#setQuality-int-}
+```
+public void setQuality(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getQuality()](../../com.aspose.diagram/svgsaveoptions\#getQuality--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSVGFitToViewPort(boolean value) {#setSVGFitToViewPort-boolean-}
+```
+public void setSVGFitToViewPort(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSVGFitToViewPort()](../../com.aspose.diagram/svgsaveoptions\#getSVGFitToViewPort--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSaveFormat()](../../com.aspose.diagram/saveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSavingCustomLinePattern(boolean value) {#setSavingCustomLinePattern-boolean-}
+```
+public void setSavingCustomLinePattern(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isSavingCustomLinePattern()](../../com.aspose.diagram/svgsaveoptions\#isSavingCustomLinePattern--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSavingImageSeparately(boolean value) {#setSavingImageSeparately-boolean-}
+```
+public void setSavingImageSeparately(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isSavingImageSeparately()](../../com.aspose.diagram/svgsaveoptions\#isSavingImageSeparately--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setShapes(ShapeCollection value) {#setShapes-com.aspose.diagram.ShapeCollection-}
+```
+public void setShapes(ShapeCollection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShapes()](../../com.aspose.diagram/renderingsaveoptions\#getShapes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ShapeCollection](../../com.aspose.diagram/shapecollection) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/tab/_index.md
+++ b/swedish/java/com.aspose.diagram/tab/_index.md
@@ -1,0 +1,261 @@
+---
+title: Tab
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en samling av Tab‑element.
+type: docs
+weight: 396
+url: /sv/java/com.aspose.diagram/tab/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Tab
+```
+
+Innehåller en samling av Tab‑element.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAlignment()](#getAlignment--) | Specificerar flikjusteringen. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [getLeader()](#getLeader--) | Angav ledaren. |
+| [getPosition()](#getPosition--) | Anger positionen för ett tabbstopp. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAlignment(Alignment value)](#setAlignment-com.aspose.diagram.Alignment-) | För beskrivningen av den här egenskapen, se [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/tab\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/tab\#getIX--) |
+| [setLeader(StrValue value)](#setLeader-com.aspose.diagram.StrValue-) | För beskrivningen av den här egenskapen, se [getLeader()](../../com.aspose.diagram/tab\#getLeader--) |
+| [setPosition(DoubleValue value)](#setPosition-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/tab\#getPosition--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAlignment() {#getAlignment--}
+```
+public Alignment getAlignment()
+```
+
+
+Specificerar flikjusteringen.
+
+**Returns:**
+[Alignment](../../com.aspose.diagram/alignment)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### getLeader() {#getLeader--}
+```
+public StrValue getLeader()
+```
+
+
+Angav ledaren.
+
+**Returns:**
+[StrValue](../../com.aspose.diagram/strvalue)
+### getPosition() {#getPosition--}
+```
+public DoubleValue getPosition()
+```
+
+
+Anger positionen för ett tabbstopp.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAlignment(Alignment value) {#setAlignment-com.aspose.diagram.Alignment-}
+```
+public void setAlignment(Alignment value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getAlignment()](../../com.aspose.diagram/tab\#getAlignment--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Alignment](../../com.aspose.diagram/alignment) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDel()](../../com.aspose.diagram/tab\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIX()](../../com.aspose.diagram/tab\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLeader(StrValue value) {#setLeader-com.aspose.diagram.StrValue-}
+```
+public void setLeader(StrValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getLeader()](../../com.aspose.diagram/tab\#getLeader--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [StrValue](../../com.aspose.diagram/strvalue) |  |
+
+### setPosition(DoubleValue value) {#setPosition-com.aspose.diagram.DoubleValue-}
+```
+public void setPosition(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPosition()](../../com.aspose.diagram/tab\#getPosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/tabcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/tabcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: TabCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en samling av Tab‑element
+type: docs
+weight: 397
+url: /sv/java/com.aspose.diagram/tabcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabCollection extends Collection
+```
+
+Innehåller en samling av Tab‑element
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Tab item)](#add-com.aspose.diagram.Tab-) | Lägg till Tab-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getIX()](#getIX--) | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Tab item)](#remove-com.aspose.diagram.Tab-) | Ta bort Tab-objektet från samlingen. |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/tabcollection\#getDel--) |
+| [setIX(int value)](#setIX-int-) | För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/tabcollection\#getIX--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Tab item) {#add-com.aspose.diagram.Tab-}
+```
+public int add(Tab item)
+```
+
+
+Lägg till Tab-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Tab get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Tab](../../com.aspose.diagram/tab) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getIX() {#getIX--}
+```
+public int getIX()
+```
+
+
+Det nollbaserade indexet för elementet inom dess föräldraelement.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Tab item) {#remove-com.aspose.diagram.Tab-}
+```
+public void remove(Tab item)
+```
+
+
+Ta bort Tab-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Tab](../../com.aspose.diagram/tab) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/tabcollection\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIX(int value) {#setIX-int-}
+```
+public void setIX(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIX()](../../com.aspose.diagram/tabcollection\#getIX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/tabscollection/_index.md
+++ b/swedish/java/com.aspose.diagram/tabscollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TabsCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller en samling av TabCollection‑element
+type: docs
+weight: 398
+url: /sv/java/com.aspose.diagram/tabscollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TabsCollection extends Collection
+```
+
+Innehåller en samling av TabCollection‑element
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(TabCollection item)](#add-com.aspose.diagram.TabCollection-) | Lägg till Tab-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(TabCollection item)](#remove-com.aspose.diagram.TabCollection-) | Ta bort Tab-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(TabCollection item) {#add-com.aspose.diagram.TabCollection-}
+```
+public int add(TabCollection item)
+```
+
+
+Lägg till Tab-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public TabCollection get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[TabCollection](../../com.aspose.diagram/tabcollection) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(TabCollection item) {#remove-com.aspose.diagram.TabCollection-}
+```
+public void remove(TabCollection item)
+```
+
+
+Ta bort Tab-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [TabCollection](../../com.aspose.diagram/tabcollection) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/text/_index.md
+++ b/swedish/java/com.aspose.diagram/text/_index.md
@@ -1,0 +1,160 @@
+---
+title: Text
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller texten för en figur.
+type: docs
+weight: 399
+url: /sv/java/com.aspose.diagram/text/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Text
+```
+
+Innehåller texten för en figur.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Text()](#Text--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | FormatTxt‑samling som innehåller texten för en form. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Text() {#Text--}
+```
+public Text()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public FormatTxtCollection getValue()
+```
+
+
+FormatTxt‑samling som innehåller texten för en form.
+
+**Returns:**
+[FormatTxtCollection](../../com.aspose.diagram/formattxtcollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textblock/_index.md
+++ b/swedish/java/com.aspose.diagram/textblock/_index.md
@@ -1,0 +1,386 @@
+---
+title: TextBlock
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar justeringsmarginaler och standardtabbstoppositioner för text i en figurs textblock.
+type: docs
+weight: 400
+url: /sv/java/com.aspose.diagram/textblock/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextBlock
+```
+
+Innehåller element som specificerar justering, marginaler och standardtabbstoppositioner för text i en figurs textblock.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBottomMargin()](#getBottomMargin--) | Bestämmer avståndet mellan textblockets nedre kant och den sista textraden som den innehåller. |
+| [getClass()](#getClass--) |  |
+| [getDefaultTabStop()](#getDefaultTabStop--) | Anger intervallet för standardtabbstopp i ett textblock. |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getLeftMargin()](#getLeftMargin--) | Anger avståndet mellan textblockets vänstra kant och den text den innehåller. |
+| [getRightMargin()](#getRightMargin--) | Anger avståndet mellan textblockets högra kant och den text den innehåller. |
+| [getTextBkgnd()](#getTextBkgnd--) | Anger textbakgrundsfärgen för en figur. |
+| [getTextBkgndTrans()](#getTextBkgndTrans--) | Anger transparensnivån för bakgrundsfärgen i en figurs textblock, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig). |
+| [getTextDirection()](#getTextDirection--) | Anger teckenriktningen i ett textblock. |
+| [getTopMargin()](#getTopMargin--) | Anger avståndet mellan textblockets övre kant och den första textraden som den innehåller. |
+| [getVerticalAlign()](#getVerticalAlign--) | Anger vertikal justering av text inom textblocket. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBottomMargin(DoubleValue value)](#setBottomMargin-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--) |
+| [setDefaultTabStop(DoubleValue value)](#setDefaultTabStop-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/textblock\#getDel--) |
+| [setLeftMargin(DoubleValue value)](#setLeftMargin-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--) |
+| [setRightMargin(DoubleValue value)](#setRightMargin-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--) |
+| [setTextBkgnd(ColorValue value)](#setTextBkgnd-com.aspose.diagram.ColorValue-) | För beskrivningen av denna egenskap, se [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--) |
+| [setTextBkgndTrans(DoubleValue value)](#setTextBkgndTrans-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--) |
+| [setTextDirection(TextDirection value)](#setTextDirection-com.aspose.diagram.TextDirection-) | För beskrivningen av den här egenskapen, se [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--) |
+| [setTopMargin(DoubleValue value)](#setTopMargin-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--) |
+| [setVerticalAlign(VerticalAlign value)](#setVerticalAlign-com.aspose.diagram.VerticalAlign-) | För beskrivningen av den här egenskapen, se [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBottomMargin() {#getBottomMargin--}
+```
+public DoubleValue getBottomMargin()
+```
+
+
+Bestämmer avståndet mellan den nedre kanten av textrutan och den sista textraden den innehåller. Standardvärdet är 4 pt. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir den nedre marginalen densamma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultTabStop() {#getDefaultTabStop--}
+```
+public DoubleValue getDefaultTabStop()
+```
+
+
+Anger intervallet för standardtabbstopp i ett textblock.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getLeftMargin() {#getLeftMargin--}
+```
+public DoubleValue getLeftMargin()
+```
+
+
+Anger avståndet mellan den vänstra kanten av textrutan och den text den innehåller. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir den vänstra marginalen densamma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRightMargin() {#getRightMargin--}
+```
+public DoubleValue getRightMargin()
+```
+
+
+Anger avståndet mellan den högra kanten av textrutan och den text den innehåller. Detta värde är oberoende av ritningens skala. Om ritningen skalas förblir den högra marginalen densamma.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextBkgnd() {#getTextBkgnd--}
+```
+public ColorValue getTextBkgnd()
+```
+
+
+Anger textbakgrundsfärgen för en figur.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getTextBkgndTrans() {#getTextBkgndTrans--}
+```
+public DoubleValue getTextBkgndTrans()
+```
+
+
+Anger transparensnivån för bakgrundsfärgen i en figurs textblock, från 0 (helt ogenomskinlig) till 1 (helt genomskinlig).
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTextDirection() {#getTextDirection--}
+```
+public TextDirection getTextDirection()
+```
+
+
+Anger teckenriktningen i ett textblock.
+
+**Returns:**
+[TextDirection](../../com.aspose.diagram/textdirection)
+### getTopMargin() {#getTopMargin--}
+```
+public DoubleValue getTopMargin()
+```
+
+
+Anger avståndet mellan textblockets övre kant och den första textraden som den innehåller.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getVerticalAlign() {#getVerticalAlign--}
+```
+public VerticalAlign getVerticalAlign()
+```
+
+
+Anger vertikal justering av text inom textblocket.
+
+**Returns:**
+[VerticalAlign](../../com.aspose.diagram/verticalalign)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBottomMargin(DoubleValue value) {#setBottomMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setBottomMargin(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBottomMargin()](../../com.aspose.diagram/textblock\#getBottomMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDefaultTabStop(DoubleValue value) {#setDefaultTabStop-com.aspose.diagram.DoubleValue-}
+```
+public void setDefaultTabStop(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultTabStop()](../../com.aspose.diagram/textblock\#getDefaultTabStop--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/textblock\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLeftMargin(DoubleValue value) {#setLeftMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setLeftMargin(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLeftMargin()](../../com.aspose.diagram/textblock\#getLeftMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRightMargin(DoubleValue value) {#setRightMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setRightMargin(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRightMargin()](../../com.aspose.diagram/textblock\#getRightMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextBkgnd(ColorValue value) {#setTextBkgnd-com.aspose.diagram.ColorValue-}
+```
+public void setTextBkgnd(ColorValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextBkgnd()](../../com.aspose.diagram/textblock\#getTextBkgnd--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setTextBkgndTrans(DoubleValue value) {#setTextBkgndTrans-com.aspose.diagram.DoubleValue-}
+```
+public void setTextBkgndTrans(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTextBkgndTrans()](../../com.aspose.diagram/textblock\#getTextBkgndTrans--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTextDirection(TextDirection value) {#setTextDirection-com.aspose.diagram.TextDirection-}
+```
+public void setTextDirection(TextDirection value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTextDirection()](../../com.aspose.diagram/textblock\#getTextDirection--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [TextDirection](../../com.aspose.diagram/textdirection) |  |
+
+### setTopMargin(DoubleValue value) {#setTopMargin-com.aspose.diagram.DoubleValue-}
+```
+public void setTopMargin(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTopMargin()](../../com.aspose.diagram/textblock\#getTopMargin--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setVerticalAlign(VerticalAlign value) {#setVerticalAlign-com.aspose.diagram.VerticalAlign-}
+```
+public void setVerticalAlign(VerticalAlign value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getVerticalAlign()](../../com.aspose.diagram/textblock\#getVerticalAlign--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [VerticalAlign](../../com.aspose.diagram/verticalalign) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textboxactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/textboxactivexcontrol/_index.md
@@ -1,0 +1,922 @@
+---
+title: TextBoxActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en textlåda ActiveX‑kontroll.
+type: docs
+weight: 401
+url: /sv/java/com.aspose.diagram/textboxactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class TextBoxActiveXControl extends ActiveXControl
+```
+
+Representerar en textlåda ActiveX‑kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderOleColor()](#getBorderOleColor--) | ole-färgen för bakgrunden. |
+| [getBorderStyle()](#getBorderStyle--) | typen av ram som används av kontrollen. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getDropButtonStyle()](#getDropButtonStyle--) | Anger symbolen som visas på nedrullningsknappen |
+| [getEnterFieldBehavior()](#getEnterFieldBehavior--) | Anger urvalsbeteende när kontrollen aktiveras. |
+| [getEnterKeyBehavior()](#getEnterKeyBehavior--) | Anger beteendet för ENTER-tangenten. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getHideSelection()](#getHideSelection--) | Indikerar om markerad text i kontrollen visas markerad när kontrollen inte har fokus. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getIntegralHeight()](#getIntegralHeight--) | Indikerar om kontrollen endast visar kompletta textrader utan att visa några partiella rader. |
+| [getMaxLength()](#getMaxLength--) | det maximala antalet tecken |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPasswordChar()](#getPasswordChar--) | Ett tecken som ska visas i stället för de inmatade tecknen. |
+| [getScrollBars()](#getScrollBars--) | Indikerar om kontrollen har vertikala rullningslister, horisontella rullningslister, båda eller ingen. |
+| [getShowDropButtonTypeWhen()](#getShowDropButtonTypeWhen--) | Anger symbolen som visas på nedrullningsknappen |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getTabKeyBehavior()](#getTabKeyBehavior--) | Indikerar om tabulatortecken är tillåtna i kontrollens text. |
+| [getText()](#getText--) | kontrollens text. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isAutoTab()](#isAutoTab--) | Anger om fokus automatiskt kommer att flyttas till nästa kontroll när användaren anger det maximala antalet tecken. |
+| [isAutoWordSelected()](#isAutoWordSelected--) | Anger den grundläggande enheten som används för att utöka en markering. |
+| [isDragBehaviorEnabled()](#isDragBehaviorEnabled--) | Indikerar om dra‑och‑släpp är aktiverat för kontrollen. |
+| [isEditable()](#isEditable--) | Indikerar om användaren kan skriva i kontrollen. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isMultiLine()](#isMultiLine--) | Anger om kontrollen kan visa mer än en rad text. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isWordWrapped()](#isWordWrapped--) | Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setAutoTab(boolean value)](#setAutoTab-boolean-) | För beskrivningen av denna egenskap, se [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--) |
+| [setAutoWordSelected(boolean value)](#setAutoWordSelected-boolean-) | För beskrivningen av denna egenskap, se [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setBorderOleColor(int value)](#setBorderOleColor-int-) | För beskrivningen av denna egenskap, se [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--) |
+| [setBorderStyle(int value)](#setBorderStyle-int-) | För beskrivningen av denna egenskap, se [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--) |
+| [setDragBehaviorEnabled(boolean value)](#setDragBehaviorEnabled-boolean-) | För beskrivningen av denna egenskap, se [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--) |
+| [setDropButtonStyle(int value)](#setDropButtonStyle-int-) | För beskrivningen av denna egenskap, se [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--) |
+| [setEditable(boolean value)](#setEditable-boolean-) | För beskrivningen av denna egenskap, se [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setEnterFieldBehavior(boolean value)](#setEnterFieldBehavior-boolean-) | För beskrivningen av denna egenskap, se [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--) |
+| [setEnterKeyBehavior(boolean value)](#setEnterKeyBehavior-boolean-) | För beskrivningen av denna egenskap, se [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setHideSelection(boolean value)](#setHideSelection-boolean-) | För beskrivningen av denna egenskap, se [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setIntegralHeight(boolean value)](#setIntegralHeight-boolean-) | För beskrivningen av denna egenskap, se [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMaxLength(int value)](#setMaxLength-int-) | För beskrivningen av denna egenskap, se [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setMultiLine(boolean value)](#setMultiLine-boolean-) | För beskrivningen av denna egenskap, se [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--) |
+| [setPasswordChar(char value)](#setPasswordChar-char-) | För beskrivningen av denna egenskap, se [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--) |
+| [setScrollBars(int value)](#setScrollBars-int-) | För beskrivningen av denna egenskap, se [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--) |
+| [setShowDropButtonTypeWhen(int value)](#setShowDropButtonTypeWhen-int-) | För beskrivningen av denna egenskap, se [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--) |
+| [setTabKeyBehavior(boolean value)](#setTabKeyBehavior-boolean-) | För beskrivningen av denna egenskap, se [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--) |
+| [setText(String value)](#setText-java.lang.String-) | För beskrivningen av denna egenskap, se [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [setWordWrapped(boolean value)](#setWordWrapped-boolean-) | För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderOleColor() {#getBorderOleColor--}
+```
+public int getBorderOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getBorderStyle() {#getBorderStyle--}
+```
+public int getBorderStyle()
+```
+
+
+typen av ram som används av kontrollen.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getDropButtonStyle() {#getDropButtonStyle--}
+```
+public int getDropButtonStyle()
+```
+
+
+Anger symbolen som visas på nedrullningsknappen
+
+**Returns:**
+int
+### getEnterFieldBehavior() {#getEnterFieldBehavior--}
+```
+public boolean getEnterFieldBehavior()
+```
+
+
+Anger markeringsbeteende när kontrollen aktiveras. True anger att markeringen förblir oförändrad sedan senaste gången kontrollen var aktiv. False anger att all text i kontrollen kommer att markeras när kontrollen aktiveras.
+
+**Returns:**
+boolean
+### getEnterKeyBehavior() {#getEnterKeyBehavior--}
+```
+public boolean getEnterKeyBehavior()
+```
+
+
+Anger beteendet för ENTER-tangenten. Sant anger att trycka på ENTER skapar en ny rad. Falskt anger att trycka på ENTER flyttar fokus till nästa objekt i tabb-ordningen.
+
+**Returns:**
+boolean
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getHideSelection() {#getHideSelection--}
+```
+public boolean getHideSelection()
+```
+
+
+Indikerar om markerad text i kontrollen visas markerad när kontrollen inte har fokus.
+
+**Returns:**
+boolean
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getIntegralHeight() {#getIntegralHeight--}
+```
+public boolean getIntegralHeight()
+```
+
+
+Indikerar om kontrollen endast visar kompletta textrader utan att visa några partiella rader.
+
+**Returns:**
+boolean
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+det maximala antalet tecken
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPasswordChar() {#getPasswordChar--}
+```
+public char getPasswordChar()
+```
+
+
+Ett tecken som ska visas i stället för de inmatade tecknen.
+
+**Returns:**
+char
+### getScrollBars() {#getScrollBars--}
+```
+public int getScrollBars()
+```
+
+
+Indikerar om kontrollen har vertikala rullningslister, horisontella rullningslister, båda eller ingen.
+
+**Returns:**
+int
+### getShowDropButtonTypeWhen() {#getShowDropButtonTypeWhen--}
+```
+public int getShowDropButtonTypeWhen()
+```
+
+
+Anger symbolen som visas på nedrullningsknappen
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getTabKeyBehavior() {#getTabKeyBehavior--}
+```
+public boolean getTabKeyBehavior()
+```
+
+
+Indikerar om tabulatortecken är tillåtna i kontrollens text.
+
+**Returns:**
+boolean
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+kontrollens text.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isAutoTab() {#isAutoTab--}
+```
+public boolean isAutoTab()
+```
+
+
+Anger om fokus automatiskt kommer att flyttas till nästa kontroll när användaren anger det maximala antalet tecken.
+
+**Returns:**
+boolean
+### isAutoWordSelected() {#isAutoWordSelected--}
+```
+public boolean isAutoWordSelected()
+```
+
+
+Anger den grundläggande enheten som används för att utöka en markering. True anger att den grundläggande enheten är ett enskilt tecken. false anger att den grundläggande enheten är ett helt ord.
+
+**Returns:**
+boolean
+### isDragBehaviorEnabled() {#isDragBehaviorEnabled--}
+```
+public boolean isDragBehaviorEnabled()
+```
+
+
+Indikerar om dra‑och‑släpp är aktiverat för kontrollen.
+
+**Returns:**
+boolean
+### isEditable() {#isEditable--}
+```
+public boolean isEditable()
+```
+
+
+Indikerar om användaren kan skriva i kontrollen.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isMultiLine() {#isMultiLine--}
+```
+public boolean isMultiLine()
+```
+
+
+Anger om kontrollen kan visa mer än en rad text.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isWordWrapped() {#isWordWrapped--}
+```
+public boolean isWordWrapped()
+```
+
+
+Anger om innehållet i kontrollen automatiskt radbryts i slutet av en rad.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setAutoTab(boolean value) {#setAutoTab-boolean-}
+```
+public void setAutoTab(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoTab()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoTab--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setAutoWordSelected(boolean value) {#setAutoWordSelected-boolean-}
+```
+public void setAutoWordSelected(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoWordSelected()](../../com.aspose.diagram/textboxactivexcontrol\#isAutoWordSelected--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderOleColor(int value) {#setBorderOleColor-int-}
+```
+public void setBorderOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBorderOleColor()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setBorderStyle(int value) {#setBorderStyle-int-}
+```
+public void setBorderStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBorderStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getBorderStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDragBehaviorEnabled(boolean value) {#setDragBehaviorEnabled-boolean-}
+```
+public void setDragBehaviorEnabled(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isDragBehaviorEnabled()](../../com.aspose.diagram/textboxactivexcontrol\#isDragBehaviorEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDropButtonStyle(int value) {#setDropButtonStyle-int-}
+```
+public void setDropButtonStyle(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDropButtonStyle()](../../com.aspose.diagram/textboxactivexcontrol\#getDropButtonStyle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEditable(boolean value) {#setEditable-boolean-}
+```
+public void setEditable(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isEditable()](../../com.aspose.diagram/textboxactivexcontrol\#isEditable--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnterFieldBehavior(boolean value) {#setEnterFieldBehavior-boolean-}
+```
+public void setEnterFieldBehavior(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEnterFieldBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterFieldBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setEnterKeyBehavior(boolean value) {#setEnterKeyBehavior-boolean-}
+```
+public void setEnterKeyBehavior(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEnterKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getEnterKeyBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setHideSelection(boolean value) {#setHideSelection-boolean-}
+```
+public void setHideSelection(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHideSelection()](../../com.aspose.diagram/textboxactivexcontrol\#getHideSelection--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setIntegralHeight(boolean value) {#setIntegralHeight-boolean-}
+```
+public void setIntegralHeight(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getIntegralHeight()](../../com.aspose.diagram/textboxactivexcontrol\#getIntegralHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMaxLength(int value) {#setMaxLength-int-}
+```
+public void setMaxLength(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getMaxLength()](../../com.aspose.diagram/textboxactivexcontrol\#getMaxLength--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMultiLine(boolean value) {#setMultiLine-boolean-}
+```
+public void setMultiLine(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isMultiLine()](../../com.aspose.diagram/textboxactivexcontrol\#isMultiLine--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPasswordChar(char value) {#setPasswordChar-char-}
+```
+public void setPasswordChar(char value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPasswordChar()](../../com.aspose.diagram/textboxactivexcontrol\#getPasswordChar--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setScrollBars(int value) {#setScrollBars-int-}
+```
+public void setScrollBars(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getScrollBars()](../../com.aspose.diagram/textboxactivexcontrol\#getScrollBars--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowDropButtonTypeWhen(int value) {#setShowDropButtonTypeWhen-int-}
+```
+public void setShowDropButtonTypeWhen(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShowDropButtonTypeWhen()](../../com.aspose.diagram/textboxactivexcontrol\#getShowDropButtonTypeWhen--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/textboxactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTabKeyBehavior(boolean value) {#setTabKeyBehavior-boolean-}
+```
+public void setTabKeyBehavior(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTabKeyBehavior()](../../com.aspose.diagram/textboxactivexcontrol\#getTabKeyBehavior--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getText()](../../com.aspose.diagram/textboxactivexcontrol\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWordWrapped(boolean value) {#setWordWrapped-boolean-}
+```
+public void setWordWrapped(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isWordWrapped()](../../com.aspose.diagram/textboxactivexcontrol\#isWordWrapped--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/textcollection/_index.md
@@ -1,0 +1,218 @@
+---
+title: TextCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller texten för en figur.
+type: docs
+weight: 402
+url: /sv/java/com.aspose.diagram/textcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class TextCollection extends Collection
+```
+
+Innehåller texten för en form. Varje objekt är text med tecken-, stycke- och tabb-egenskaper.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Text item)](#add-com.aspose.diagram.Text-) | Lägg till Text-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Text item)](#remove-com.aspose.diagram.Text-) | Ta bort Text-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Text item) {#add-com.aspose.diagram.Text-}
+```
+public int add(Text item)
+```
+
+
+Lägg till Text-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Text get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Text](../../com.aspose.diagram/text) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Text item) {#remove-com.aspose.diagram.Text-}
+```
+public void remove(Text item)
+```
+
+
+Ta bort Text-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [Text](../../com.aspose.diagram/text) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textdirection/_index.md
+++ b/swedish/java/com.aspose.diagram/textdirection/_index.md
@@ -1,0 +1,204 @@
+---
+title: TextDirection
+second_title: Aspose.Diagram för Java API-referens
+description: Anger teckenriktningen i ett textblock.
+type: docs
+weight: 403
+url: /sv/java/com.aspose.diagram/textdirection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextDirection
+```
+
+Anger teckenriktningen i ett textblock.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TextDirection(int value)](#TextDirection-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger teckenriktningen i ett textblock. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/textdirection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TextDirection(int value) {#TextDirection-int-}
+```
+public TextDirection(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger teckenriktningen i ett textblock.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/textdirection\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/textdirection\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textdirectionvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/textdirectionvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: TextDirectionValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger teckenriktningen i ett textblock.
+type: docs
+weight: 404
+url: /sv/java/com.aspose.diagram/textdirectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TextDirectionValue
+```
+
+Anger teckenriktningen i ett textblock.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [HORIZONTAL](#HORIZONTAL) | Horizontal. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VERTICAL](#VERTICAL) | Vertical. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HORIZONTAL {#HORIZONTAL}
+```
+public static final int HORIZONTAL
+```
+
+
+Horizontal.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VERTICAL {#VERTICAL}
+```
+public static final int VERTICAL
+```
+
+
+Vertical.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/textxform/_index.md
+++ b/swedish/java/com.aspose.diagram/textxform/_index.md
@@ -1,0 +1,336 @@
+---
+title: TextXForm
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som specificerar placeringsinformation om en formes textblock.
+type: docs
+weight: 405
+url: /sv/java/com.aspose.diagram/textxform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TextXForm
+```
+
+Innehåller element som specificerar placeringsinformation om en figurs textblock.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getTxtAngle()](#getTxtAngle--) | Anger textblockets aktuella rotationsvinkel i förhållande till formens x‑axel. |
+| [getTxtHeight()](#getTxtHeight--) | Anger höjden på textblocket. |
+| [getTxtLocPinX()](#getTxtLocPinX--) | Anger x‑koordinaten för textblockets rotationscentrum i förhållande till textblockets ursprung. |
+| [getTxtLocPinY()](#getTxtLocPinY--) | Anger y‑koordinaten för textblockets rotationscentrum i förhållande till textblockets ursprung. |
+| [getTxtPinX()](#getTxtPinX--) | Anger x‑koordinaten för textblockets rotationscentrum i förhållande till formens ursprung. |
+| [getTxtPinY()](#getTxtPinY--) | Anger y‑koordinaten för textblockets rotationscentrum i förhållande till formens ursprung. |
+| [getTxtWidth()](#getTxtWidth--) | Anger bredden på textblocket. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/textxform\#getDel--) |
+| [setTxtAngle(DoubleValue value)](#setTxtAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--) |
+| [setTxtHeight(DoubleValue value)](#setTxtHeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--) |
+| [setTxtLocPinX(DoubleValue value)](#setTxtLocPinX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--) |
+| [setTxtLocPinY(DoubleValue value)](#setTxtLocPinY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--) |
+| [setTxtPinX(DoubleValue value)](#setTxtPinX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--) |
+| [setTxtPinY(DoubleValue value)](#setTxtPinY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--) |
+| [setTxtWidth(DoubleValue value)](#setTxtWidth-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getTxtAngle() {#getTxtAngle--}
+```
+public DoubleValue getTxtAngle()
+```
+
+
+Anger textblockets aktuella rotationsvinkel i förhållande till formens x‑axel. Standardvärdet är 0 grader.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtHeight() {#getTxtHeight--}
+```
+public DoubleValue getTxtHeight()
+```
+
+
+Anger höjden på textblocket. Standardformeln, som utvärderas till formens höjd, är F="Height\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinX() {#getTxtLocPinX--}
+```
+public DoubleValue getTxtLocPinX()
+```
+
+
+Anger x‑koordinaten för textblockets rotationscentrum i förhållande till textblockets ursprung. Standardformeln, som utvärderas till textblockets horisontella centrum, är F="TxtWidth\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtLocPinY() {#getTxtLocPinY--}
+```
+public DoubleValue getTxtLocPinY()
+```
+
+
+Anger y‑koordinaten för textblockets rotationscentrum i förhållande till textblockets ursprung. Standardformeln, som utvärderas till textblockets vertikala centrum, är F="TxtHeight\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinX() {#getTxtPinX--}
+```
+public DoubleValue getTxtPinX()
+```
+
+
+Anger x‑koordinaten för textblockets rotationscentrum i förhållande till formens ursprung. Standardformeln, som utvärderas till formens horisontella centrum, är F="Width\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtPinY() {#getTxtPinY--}
+```
+public DoubleValue getTxtPinY()
+```
+
+
+Anger y‑koordinaten för textblockets rotationscentrum i förhållande till formens ursprung. Standardformeln, som utvärderas till formens vertikala centrum, är F="Height\*0.5".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getTxtWidth() {#getTxtWidth--}
+```
+public DoubleValue getTxtWidth()
+```
+
+
+Anger bredden på textblocket. Standardformeln, som utvärderas till formens bredd, är F="Width\*1".
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/textxform\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTxtAngle(DoubleValue value) {#setTxtAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtAngle(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtAngle()](../../com.aspose.diagram/textxform\#getTxtAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtHeight(DoubleValue value) {#setTxtHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtHeight(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtHeight()](../../com.aspose.diagram/textxform\#getTxtHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinX(DoubleValue value) {#setTxtLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtLocPinX()](../../com.aspose.diagram/textxform\#getTxtLocPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtLocPinY(DoubleValue value) {#setTxtLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtLocPinY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtLocPinY()](../../com.aspose.diagram/textxform\#getTxtLocPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinX(DoubleValue value) {#setTxtPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtPinX()](../../com.aspose.diagram/textxform\#getTxtPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtPinY(DoubleValue value) {#setTxtPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtPinY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtPinY()](../../com.aspose.diagram/textxform\#getTxtPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setTxtWidth(DoubleValue value) {#setTxtWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setTxtWidth(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTxtWidth()](../../com.aspose.diagram/textxform\#getTxtWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/threedformat/_index.md
+++ b/swedish/java/com.aspose.diagram/threedformat/_index.md
@@ -1,0 +1,625 @@
+---
+title: ThreeDFormat
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en forms tredimensionella formatering.
+type: docs
+weight: 406
+url: /sv/java/com.aspose.diagram/threedformat/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ThreeDFormat
+```
+
+Representerar en figurs tredimensionella formatering.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getBevelBottomHeight()](#getBevelBottomHeight--) | Anger höjden på den nedre avfasningen på en 3D-form. |
+| [getBevelBottomType()](#getBevelBottomType--) | Anger den förinställda avfasningstypen för den nedre avfasningen på en 3D-form. |
+| [getBevelBottomWidth()](#getBevelBottomWidth--) | Anger bredden på den nedre avfasningen på en 3D-form. |
+| [getBevelContourColor()](#getBevelContourColor--) | Anger färgen på konturen på en 3D-form. |
+| [getBevelContourSize()](#getBevelContourSize--) | Anger tjockleken på konturen på en 3D-form. |
+| [getBevelDepthColor()](#getBevelDepthColor--) | Anger extruderingsfärgen på en 3D-form. |
+| [getBevelDepthSize()](#getBevelDepthSize--) | Anger extruderingsdjupet på en 3D-form. |
+| [getBevelLightingAngle()](#getBevelLightingAngle--) | Anger riktningen för belysning på en 3D-form. |
+| [getBevelLightingType()](#getBevelLightingType--) | Anger den förinställda belysningstypen på en 3D-form. |
+| [getBevelMaterialType()](#getBevelMaterialType--) | Anger det förinställda ytutseendet på en 3D-form. |
+| [getBevelTopHeight()](#getBevelTopHeight--) | Anger höjden på den övre avfasningen på en 3D-form. |
+| [getBevelTopType()](#getBevelTopType--) | Anger den förinställda avfasningstypen för den övre avfasningen på en 3D-form. |
+| [getBevelTopWidth()](#getBevelTopWidth--) | Anger bredden på den övre avfasningen på en 3D-form. |
+| [getClass()](#getClass--) |  |
+| [getDistanceFromGround()](#getDistanceFromGround--) | Anger avståndet som en form med 3D-rotationsegenskaper |
+| [getKeepTextFlat()](#getKeepTextFlat--) | Anger om 3D-rotationsegenskaper gäller för texten i en form. |
+| [getPerspective()](#getPerspective--) | Anger betraktningsvinkeln för en form med 3D-rotationsegenskaper. |
+| [getRotationType()](#getRotationType--) | Anger projektionstypen för effektens egenskaper hos en form. |
+| [getRotationXAngle()](#getRotationXAngle--) | Anger den moturs rotationen runt y-axeln för en form. |
+| [getRotationYAngle()](#getRotationYAngle--) | Anger den moturs rotationen runt x-axeln för en form. |
+| [getRotationZAngle()](#getRotationZAngle--) | Anger den moturs rotationen runt z-axeln för en form. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBevelBottomHeight(DoubleValue value)](#setBevelBottomHeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--) |
+| [setBevelBottomType(BevelType value)](#setBevelBottomType-com.aspose.diagram.BevelType-) | För beskrivningen av den här egenskapen, se [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--) |
+| [setBevelBottomWidth(DoubleValue value)](#setBevelBottomWidth-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--) |
+| [setBevelContourColor(ColorValue value)](#setBevelContourColor-com.aspose.diagram.ColorValue-) | För beskrivningen av den här egenskapen, se [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--) |
+| [setBevelContourSize(DoubleValue value)](#setBevelContourSize-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--) |
+| [setBevelDepthColor(ColorValue value)](#setBevelDepthColor-com.aspose.diagram.ColorValue-) | För beskrivningen av den här egenskapen, se [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--) |
+| [setBevelDepthSize(DoubleValue value)](#setBevelDepthSize-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--) |
+| [setBevelLightingAngle(DoubleValue value)](#setBevelLightingAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--) |
+| [setBevelLightingType(BevelLightingType value)](#setBevelLightingType-com.aspose.diagram.BevelLightingType-) | För beskrivningen av den här egenskapen, se [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--) |
+| [setBevelMaterialType(BevelMaterialType value)](#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-) | För beskrivningen av den här egenskapen, se [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--) |
+| [setBevelTopHeight(DoubleValue value)](#setBevelTopHeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--) |
+| [setBevelTopType(BevelType value)](#setBevelTopType-com.aspose.diagram.BevelType-) | För beskrivningen av den här egenskapen, se [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--) |
+| [setBevelTopWidth(DoubleValue value)](#setBevelTopWidth-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--) |
+| [setDistanceFromGround(DoubleValue value)](#setDistanceFromGround-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--) |
+| [setKeepTextFlat(BoolValue value)](#setKeepTextFlat-com.aspose.diagram.BoolValue-) | För beskrivningen av den här egenskapen, se [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--) |
+| [setPerspective(DoubleValue value)](#setPerspective-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--) |
+| [setRotationType(RotationType value)](#setRotationType-com.aspose.diagram.RotationType-) | För beskrivningen av den här egenskapen, se [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--) |
+| [setRotationXAngle(DoubleValue value)](#setRotationXAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--) |
+| [setRotationYAngle(DoubleValue value)](#setRotationYAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--) |
+| [setRotationZAngle(DoubleValue value)](#setRotationZAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av den här egenskapen, se [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getBevelBottomHeight() {#getBevelBottomHeight--}
+```
+public DoubleValue getBevelBottomHeight()
+```
+
+
+Anger höjden på den nedre avfasningen på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelBottomType() {#getBevelBottomType--}
+```
+public BevelType getBevelBottomType()
+```
+
+
+Anger den förinställda avfasningstypen för den nedre avfasningen på en 3D-form.
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelBottomWidth() {#getBevelBottomWidth--}
+```
+public DoubleValue getBevelBottomWidth()
+```
+
+
+Anger bredden på den nedre avfasningen på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelContourColor() {#getBevelContourColor--}
+```
+public ColorValue getBevelContourColor()
+```
+
+
+Anger färgen på konturen på en 3D-form.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelContourSize() {#getBevelContourSize--}
+```
+public DoubleValue getBevelContourSize()
+```
+
+
+Anger tjockleken på konturen på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelDepthColor() {#getBevelDepthColor--}
+```
+public ColorValue getBevelDepthColor()
+```
+
+
+Anger extruderingsfärgen på en 3D-form.
+
+**Returns:**
+[ColorValue](../../com.aspose.diagram/colorvalue)
+### getBevelDepthSize() {#getBevelDepthSize--}
+```
+public DoubleValue getBevelDepthSize()
+```
+
+
+Anger extruderingsdjupet på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingAngle() {#getBevelLightingAngle--}
+```
+public DoubleValue getBevelLightingAngle()
+```
+
+
+Anger riktningen för belysning på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelLightingType() {#getBevelLightingType--}
+```
+public BevelLightingType getBevelLightingType()
+```
+
+
+Anger den förinställda belysningstypen på en 3D-form.
+
+**Returns:**
+[BevelLightingType](../../com.aspose.diagram/bevellightingtype)
+### getBevelMaterialType() {#getBevelMaterialType--}
+```
+public BevelMaterialType getBevelMaterialType()
+```
+
+
+Anger det förinställda ytutseendet på en 3D-form.
+
+**Returns:**
+[BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype)
+### getBevelTopHeight() {#getBevelTopHeight--}
+```
+public DoubleValue getBevelTopHeight()
+```
+
+
+Anger höjden på den övre avfasningen på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBevelTopType() {#getBevelTopType--}
+```
+public BevelType getBevelTopType()
+```
+
+
+Anger den förinställda avfasningstypen för den övre avfasningen på en 3D-form.
+
+**Returns:**
+[BevelType](../../com.aspose.diagram/beveltype)
+### getBevelTopWidth() {#getBevelTopWidth--}
+```
+public DoubleValue getBevelTopWidth()
+```
+
+
+Anger bredden på den övre avfasningen på en 3D-form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDistanceFromGround() {#getDistanceFromGround--}
+```
+public DoubleValue getDistanceFromGround()
+```
+
+
+Anger avståndet som en form med 3D-rotationsegenskaper
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getKeepTextFlat() {#getKeepTextFlat--}
+```
+public BoolValue getKeepTextFlat()
+```
+
+
+Anger om 3D-rotationsegenskaper gäller för texten i en form.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getPerspective() {#getPerspective--}
+```
+public DoubleValue getPerspective()
+```
+
+
+Anger betraktningsvinkeln för en form med 3D-rotationsegenskaper.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationType() {#getRotationType--}
+```
+public RotationType getRotationType()
+```
+
+
+Anger projektionstypen för effektens egenskaper hos en form.
+
+**Returns:**
+[RotationType](../../com.aspose.diagram/rotationtype)
+### getRotationXAngle() {#getRotationXAngle--}
+```
+public DoubleValue getRotationXAngle()
+```
+
+
+Anger den moturs rotationen runt y-axeln för en form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationYAngle() {#getRotationYAngle--}
+```
+public DoubleValue getRotationYAngle()
+```
+
+
+Anger den moturs rotationen runt x-axeln för en form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getRotationZAngle() {#getRotationZAngle--}
+```
+public DoubleValue getRotationZAngle()
+```
+
+
+Anger den moturs rotationen runt z-axeln för en form.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBevelBottomHeight(DoubleValue value) {#setBevelBottomHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomHeight(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelBottomHeight()](../../com.aspose.diagram/threedformat\#getBevelBottomHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelBottomType(BevelType value) {#setBevelBottomType-com.aspose.diagram.BevelType-}
+```
+public void setBevelBottomType(BevelType value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelBottomType()](../../com.aspose.diagram/threedformat\#getBevelBottomType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelBottomWidth(DoubleValue value) {#setBevelBottomWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelBottomWidth(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelBottomWidth()](../../com.aspose.diagram/threedformat\#getBevelBottomWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelContourColor(ColorValue value) {#setBevelContourColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelContourColor(ColorValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelContourColor()](../../com.aspose.diagram/threedformat\#getBevelContourColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelContourSize(DoubleValue value) {#setBevelContourSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelContourSize(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelContourSize()](../../com.aspose.diagram/threedformat\#getBevelContourSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelDepthColor(ColorValue value) {#setBevelDepthColor-com.aspose.diagram.ColorValue-}
+```
+public void setBevelDepthColor(ColorValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelDepthColor()](../../com.aspose.diagram/threedformat\#getBevelDepthColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ColorValue](../../com.aspose.diagram/colorvalue) |  |
+
+### setBevelDepthSize(DoubleValue value) {#setBevelDepthSize-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelDepthSize(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelDepthSize()](../../com.aspose.diagram/threedformat\#getBevelDepthSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingAngle(DoubleValue value) {#setBevelLightingAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelLightingAngle(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelLightingAngle()](../../com.aspose.diagram/threedformat\#getBevelLightingAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelLightingType(BevelLightingType value) {#setBevelLightingType-com.aspose.diagram.BevelLightingType-}
+```
+public void setBevelLightingType(BevelLightingType value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelLightingType()](../../com.aspose.diagram/threedformat\#getBevelLightingType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BevelLightingType](../../com.aspose.diagram/bevellightingtype) |  |
+
+### setBevelMaterialType(BevelMaterialType value) {#setBevelMaterialType-com.aspose.diagram.BevelMaterialType-}
+```
+public void setBevelMaterialType(BevelMaterialType value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelMaterialType()](../../com.aspose.diagram/threedformat\#getBevelMaterialType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BevelMaterialType](../../com.aspose.diagram/bevelmaterialtype) |  |
+
+### setBevelTopHeight(DoubleValue value) {#setBevelTopHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopHeight(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelTopHeight()](../../com.aspose.diagram/threedformat\#getBevelTopHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBevelTopType(BevelType value) {#setBevelTopType-com.aspose.diagram.BevelType-}
+```
+public void setBevelTopType(BevelType value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelTopType()](../../com.aspose.diagram/threedformat\#getBevelTopType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BevelType](../../com.aspose.diagram/beveltype) |  |
+
+### setBevelTopWidth(DoubleValue value) {#setBevelTopWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setBevelTopWidth(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getBevelTopWidth()](../../com.aspose.diagram/threedformat\#getBevelTopWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDistanceFromGround(DoubleValue value) {#setDistanceFromGround-com.aspose.diagram.DoubleValue-}
+```
+public void setDistanceFromGround(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDistanceFromGround()](../../com.aspose.diagram/threedformat\#getDistanceFromGround--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setKeepTextFlat(BoolValue value) {#setKeepTextFlat-com.aspose.diagram.BoolValue-}
+```
+public void setKeepTextFlat(BoolValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getKeepTextFlat()](../../com.aspose.diagram/threedformat\#getKeepTextFlat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setPerspective(DoubleValue value) {#setPerspective-com.aspose.diagram.DoubleValue-}
+```
+public void setPerspective(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPerspective()](../../com.aspose.diagram/threedformat\#getPerspective--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationType(RotationType value) {#setRotationType-com.aspose.diagram.RotationType-}
+```
+public void setRotationType(RotationType value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRotationType()](../../com.aspose.diagram/threedformat\#getRotationType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [RotationType](../../com.aspose.diagram/rotationtype) |  |
+
+### setRotationXAngle(DoubleValue value) {#setRotationXAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationXAngle(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRotationXAngle()](../../com.aspose.diagram/threedformat\#getRotationXAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationYAngle(DoubleValue value) {#setRotationYAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationYAngle(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRotationYAngle()](../../com.aspose.diagram/threedformat\#getRotationYAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setRotationZAngle(DoubleValue value) {#setRotationZAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setRotationZAngle(DoubleValue value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getRotationZAngle()](../../com.aspose.diagram/threedformat\#getRotationZAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/tiffcompression/_index.md
+++ b/swedish/java/com.aspose.diagram/tiffcompression/_index.md
@@ -1,0 +1,174 @@
+---
+title: TiffCompression
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vilken typ av komprimering som ska tillämpas när sidor sparas i TIFF‑format.
+type: docs
+weight: 407
+url: /sv/java/com.aspose.diagram/tiffcompression/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TiffCompression
+```
+
+Anger vilken typ av komprimering som ska tillämpas när sidor sparas i TIFF‑format.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CCITT_3](#CCITT-3) | Anger CCITT3-komprimeringsschemat. |
+| [CCITT_4](#CCITT-4) | Anger CCITT4-komprimeringsschemat. |
+| [LZW](#LZW) | Anger LZW-komprimeringsschemat. |
+| [NONE](#NONE) | Anger ingen komprimering. |
+| [RLE](#RLE) | Anger RLE-komprimeringsschemat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CCITT_3 {#CCITT-3}
+```
+public static final int CCITT_3
+```
+
+
+Anger CCITT3-komprimeringsschemat.
+
+### CCITT_4 {#CCITT-4}
+```
+public static final int CCITT_4
+```
+
+
+Anger CCITT4-komprimeringsschemat.
+
+### LZW {#LZW}
+```
+public static final int LZW
+```
+
+
+Anger LZW-komprimeringsschemat.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Anger ingen komprimering.
+
+### RLE {#RLE}
+```
+public static final int RLE
+```
+
+
+Anger RLE-komprimeringsschemat.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/timelinehelper/_index.md
+++ b/swedish/java/com.aspose.diagram/timelinehelper/_index.md
@@ -1,0 +1,512 @@
+---
+title: TimeLineHelper
+second_title: Aspose.Diagram för Java API-referens
+description: TimeLineHelper för att sätta egenskap på tidslinjefigur.
+type: docs
+weight: 408
+url: /sv/java/com.aspose.diagram/timelinehelper/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TimeLineHelper
+```
+
+TimeLineHelper för att sätta egenskap på tidslinjefigur.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TimeLineHelper(Shape shape)](#TimeLineHelper-com.aspose.diagram.Shape-) | TimeLineHelper. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDoubleStringFromDateTime(DateTime dateTime)](#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-) | Konvertera datumtiden till ett dubbelvärde. |
+| [getTimePeriodFinish()](#getTimePeriodFinish--) | Tidsperiod för slutet av tidslinjeformen |
+| [getTimePeriodStart()](#getTimePeriodStart--) | Tidsperiod för start av tidslinjeformen |
+| [getTimeScale()](#getTimeScale--) | Skala för tidslinjeformen |
+| [getWeekEnd(DateTime startDate, int weekStart)](#getWeekEnd-com.aspose.diagram.DateTime-int-) | getweekstart |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [refreshTimeLine()](#refreshTimeLine--) | Uppdatera tiden för tidslinjeformer |
+| [setArrowHead(int value)](#setArrowHead-int-) | Pilspets för tidslinjeformen |
+| [setAutoUpdate(boolean value)](#setAutoUpdate-boolean-) | om data för markörer (milstenar, intervaller) ska uppdateras när de flyttas på tidslinjen |
+| [setBeginWeek(int value)](#setBeginWeek-int-) | Startvecka för tidslinjeformen |
+|  | [setDateFormatForBE(int value)](#setDateFormatForBE-int-) | Datumformat för start och slut av tidslinjeformen /// |
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+|  | [setDateFormatForIntm(int value)](#setDateFormatForIntm-int-) | Datumformat för mellanliggande tid för tidslinjeformen /// |
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.                         | |
+| [setDateFormatStringForBE(String value)](#setDateFormatStringForBE-java.lang.String-) | Datumformatsträng för start och slut av tidslinjeformen |
+| [setDateFormatStringForIntm(String value)](#setDateFormatStringForIntm-java.lang.String-) | Datumformatsträng för mellanliggande tid för tidslinjeformen |
+| [setDisplayBE(boolean value)](#setDisplayBE-boolean-) | om start- och slutdatum ska visas på tidslinjen |
+| [setDisplayIntm(boolean value)](#setDisplayIntm-boolean-) | om interim datum/tid-markeringar ska visas på tidslinjen |
+| [setDisplayIntmDates(boolean value)](#setDisplayIntmDates-boolean-) | om interimdatum ska visas på interimmarkeringar |
+| [setFiscalStart(DateTime value)](#setFiscalStart-com.aspose.diagram.DateTime-) | Första dagen i räkenskapsåret |
+| [setTimeLineType(int value)](#setTimeLineType-int-) | Startvecka för tidslinjeformen |
+| [setTimePeriodFinish(DateTime value)](#setTimePeriodFinish-com.aspose.diagram.DateTime-) |  |
+| [setTimePeriodStart(DateTime value)](#setTimePeriodStart-com.aspose.diagram.DateTime-) |  |
+| [setTimeScale(int value)](#setTimeScale-int-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TimeLineHelper(Shape shape) {#TimeLineHelper-com.aspose.diagram.Shape-}
+```
+public TimeLineHelper(Shape shape)
+```
+
+
+TimeLineHelper.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| shape | [Shape](../../com.aspose.diagram/shape) |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDoubleStringFromDateTime(DateTime dateTime) {#getDoubleStringFromDateTime-com.aspose.diagram.DateTime-}
+```
+public static String getDoubleStringFromDateTime(DateTime dateTime)
+```
+
+
+Konvertera datumtiden till ett dubbelvärde.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| dateTime | [DateTime](../../com.aspose.diagram/datetime) | Datum och tid. |
+
+**Returns:**
+java.lang.String -
+### getTimePeriodFinish() {#getTimePeriodFinish--}
+```
+public DateTime getTimePeriodFinish()
+```
+
+
+Tidsperiod för slutet av tidslinjeformen
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimePeriodStart() {#getTimePeriodStart--}
+```
+public DateTime getTimePeriodStart()
+```
+
+
+Tidsperiod för start av tidslinjeformen
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getTimeScale() {#getTimeScale--}
+```
+public int getTimeScale()
+```
+
+
+Skala för tidslinjeformen
+
+**Returns:**
+int
+### getWeekEnd(DateTime startDate, int weekStart) {#getWeekEnd-com.aspose.diagram.DateTime-int-}
+```
+public static DateTime getWeekEnd(DateTime startDate, int weekStart)
+```
+
+
+getweekstart
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| startDate | [DateTime](../../com.aspose.diagram/datetime) |  |
+| veckostart | int | (0söndag 1måndag 2 3 4 5 6) |
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### refreshTimeLine() {#refreshTimeLine--}
+```
+public void refreshTimeLine()
+```
+
+
+Uppdatera tiden för tidslinjeformer
+
+### setArrowHead(int value) {#setArrowHead-int-}
+```
+public void setArrowHead(int value)
+```
+
+
+Pilspets för tidslinjeformen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setAutoUpdate(boolean value) {#setAutoUpdate-boolean-}
+```
+public void setAutoUpdate(boolean value)
+```
+
+
+om data för markörer (milstenar, intervaller) ska uppdateras när de flyttas på tidslinjen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBeginWeek(int value) {#setBeginWeek-int-}
+```
+public void setBeginWeek(int value)
+```
+
+
+Startvecka för tidslinjeformen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDateFormatForBE(int value) {#setDateFormatForBE-int-}
+```
+public void setDateFormatForBE(int value)
+```
+
+
+Datumformat för start och slut av tidslinjeformen ///
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDateFormatForIntm(int value) {#setDateFormatForIntm-int-}
+```
+public void setDateFormatForIntm(int value)
+```
+
+
+Datumformat för mellanliggande tid för tidslinjeformen ///
+
+| ----------------------- | ------------------------------- |
+| **Värde**\u9286\u20ac | **Formatsträng**\u9286\u20ac |
+| 0                       | dddd, yyyy-M-d                  |
+| 1                       | yyyy-MM-dd                      |
+| 2                       | yy-MMM-d                        |
+| 3                       | yyyy/M/d                        |
+| 4                       | yy-MMM.-d                       |
+| 5                       | d MMMM yyyy                     |
+| 6                       | yy-M                            |
+| 7                       | MMM-yy                          |
+| 8                       | MMMM d, yyyy                    |
+| 9                       | MMM d, yyyy                     |
+| 10                      | M-d-yy                          |
+| 11                      | M-d                             |
+| 12                      | d MMMM, yyyy                    |
+| 13                      | d MMM, yyyy                     |
+| 14                      | d-M-yy                          |
+| 15                      | d-M                             |
+| 16                      | yy-M-d                          |
+| 17                      | yyyy-M-d                        |
+| 18                      | M-yy                            |
+| 19                      | M-yyyy                          |
+| 20                      | MMMM yyyy                       |
+| 21                      | MMMM yy                         |
+| 22                      | MMM yyyy                        |
+| 23                      | MMM yy                          |
+| 24                      | yy                              |
+| 25                      | yyyy                            |
+| 26                      | d                               |
+| 27                      | MMMM                            |
+| 28                      | MMM                             |
+| 29                      | M                               |
+| 30                      | MM/dd/yyyy                      |
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDateFormatStringForBE(String value) {#setDateFormatStringForBE-java.lang.String-}
+```
+public void setDateFormatStringForBE(String value)
+```
+
+
+Datumformatsträng för start och slut av tidslinjeformen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDateFormatStringForIntm(String value) {#setDateFormatStringForIntm-java.lang.String-}
+```
+public void setDateFormatStringForIntm(String value)
+```
+
+
+Datumformatsträng för mellanliggande tid för tidslinjeformen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDisplayBE(boolean value) {#setDisplayBE-boolean-}
+```
+public void setDisplayBE(boolean value)
+```
+
+
+om start- och slutdatum ska visas på tidslinjen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDisplayIntm(boolean value) {#setDisplayIntm-boolean-}
+```
+public void setDisplayIntm(boolean value)
+```
+
+
+om interim datum/tid-markeringar ska visas på tidslinjen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setDisplayIntmDates(boolean value) {#setDisplayIntmDates-boolean-}
+```
+public void setDisplayIntmDates(boolean value)
+```
+
+
+om interimdatum ska visas på interimmarkeringar
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setFiscalStart(DateTime value) {#setFiscalStart-com.aspose.diagram.DateTime-}
+```
+public void setFiscalStart(DateTime value)
+```
+
+
+Första dagen i räkenskapsåret
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeLineType(int value) {#setTimeLineType-int-}
+```
+public void setTimeLineType(int value)
+```
+
+
+Startvecka för tidslinjeformen
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTimePeriodFinish(DateTime value) {#setTimePeriodFinish-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodFinish(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimePeriodStart(DateTime value) {#setTimePeriodStart-com.aspose.diagram.DateTime-}
+```
+public void setTimePeriodStart(DateTime value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setTimeScale(int value) {#setTimeScale-int-}
+```
+public void setTimeScale(int value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/togglebuttonactivexcontrol/_index.md
@@ -1,0 +1,604 @@
+---
+title: ToggleButtonActiveXControl
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en ToggleButton ActiveX‑kontroll.
+type: docs
+weight: 410
+url: /sv/java/com.aspose.diagram/togglebuttonactivexcontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class ToggleButtonActiveXControl extends ActiveXControl
+```
+
+Representerar en ToggleButton ActiveX‑kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAccelerator()](#getAccelerator--) | Acceleratortangenten för kontrollen. |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getCaption()](#getCaption--) | Den beskrivande texten som visas på en kontroll. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPicture()](#getPicture--) | Bildens data. |
+| [getPicturePosition()](#getPicturePosition--) | platsen för kontrollens bild relativt dess rubrik. |
+| [getSpecialEffect()](#getSpecialEffect--) | den speciella effekten för kontrollen. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getValue()](#getValue--) | Anger om kontrollen är markerad eller inte. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [isTripleState()](#isTripleState--) | Anger hur den angivna kontrollen kommer att visa Null‑värden. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAccelerator(char value)](#setAccelerator-char-) | För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--) |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setCaption(String value)](#setCaption-java.lang.String-) | För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setPicture(byte[] value)](#setPicture-byte---) | För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--) |
+| [setPicturePosition(int value)](#setPicturePosition-int-) | För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--) |
+| [setSpecialEffect(int value)](#setSpecialEffect-int-) | För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setTripleState(boolean value)](#setTripleState-boolean-) | För beskrivningen av denna egenskap, se [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAccelerator() {#getAccelerator--}
+```
+public char getAccelerator()
+```
+
+
+Acceleratortangenten för kontrollen.
+
+**Returns:**
+char
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getCaption() {#getCaption--}
+```
+public String getCaption()
+```
+
+
+Den beskrivande texten som visas på en kontroll.
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPicture() {#getPicture--}
+```
+public byte[] getPicture()
+```
+
+
+Bildens data.
+
+**Returns:**
+byte[]
+### getPicturePosition() {#getPicturePosition--}
+```
+public int getPicturePosition()
+```
+
+
+platsen för kontrollens bild relativt dess rubrik.
+
+**Returns:**
+int
+### getSpecialEffect() {#getSpecialEffect--}
+```
+public int getSpecialEffect()
+```
+
+
+den speciella effekten för kontrollen.
+
+**Returns:**
+int
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om kontrollen är markerad eller inte.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### isTripleState() {#isTripleState--}
+```
+public boolean isTripleState()
+```
+
+
+Anger hur den angivna kontrollen kommer att visa Null‑värden.
+
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inställning | Beskrivning                                                                                                                                     |
+| True    | Kontrollen kommer att cykla genom tillstånd för Ja, Nej och Null‑värden. Kontrollen visas nedtonad (grå) när dess Value‑egenskap är satt till Null. |
+| False   | (Standard) Kontrollen kommer att cykla genom tillstånd för Ja och Nej‑värden. Null‑värden visas som om de vore Nej‑värden.                           |
+
+|
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAccelerator(char value) {#setAccelerator-char-}
+```
+public void setAccelerator(char value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAccelerator()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getAccelerator--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | char |  |
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setCaption(String value) {#setCaption-java.lang.String-}
+```
+public void setCaption(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getCaption()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getCaption--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPicture(byte[] value) {#setPicture-byte---}
+```
+public void setPicture(byte[] value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicture()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicture--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setPicturePosition(int value) {#setPicturePosition-int-}
+```
+public void setPicturePosition(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPicturePosition()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getPicturePosition--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSpecialEffect(int value) {#setSpecialEffect-int-}
+```
+public void setSpecialEffect(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSpecialEffect()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getSpecialEffect--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setTripleState(boolean value) {#setTripleState-boolean-}
+```
+public void setTripleState(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isTripleState()](../../com.aspose.diagram/togglebuttonactivexcontrol\#isTripleState--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/togglebuttonactivexcontrol\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/topartvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/topartvalue/_index.md
@@ -1,0 +1,201 @@
+---
+title: ToPartValue
+second_title: Aspose.Diagram för Java API-referens
+description: Den del av en figur som en anslutning görs till.
+type: docs
+weight: 409
+url: /sv/java/com.aspose.diagram/topartvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class ToPartValue
+```
+
+Den del av en figur som en anslutning görs till.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CONNECTION_POINT](#CONNECTION-POINT) | Anslutningspunkt. |
+| [GUIDE_INTERSECTION](#GUIDE-INTERSECTION) | Guidekorsning. |
+| [GUIDE_X](#GUIDE-X) | GuideX. |
+| [GUIDE_Y](#GUIDE-Y) | GuideY. |
+| [NONE](#NONE) | Ingen. |
+| [TO_ANGLE](#TO-ANGLE) | Till vinkel. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [WHOLE_SHAPE](#WHOLE-SHAPE) | Hel form. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONNECTION_POINT {#CONNECTION-POINT}
+```
+public static final int CONNECTION_POINT
+```
+
+
+Anslutningspunkt.
+
+### GUIDE_INTERSECTION {#GUIDE-INTERSECTION}
+```
+public static final int GUIDE_INTERSECTION
+```
+
+
+Guidekorsning.
+
+### GUIDE_X {#GUIDE-X}
+```
+public static final int GUIDE_X
+```
+
+
+GuideX.
+
+### GUIDE_Y {#GUIDE-Y}
+```
+public static final int GUIDE_Y
+```
+
+
+GuideY.
+
+### NONE {#NONE}
+```
+public static final int NONE
+```
+
+
+Ingen.
+
+### TO_ANGLE {#TO-ANGLE}
+```
+public static final int TO_ANGLE
+```
+
+
+Till vinkel.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### WHOLE_SHAPE {#WHOLE-SHAPE}
+```
+public static final int WHOLE_SHAPE
+```
+
+
+Hel form.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/tp/_index.md
+++ b/swedish/java/com.aspose.diagram/tp/_index.md
@@ -1,0 +1,154 @@
+---
+title: Tp
+second_title: Aspose.Diagram för Java API-referens
+description: Anger början på en sekvens av tabb‑egenskaper.
+type: docs
+weight: 411
+url: /sv/java/com.aspose.diagram/tp/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Tp extends FormatTxt
+```
+
+Anger början på en flikegenskapssekvens. Sekvensen definieras till slutet av texten eller tills nästa
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Tp(int IX)](#Tp-int-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Tp(int IX) {#Tp-int-}
+```
+public Tp(int IX)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| IX | int | Det nollbaserade indexet för elementet inom dess föräldraelement. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/txt/_index.md
+++ b/swedish/java/com.aspose.diagram/txt/_index.md
@@ -1,0 +1,179 @@
+---
+title: Txt
+second_title: Aspose.Diagram för Java API-referens
+description: Figurens text
+type: docs
+weight: 412
+url: /sv/java/com.aspose.diagram/txt/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.FormatTxt](../../com.aspose.diagram/formattxt)
+```
+public class Txt extends FormatTxt
+```
+
+Figurens text
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Txt(String value)](#Txt-java.lang.String-) | Konstruktor |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getText()](#getText--) | Innehåller texten för en figur. |
+| [getValue()](#getValue--) | Value |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setText(String value)](#setText-java.lang.String-) | För beskrivningen av den här egenskapen, se [getText()](../../com.aspose.diagram/txt\#getText--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Txt(String value) {#Txt-java.lang.String-}
+```
+public Txt(String value)
+```
+
+
+Konstruktor
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String | Formens text. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+Innehåller texten för en figur.
+
+**Returns:**
+java.lang.String
+### getValue() {#getValue--}
+```
+public String getValue()
+```
+
+
+Value
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setText(String value) {#setText-java.lang.String-}
+```
+public void setText(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getText()](../../com.aspose.diagram/txt\#getText--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typeconnection/_index.md
+++ b/swedish/java/com.aspose.diagram/typeconnection/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeConnection
+second_title: Aspose.Diagram för Java API-referens
+description: Anger olika typer baserat på elementet som den innehåller.
+type: docs
+weight: 413
+url: /sv/java/com.aspose.diagram/typeconnection/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeConnection
+```
+
+Anger olika typer, baserat på elementet som den finns i.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TypeConnection(int value)](#TypeConnection-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger olika typer, baserat på elementet som den finns i. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se gärna [getValue()](../../com.aspose.diagram/typeconnection\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeConnection(int value) {#TypeConnection-int-}
+```
+public TypeConnection(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger olika typer, baserat på elementet som den finns i.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se gärna [getValue()](../../com.aspose.diagram/typeconnection\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typeconnectionvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/typeconnectionvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: TypeConnectionValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger olika typer baserat på elementet som den innehåller.
+type: docs
+weight: 414
+url: /sv/java/com.aspose.diagram/typeconnectionvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeConnectionValue
+```
+
+Anger olika typer, baserat på elementet som den finns i.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [INWARD](#INWARD) | Inåt. |
+| [INWARD_OUTWARD](#INWARD-OUTWARD) | Inåt och utåt. |
+| [OUTWARD](#OUTWARD) | Utåt. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### INWARD {#INWARD}
+```
+public static final int INWARD
+```
+
+
+Inåt.
+
+### INWARD_OUTWARD {#INWARD-OUTWARD}
+```
+public static final int INWARD_OUTWARD
+```
+
+
+Inåt och utåt.
+
+### OUTWARD {#OUTWARD}
+```
+public static final int OUTWARD
+```
+
+
+Utåt.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typefield/_index.md
+++ b/swedish/java/com.aspose.diagram/typefield/_index.md
@@ -1,0 +1,190 @@
+---
+title: TypeField
+second_title: Aspose.Diagram för Java API-referens
+description: Typ anger en datatyp för textfältets värde.
+type: docs
+weight: 415
+url: /sv/java/com.aspose.diagram/typefield/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeField
+```
+
+Typ anger en datatyp för textfältets värde.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TypeField(int value)](#TypeField-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Typ anger en datatyp för textfältets värde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/typefield\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeField(int value) {#TypeField-int-}
+```
+public TypeField(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Typ anger en datatyp för textfältets värde.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/typefield\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typefieldvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/typefieldvalue/_index.md
@@ -1,0 +1,183 @@
+---
+title: TypeFieldValue
+second_title: Aspose.Diagram för Java API-referens
+description: Typ anger en datatyp för textfältets värde.
+type: docs
+weight: 416
+url: /sv/java/com.aspose.diagram/typefieldvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeFieldValue
+```
+
+Typ anger en datatyp för textfältets värde.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CURRENCY](#CURRENCY) | Valuta värde. |
+| [DATE_TIME](#DATE-TIME) | Datum- eller tidsvärde. |
+| [DURATION](#DURATION) | Varaktighetsvärde. |
+| [NUMBER](#NUMBER) | Nummer. |
+| [STRING](#STRING) | Sträng. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valutavärde. Använder systemets aktuella regionala inställningar.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Datum- eller tidsvärde. Visar dagar, månader och år, eller sekunder, minuter och timmar, eller ett kombinerat datum- och tidsvärde.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Varaktighetsvärde. Visar förfluten tid.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Nummer. Inkluderar datum-, tids-, varaktighets- och valutavärden samt skalärer, dimensioner och vinklar.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Sträng.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typeprop/_index.md
+++ b/swedish/java/com.aspose.diagram/typeprop/_index.md
@@ -1,0 +1,193 @@
+---
+title: TypeProp
+second_title: Aspose.Diagram för Java API-referens
+description: Typ anger en datatyp för det anpassade egenskapsvärdet.
+type: docs
+weight: 417
+url: /sv/java/com.aspose.diagram/typeprop/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class TypeProp
+```
+
+Typ anger en datatyp för det anpassade egenskapsvärdet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [TypeProp(int value)](#TypeProp-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Typ anger en datatyp för det anpassade egenskapsvärdet. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/typeprop\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TypeProp(int value) {#TypeProp-int-}
+```
+public TypeProp(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Typ anger en datatyp för det anpassade egenskapsvärdet.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/typeprop\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/typeprop\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typepropvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/typepropvalue/_index.md
@@ -1,0 +1,210 @@
+---
+title: TypePropValue
+second_title: Aspose.Diagram för Java API-referens
+description: Typ anger en datatyp för det anpassade egenskapsvärdet.
+type: docs
+weight: 418
+url: /sv/java/com.aspose.diagram/typepropvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypePropValue
+```
+
+Typ anger en datatyp för det anpassade egenskapsvärdet.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOOLEAN](#BOOLEAN) | Boolesk. |
+| [CURRENCY](#CURRENCY) | Valuta värde. |
+| [DATE_TIME](#DATE-TIME) | Datum- eller tidsvärde. |
+| [DURATION](#DURATION) | Varaktighetsvärde. |
+| [FIXED_LIST](#FIXED-LIST) | Fast lista. |
+| [NUMBER](#NUMBER) | Nummer. |
+| [STRING](#STRING) | Sträng. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VARIABLE_LIST](#VARIABLE-LIST) | Variabel lista. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOOLEAN {#BOOLEAN}
+```
+public static final int BOOLEAN
+```
+
+
+Boolean. Visar FALSE och TRUE som objekt som användare kan välja från en rullgardinslista i dialogrutan Anpassade egenskaper i Visio‑programmet.
+
+### CURRENCY {#CURRENCY}
+```
+public static final int CURRENCY
+```
+
+
+Valuta värde. Använder systemets aktuella regionala inställningar.
+
+### DATE_TIME {#DATE-TIME}
+```
+public static final int DATE_TIME
+```
+
+
+Datum- eller tidsvärde. Visar dagar, månader och år, eller sekunder, minuter och timmar, eller ett kombinerat datum- och tidsvärde.
+
+### DURATION {#DURATION}
+```
+public static final int DURATION
+```
+
+
+Varaktighetsvärde. Visar förfluten tid.
+
+### FIXED_LIST {#FIXED-LIST}
+```
+public static final int FIXED_LIST
+```
+
+
+Fast lista. Visar listobjekten i en rullgardinskombinationsruta i dialogrutan Anpassade egenskaper.
+
+### NUMBER {#NUMBER}
+```
+public static final int NUMBER
+```
+
+
+Nummer. Inkluderar datum-, tids-, varaktighets- och valutavärden samt skalärer, dimensioner och vinklar.
+
+### STRING {#STRING}
+```
+public static final int STRING
+```
+
+
+Sträng. Detta är standard.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VARIABLE_LIST {#VARIABLE-LIST}
+```
+public static final int VARIABLE_LIST
+```
+
+
+Variabel lista. Visar listobjekten i en rullgardinskombinationsruta i dialogrutan Anpassade egenskaper i Visio. Användare kan välja ett listobjekt eller ange ett nytt objekt som läggs till i den aktuella listan i Format‑elementet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/typevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/typevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: TypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Valfri uppräkning.
+type: docs
+weight: 419
+url: /sv/java/com.aspose.diagram/typevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class TypeValue
+```
+
+Valfri uppräkning. Typen av en form.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FOREIGN](#FOREIGN) | Utländsk. |
+| [GROUP](#GROUP) | Grupp. |
+| [GUIDE](#GUIDE) | Guide. |
+| [SHAPE](#SHAPE) | Form. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FOREIGN {#FOREIGN}
+```
+public static final int FOREIGN
+```
+
+
+Utländsk.
+
+### GROUP {#GROUP}
+```
+public static final int GROUP
+```
+
+
+Grupp.
+
+### GUIDE {#GUIDE}
+```
+public static final int GUIDE
+```
+
+
+Guide.
+
+### SHAPE {#SHAPE}
+```
+public static final int SHAPE
+```
+
+
+Form.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/uivisibility/_index.md
+++ b/swedish/java/com.aspose.diagram/uivisibility/_index.md
@@ -1,0 +1,179 @@
+---
+title: UIVisibility
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar flikjusteringen.
+type: docs
+weight: 420
+url: /sv/java/com.aspose.diagram/uivisibility/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UIVisibility
+```
+
+Specificerar flikjusteringen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [UIVisibility(int value)](#UIVisibility-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger uivisibility. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/uivisibility\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UIVisibility(int value) {#UIVisibility-int-}
+```
+public UIVisibility(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger uivisibility.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getValue()](../../com.aspose.diagram/uivisibility\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/uivisibilityvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/uivisibilityvalue/_index.md
@@ -1,0 +1,156 @@
+---
+title: UIVisibilityValue
+second_title: Aspose.Diagram för Java API-referens
+description: Specificerar flikjusteringen.
+type: docs
+weight: 421
+url: /sv/java/com.aspose.diagram/uivisibilityvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class UIVisibilityValue
+```
+
+Specificerar flikjusteringen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [HIDDEN](#HIDDEN) | Hidden. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VISIBLE](#VISIBLE) | Visible . |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HIDDEN {#HIDDEN}
+```
+public static final int HIDDEN
+```
+
+
+Hidden.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VISIBLE {#VISIBLE}
+```
+public static final int VISIBLE
+```
+
+
+Visible .
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/unitformulaerr/_index.md
+++ b/swedish/java/com.aspose.diagram/unitformulaerr/_index.md
@@ -1,0 +1,240 @@
+---
+title: UnitFormulaErr
+second_title: Aspose.Diagram för Java API-referens
+description: Anger attribut för ett element.
+type: docs
+weight: 422
+url: /sv/java/com.aspose.diagram/unitformulaerr/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class UnitFormulaErr
+```
+
+Anger attribut för ett element.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [UnitFormulaErr(int unit, String f, String err)](#UnitFormulaErr-int-java.lang.String-java.lang.String-) | Konstruktor. |
+| [UnitFormulaErr()](#UnitFormulaErr--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indikerar att formeln utvärderas till ett fel. |
+| [getF()](#getF--) | Representerar elementets formel. |
+| [getUnit()](#getUnit--) | Måttenheter. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | För beskrivningen av denna egenskap, se [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | För beskrivningen av denna egenskap, se [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | För beskrivningen av denna egenskap, se [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErr(int unit, String f, String err) {#UnitFormulaErr-int-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErr(int unit, String f, String err)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| enhet | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+
+### UnitFormulaErr() {#UnitFormulaErr--}
+```
+public UnitFormulaErr()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indikerar att formeln utvärderas till ett fel.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Representerar elementets formel.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Måttenheter.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/unitformulaerrv/_index.md
+++ b/swedish/java/com.aspose.diagram/unitformulaerrv/_index.md
@@ -1,0 +1,257 @@
+---
+title: UnitFormulaErrV
+second_title: Aspose.Diagram för Java API-referens
+description: Angivna attribut för ett element.
+type: docs
+weight: 423
+url: /sv/java/com.aspose.diagram/unitformulaerrv/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+```
+public class UnitFormulaErrV extends UnitFormulaErr
+```
+
+Angivna attribut för ett element.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [UnitFormulaErrV(int unit, String f, String err, String v)](#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getErr()](#getErr--) | Indikerar att formeln utvärderas till ett fel. |
+| [getF()](#getF--) | Representerar elementets formel. |
+| [getUnit()](#getUnit--) | Måttenheter. |
+| [getV()](#getV--) | Representerar nullsträngstillståndet för ett strängcellervärde. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setErr(String value)](#setErr-java.lang.String-) | För beskrivningen av denna egenskap, se [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--) |
+| [setF(String value)](#setF-java.lang.String-) | För beskrivningen av denna egenskap, se [getF()](../../com.aspose.diagram/unitformulaerr\#getF--) |
+| [setUnit(int value)](#setUnit-int-) | För beskrivningen av denna egenskap, se [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--) |
+| [setV(String value)](#setV-java.lang.String-) | För beskrivningen av denna egenskap, se [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UnitFormulaErrV(int unit, String f, String err, String v) {#UnitFormulaErrV-int-java.lang.String-java.lang.String-java.lang.String-}
+```
+public UnitFormulaErrV(int unit, String f, String err, String v)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| enhet | int |  |
+| f | java.lang.String |  |
+| err | java.lang.String |  |
+| v | java.lang.String |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getErr() {#getErr--}
+```
+public String getErr()
+```
+
+
+Indikerar att formeln utvärderas till ett fel.
+
+**Returns:**
+java.lang.String
+### getF() {#getF--}
+```
+public String getF()
+```
+
+
+Representerar elementets formel.
+
+**Returns:**
+java.lang.String
+### getUnit() {#getUnit--}
+```
+public int getUnit()
+```
+
+
+Måttenheter.
+
+**Returns:**
+int
+### getV() {#getV--}
+```
+public String getV()
+```
+
+
+Representerar nullsträngstillståndet för ett strängcellervärde. I vissa fall kan det vara hjälpsamt att skilja mellan en tom strängceller null och ett null strängcellervärde. Detta attribut används för att särskilja dessa former av ett tomt värde.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setErr(String value) {#setErr-java.lang.String-}
+```
+public void setErr(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getErr()](../../com.aspose.diagram/unitformulaerr\#getErr--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setF(String value) {#setF-java.lang.String-}
+```
+public void setF(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getF()](../../com.aspose.diagram/unitformulaerr\#getF--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setUnit(int value) {#setUnit-int-}
+```
+public void setUnit(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUnit()](../../com.aspose.diagram/unitformulaerr\#getUnit--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setV(String value) {#setV-java.lang.String-}
+```
+public void setV(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getV()](../../com.aspose.diagram/unitformulaerrv\#getV--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/unknowncontrol/_index.md
+++ b/swedish/java/com.aspose.diagram/unknowncontrol/_index.md
@@ -1,0 +1,449 @@
+---
+title: UnknownControl
+second_title: Aspose.Diagram för Java API-referens
+description: Okänd kontroll.
+type: docs
+weight: 424
+url: /sv/java/com.aspose.diagram/unknowncontrol/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.ActiveXControlBase](../../com.aspose.diagram/activexcontrolbase), [com.aspose.diagram.ActiveXControl](../../com.aspose.diagram/activexcontrol)
+```
+public class UnknownControl extends ActiveXControl
+```
+
+Okänd kontroll.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBackOleColor()](#getBackOleColor--) | ole-färgen för bakgrunden. |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | den binära datan för kontrollen. |
+| [getForeOleColor()](#getForeOleColor--) | ole-färgen för förgrunden. |
+| [getHeight()](#getHeight--) | höjden på kontrollen i enheter av punkter. |
+| [getIMEMode()](#getIMEMode--) | standardkörningsläget för Input Method Editor för kontrollen när den får fokus. |
+| [getMouseIcon()](#getMouseIcon--) | en anpassad ikon som visas som muspekare för kontrollen. |
+| [getMousePointer()](#getMousePointer--) | typen av ikon som visas som muspekare för kontrollen. |
+| [getPersistenceType()](#getPersistenceType--) | Hämtar persistensmetoden för att spara en ActiveX-kontroll. |
+| [getRelationshipData(String relId)](#getRelationshipData-java.lang.String-) | Hämtar relationsdata. |
+| [getType()](#getType--) | Hämtar typen av ActiveX-kontrollen. |
+| [getWidth()](#getWidth--) | kontrollens bredd i enheten punkt. |
+| [hashCode()](#hashCode--) |  |
+| [isAutoSize()](#isAutoSize--) | Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet. |
+| [isEnabled()](#isEnabled--) | Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren. |
+| [isLocked()](#isLocked--) | Indikerar om data i kontrollen är låst för redigering. |
+| [isTransparent()](#isTransparent--) | Indikerar om kontrollen är transparent. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAutoSize(boolean value)](#setAutoSize-boolean-) | För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--) |
+| [setBackOleColor(int value)](#setBackOleColor-int-) | För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--) |
+| [setEnabled(boolean value)](#setEnabled-boolean-) | För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--) |
+| [setForeOleColor(int value)](#setForeOleColor-int-) | För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--) |
+| [setHeight(double value)](#setHeight-double-) | För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--) |
+| [setIMEMode(int value)](#setIMEMode-int-) | För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--) |
+| [setLocked(boolean value)](#setLocked-boolean-) | För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--) |
+| [setMouseIcon(byte[] value)](#setMouseIcon-byte---) | För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--) |
+| [setMousePointer(int value)](#setMousePointer-int-) | För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--) |
+| [setTransparent(boolean value)](#setTransparent-boolean-) | För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--) |
+| [setWidth(double value)](#setWidth-double-) | För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBackOleColor() {#getBackOleColor--}
+```
+public int getBackOleColor()
+```
+
+
+ole-färgen för bakgrunden.
+
+**Returns:**
+int
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public byte[] getData()
+```
+
+
+den binära datan för kontrollen.
+
+**Returns:**
+byte[]
+### getForeOleColor() {#getForeOleColor--}
+```
+public int getForeOleColor()
+```
+
+
+OLE-färgen för förgrunden. Gäller inte för Image-kontrollen.
+
+**Returns:**
+int
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+höjden på kontrollen i enheter av punkter.
+
+**Returns:**
+double
+### getIMEMode() {#getIMEMode--}
+```
+public int getIMEMode()
+```
+
+
+standardkörningsläget för Input Method Editor för kontrollen när den får fokus.
+
+**Returns:**
+int
+### getMouseIcon() {#getMouseIcon--}
+```
+public byte[] getMouseIcon()
+```
+
+
+en anpassad ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+byte[]
+### getMousePointer() {#getMousePointer--}
+```
+public int getMousePointer()
+```
+
+
+typen av ikon som visas som muspekare för kontrollen.
+
+**Returns:**
+int
+### getPersistenceType() {#getPersistenceType--}
+```
+public int getPersistenceType()
+```
+
+
+Hämtar persistensmetoden för att spara en ActiveX-kontroll.
+
+**Returns:**
+int
+### getRelationshipData(String relId) {#getRelationshipData-java.lang.String-}
+```
+public byte[] getRelationshipData(String relId)
+```
+
+
+Hämtar relationsdata.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| relId | java.lang.String | Relations-ID. |
+
+**Returns:**
+byte[] - returnerar relationsdata.
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen av ActiveX-kontrollen.
+
+**Returns:**
+int
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+kontrollens bredd i enheten punkt.
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isAutoSize() {#isAutoSize--}
+```
+public boolean isAutoSize()
+```
+
+
+Indikerar om kontrollen automatiskt kommer att ändra storlek för att visa hela innehållet.
+
+**Returns:**
+boolean
+### isEnabled() {#isEnabled--}
+```
+public boolean isEnabled()
+```
+
+
+Indikerar om kontrollen kan ta emot fokus och svara på händelser som genereras av användaren.
+
+**Returns:**
+boolean
+### isLocked() {#isLocked--}
+```
+public boolean isLocked()
+```
+
+
+Indikerar om data i kontrollen är låst för redigering.
+
+**Returns:**
+boolean
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+Indikerar om kontrollen är transparent.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAutoSize(boolean value) {#setAutoSize-boolean-}
+```
+public void setAutoSize(boolean value)
+```
+
+
+För beskrivningen av denna egenskap, se [isAutoSize()](../../com.aspose.diagram/activexcontrol\#isAutoSize--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setBackOleColor(int value) {#setBackOleColor-int-}
+```
+public void setBackOleColor(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBackOleColor()](../../com.aspose.diagram/activexcontrolbase\#getBackOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEnabled(boolean value) {#setEnabled-boolean-}
+```
+public void setEnabled(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isEnabled()](../../com.aspose.diagram/activexcontrol\#isEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setForeOleColor(int value) {#setForeOleColor-int-}
+```
+public void setForeOleColor(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getForeOleColor()](../../com.aspose.diagram/activexcontrolbase\#getForeOleColor--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setHeight(double value) {#setHeight-double-}
+```
+public void setHeight(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getHeight()](../../com.aspose.diagram/activexcontrolbase\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setIMEMode(int value) {#setIMEMode-int-}
+```
+public void setIMEMode(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getIMEMode()](../../com.aspose.diagram/activexcontrol\#getIMEMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setLocked(boolean value) {#setLocked-boolean-}
+```
+public void setLocked(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isLocked()](../../com.aspose.diagram/activexcontrol\#isLocked--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setMouseIcon(byte[] value) {#setMouseIcon-byte---}
+```
+public void setMouseIcon(byte[] value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMouseIcon()](../../com.aspose.diagram/activexcontrolbase\#getMouseIcon--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | byte[] |  |
+
+### setMousePointer(int value) {#setMousePointer-int-}
+```
+public void setMousePointer(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMousePointer()](../../com.aspose.diagram/activexcontrolbase\#getMousePointer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTransparent(boolean value) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [isTransparent()](../../com.aspose.diagram/activexcontrol\#isTransparent--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setWidth(double value) {#setWidth-double-}
+```
+public void setWidth(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWidth()](../../com.aspose.diagram/activexcontrolbase\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/user/_index.md
+++ b/swedish/java/com.aspose.diagram/user/_index.md
@@ -1,0 +1,299 @@
+---
+title: Användare
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller ett arbetsområde för att ange formler i användarspecifika element som refereras till av andra element och tilläggsverktyg.
+type: docs
+weight: 425
+url: /sv/java/com.aspose.diagram/user/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class User
+```
+
+Innehåller ett arbetsområde för att ange formler i användarspecifika element som refereras till av andra element och tilläggsverktyg.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [User()](#User--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getName()](#getName--) | Elementets namn. |
+| [getNameU()](#getNameU--) | Det universella namnet för elementet. |
+| [getPrompt()](#getPrompt--) | Den anger en beskrivande prompt eller kommentar för det användardefinierade elementet. |
+| [getValue()](#getValue--) | Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/user\#getDel--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/user\#getID--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/user\#getName--) |
+| [setNameU(String value)](#setNameU-java.lang.String-) | För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/user\#getNameU--) |
+| [setPrompt(Str2Value value)](#setPrompt-com.aspose.diagram.Str2Value-) | För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/user\#getPrompt--) |
+| [setValue(Value value)](#setValue-com.aspose.diagram.Value-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/user\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### User() {#User--}
+```
+public User()
+```
+
+
+Konstruktor.
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+Elementets namn.
+
+**Returns:**
+java.lang.String
+### getNameU() {#getNameU--}
+```
+public String getNameU()
+```
+
+
+Det universella namnet för elementet.
+
+**Returns:**
+java.lang.String
+### getPrompt() {#getPrompt--}
+```
+public Str2Value getPrompt()
+```
+
+
+Den anger en beskrivande prompt eller kommentar för det användardefinierade elementet.
+
+**Returns:**
+[Str2Value](../../com.aspose.diagram/str2value)
+### getValue() {#getValue--}
+```
+public Value getValue()
+```
+
+
+Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument.
+
+**Returns:**
+[Value](../../com.aspose.diagram/value)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/user\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getID()](../../com.aspose.diagram/user\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/user\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setNameU(String value) {#setNameU-java.lang.String-}
+```
+public void setNameU(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getNameU()](../../com.aspose.diagram/user\#getNameU--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPrompt(Str2Value value) {#setPrompt-com.aspose.diagram.Str2Value-}
+```
+public void setPrompt(Str2Value value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPrompt()](../../com.aspose.diagram/user\#getPrompt--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Str2Value](../../com.aspose.diagram/str2value) |  |
+
+### setValue(Value value) {#setValue-com.aspose.diagram.Value-}
+```
+public void setValue(Value value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/user\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Value](../../com.aspose.diagram/value) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/usercollection/_index.md
+++ b/swedish/java/com.aspose.diagram/usercollection/_index.md
@@ -1,0 +1,250 @@
+---
+title: UserCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Användarsamling.
+type: docs
+weight: 426
+url: /sv/java/com.aspose.diagram/usercollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class UserCollection extends Collection
+```
+
+Användarsamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(User item)](#add-com.aspose.diagram.User-) | Lägg till User-objektet i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [getUser(int ID)](#getUser-int-) | Hämtar elementet med angivet ID. |
+| [getUser(String name)](#getUser-java.lang.String-) | Hämtar elementet med angivet ID. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(User item)](#remove-com.aspose.diagram.User-) | Ta bort User-objektet från samlingen. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(User item) {#add-com.aspose.diagram.User-}
+```
+public int add(User item)
+```
+
+
+Lägg till User-objektet i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public User get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### getUser(int ID) {#getUser-int-}
+```
+public User getUser(int ID)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| ID | int |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### getUser(String name) {#getUser-java.lang.String-}
+```
+public User getUser(String name)
+```
+
+
+Hämtar elementet med angivet ID.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+**Returns:**
+[User](../../com.aspose.diagram/user) - 
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(User item) {#remove-com.aspose.diagram.User-}
+```
+public void remove(User item)
+```
+
+
+Ta bort User-objektet från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| item | [User](../../com.aspose.diagram/user) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/validation/_index.md
+++ b/swedish/java/com.aspose.diagram/validation/_index.md
@@ -1,0 +1,158 @@
+---
+title: Validering
+second_title: Aspose.Diagram för Java API-referens
+description: Lagrar information om diagramvalidering för dokumentet.
+type: docs
+weight: 427
+url: /sv/java/com.aspose.diagram/validation/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Validation
+```
+
+Lagrar information om diagramvalidering för dokumentet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIssues()](#getIssues--) | Innehåller alla Issue-element för dokumentet. |
+| [getRuleSets()](#getRuleSets--) | Inkluderar ett RuleSet-element för varje valideringsregelsats i dokumentet. |
+| [getValidationProperties()](#getValidationProperties--) | Inkapslar egenskaper relaterade till validering för dokumentet. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIssues() {#getIssues--}
+```
+public IssueCollection getIssues()
+```
+
+
+Innehåller alla Issue-element för dokumentet.
+
+**Returns:**
+[IssueCollection](../../com.aspose.diagram/issuecollection)
+### getRuleSets() {#getRuleSets--}
+```
+public RuleSetCollection getRuleSets()
+```
+
+
+Inkluderar ett RuleSet-element för varje valideringsregelsats i dokumentet.
+
+**Returns:**
+[RuleSetCollection](../../com.aspose.diagram/rulesetcollection)
+### getValidationProperties() {#getValidationProperties--}
+```
+public ValidationProperties getValidationProperties()
+```
+
+
+Inkapslar egenskaper relaterade till validering för dokumentet.
+
+**Returns:**
+[ValidationProperties](../../com.aspose.diagram/validationproperties)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/validationproperties/_index.md
+++ b/swedish/java/com.aspose.diagram/validationproperties/_index.md
@@ -1,0 +1,194 @@
+---
+title: ValidationProperties
+second_title: Aspose.Diagram för Java API-referens
+description: Inkapslar egenskaper relaterade till validering för dokumentet.
+type: docs
+weight: 428
+url: /sv/java/com.aspose.diagram/validationproperties/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class ValidationProperties
+```
+
+Inkapslar egenskaper relaterade till validering för dokumentet.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [ValidationProperties(DateTime lastValidated, int showIgnored)](#ValidationProperties-com.aspose.diagram.DateTime-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getLastValidated()](#getLastValidated--) | Datum och tid då dokumentet senast validerades |
+| [getShowIgnored()](#getShowIgnored--) | Om ignorerade valideringsproblem ska visas i fönstret Problem. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLastValidated(DateTime value)](#setLastValidated-com.aspose.diagram.DateTime-) | För beskrivningen av denna egenskap, se [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--) |
+| [setShowIgnored(int value)](#setShowIgnored-int-) | För beskrivningen av denna egenskap, se [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ValidationProperties(DateTime lastValidated, int showIgnored) {#ValidationProperties-com.aspose.diagram.DateTime-int-}
+```
+public ValidationProperties(DateTime lastValidated, int showIgnored)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| lastValidated | [DateTime](../../com.aspose.diagram/datetime) |  |
+| showIgnored | int |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLastValidated() {#getLastValidated--}
+```
+public DateTime getLastValidated()
+```
+
+
+Datum och tid då dokumentet senast validerades
+
+**Returns:**
+[DateTime](../../com.aspose.diagram/datetime)
+### getShowIgnored() {#getShowIgnored--}
+```
+public int getShowIgnored()
+```
+
+
+Om ignorerade valideringsproblem ska visas i fönstret Problem.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLastValidated(DateTime value) {#setLastValidated-com.aspose.diagram.DateTime-}
+```
+public void setLastValidated(DateTime value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLastValidated()](../../com.aspose.diagram/validationproperties\#getLastValidated--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DateTime](../../com.aspose.diagram/datetime) |  |
+
+### setShowIgnored(int value) {#setShowIgnored-int-}
+```
+public void setShowIgnored(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getShowIgnored()](../../com.aspose.diagram/validationproperties\#getShowIgnored--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/value/_index.md
+++ b/swedish/java/com.aspose.diagram/value/_index.md
@@ -1,0 +1,211 @@
+---
+title: Value
+second_title: Aspose.Diagram för Java API-referens
+description: Värde.
+type: docs
+weight: 429
+url: /sv/java/com.aspose.diagram/value/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Value
+```
+
+Värde.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object obj)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getSolutionXML()](#getSolutionXML--) | Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument. |
+| [getUfev()](#getUfev--) | Angivna attribut för ett element. |
+| [getVal()](#getVal--) | Textvärde |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSolutionXML(SolutionXML value)](#setSolutionXML-com.aspose.diagram.SolutionXML-) | För beskrivningen av denna egenskap, se [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--) |
+| [setUfev(UnitFormulaErrV value)](#setUfev-com.aspose.diagram.UnitFormulaErrV-) | För beskrivningen av denna egenskap, se [getUfev()](../../com.aspose.diagram/value\#getUfev--) |
+| [setVal(String value)](#setVal-java.lang.String-) | För beskrivningen av denna egenskap, se [getVal()](../../com.aspose.diagram/value\#getVal--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSolutionXML() {#getSolutionXML--}
+```
+public SolutionXML getSolutionXML()
+```
+
+
+Innehåller lösningsspecifik, välformad XML-data som har ett prefix i ett explicit namnrymd och lagras med ett dokument.
+
+**Returns:**
+[SolutionXML](../../com.aspose.diagram/solutionxml)
+### getUfev() {#getUfev--}
+```
+public UnitFormulaErrV getUfev()
+```
+
+
+Angivna attribut för ett element.
+
+**Returns:**
+[UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv)
+### getVal() {#getVal--}
+```
+public String getVal()
+```
+
+
+Textvärde
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSolutionXML(SolutionXML value) {#setSolutionXML-com.aspose.diagram.SolutionXML-}
+```
+public void setSolutionXML(SolutionXML value)
+```
+
+
+För beskrivningen av denna egenskap, se [getSolutionXML()](../../com.aspose.diagram/value\#getSolutionXML--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [SolutionXML](../../com.aspose.diagram/solutionxml) |  |
+
+### setUfev(UnitFormulaErrV value) {#setUfev-com.aspose.diagram.UnitFormulaErrV-}
+```
+public void setUfev(UnitFormulaErrV value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfev()](../../com.aspose.diagram/value\#getUfev--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErrV](../../com.aspose.diagram/unitformulaerrv) |  |
+
+### setVal(String value) {#setVal-java.lang.String-}
+```
+public void setVal(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getVal()](../../com.aspose.diagram/value\#getVal--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbamodule/_index.md
+++ b/swedish/java/com.aspose.diagram/vbamodule/_index.md
@@ -1,0 +1,186 @@
+---
+title: VbaModule
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar modul som finns i VBA-projektet.
+type: docs
+weight: 430
+url: /sv/java/com.aspose.diagram/vbamodule/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaModule
+```
+
+Representerar modul som finns i VBA-projektet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCodes()](#getCodes--) | modulens kod. |
+| [getName()](#getName--) | modulens namn. |
+| [getType()](#getType--) | Hämtar modulens typ. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCodes(String value)](#setCodes-java.lang.String-) | För beskrivningen av den här egenskapen, se [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/vbamodule\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCodes() {#getCodes--}
+```
+public String getCodes()
+```
+
+
+modulens kod.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+modulens namn.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar modulens typ.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCodes(String value) {#setCodes-java.lang.String-}
+```
+public void setCodes(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getCodes()](../../com.aspose.diagram/vbamodule\#getCodes--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getName()](../../com.aspose.diagram/vbamodule\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbamodulecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/vbamodulecollection/_index.md
@@ -1,0 +1,311 @@
+---
+title: VbaModuleCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar en lista av
+type: docs
+weight: 431
+url: /sv/java/com.aspose.diagram/vbamodulecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaModuleCollection extends CollectionBase
+```
+
+Representerar listan av [VbaModule](../../com.aspose.diagram/vbamodule)
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Page page)](#add-com.aspose.diagram.Page-) | Lägger till modul för en sida. |
+| [add(int type, String name)](#add-int-java.lang.String-) | Lägger till modul. |
+| [add(Object o)](#add-java.lang.Object-) | Lägger till ett objekt i CollectionBase-instansen. |
+| [clear()](#clear--) | Tar bort alla objekt från CollectionBase-instansen. |
+| [contains(Object o)](#contains-java.lang.Object-) | Returnerar huruvida instansen innehåller detta objekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar [VbaModule](../../com.aspose.diagram/vbamodule) i listan med indexet. |
+| [get(String name)](#get-java.lang.String-) | Hämtar [VbaModule](../../com.aspose.diagram/vbamodule) i listan efter namn. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som finns i CollectionBase-instansen. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+| [iterator()](#iterator--) | Returnerar en enumerator som itererar genom CollectionBase-instansen. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Page page)](#remove-com.aspose.diagram.Page-) | Tar bort modul för en sida. |
+| [remove(String name)](#remove-java.lang.String-) | Ta bort modulen efter namn. |
+| [removeAt(int index)](#removeAt-int-) | Tar bort objektet på det angivna indexet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Page page) {#add-com.aspose.diagram.Page-}
+```
+public int add(Page page)
+```
+
+
+Lägger till modul för en sida.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | Sidan |
+
+**Returns:**
+int -
+### add(int type, String name) {#add-int-java.lang.String-}
+```
+public int add(int type, String name)
+```
+
+
+Lägger till modul.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| typ | int | Modulens typ. |
+| namn | java.lang.String | Modulens namn. |
+
+**Returns:**
+int -
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Lägger till ett objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Objektet som ska läggas till i CollectionBase-instansen. |
+
+**Returns:**
+int - Positionen där det nya elementet infördes.
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla objekt från CollectionBase-instansen.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Returnerar huruvida instansen innehåller detta objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | testobjekt |
+
+**Returns:**
+boolean - Om instansen innehåller detta objekt
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public VbaModule get(int index)
+```
+
+
+Hämtar [VbaModule](../../com.aspose.diagram/vbamodule) i listan med indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Indexet. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### get(String name) {#get-java.lang.String-}
+```
+public VbaModule get(String name)
+```
+
+
+Hämtar [VbaModule](../../com.aspose.diagram/vbamodule) i listan efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Modulens namn. |
+
+**Returns:**
+[VbaModule](../../com.aspose.diagram/vbamodule) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som finns i CollectionBase-instansen.
+
+**Returns:**
+int - Antalet element som finns i CollectionBase‑instansen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+
+**Returns:**
+int - Indexet för värdet om det hittas i listan; annars -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returnerar en enumerator som itererar genom CollectionBase-instansen.
+
+**Returns:**
+java.util.Iterator - En iterator för CollectionBase‑instansen.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Page page) {#remove-com.aspose.diagram.Page-}
+```
+public void remove(Page page)
+```
+
+
+Tar bort modul för en sida.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| page | [Page](../../com.aspose.diagram/page) | Sidan |
+
+### remove(String name) {#remove-java.lang.String-}
+```
+public void remove(String name)
+```
+
+
+Ta bort modulen efter namn.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String |  |
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Tar bort objektet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Det nollbaserade indexet för objektet som ska tas bort. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbamoduletype/_index.md
+++ b/swedish/java/com.aspose.diagram/vbamoduletype/_index.md
@@ -1,0 +1,165 @@
+---
+title: VbaModuleType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av VBA-modul.
+type: docs
+weight: 432
+url: /sv/java/com.aspose.diagram/vbamoduletype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaModuleType
+```
+
+Representerar typen av VBA-modul.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CLASS](#CLASS) | Representerar en klassmodul. |
+| [DESIGNER](#DESIGNER) | Representerar en designermodul. |
+| [DOCUMENT](#DOCUMENT) | Representerar en dokumentmodul. |
+| [PROCEDURAL](#PROCEDURAL) | Representerar en procedurmodul. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CLASS {#CLASS}
+```
+public static final int CLASS
+```
+
+
+Representerar en klassmodul.
+
+### DESIGNER {#DESIGNER}
+```
+public static final int DESIGNER
+```
+
+
+Representerar en designermodul.
+
+### DOCUMENT {#DOCUMENT}
+```
+public static final int DOCUMENT
+```
+
+
+Representerar en dokumentmodul.
+
+### PROCEDURAL {#PROCEDURAL}
+```
+public static final int PROCEDURAL
+```
+
+
+Representerar en procedurmodul.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbaproject/_index.md
+++ b/swedish/java/com.aspose.diagram/vbaproject/_index.md
@@ -1,0 +1,183 @@
+---
+title: VbaProject
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar VBA-projektet.
+type: docs
+weight: 433
+url: /sv/java/com.aspose.diagram/vbaproject/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProject
+```
+
+Representerar VBA-projektet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getModules()](#getModules--) | Hämtar alla [VbaModule](../../com.aspose.diagram/vbamodule) objekt. |
+| [getName()](#getName--) | namnet på VBA-projektet. |
+| [getReferences()](#getReferences--) | Hämtar alla referenser till VBA-projektet. |
+| [hashCode()](#hashCode--) |  |
+| [isSigned()](#isSigned--) | Anger om VBAcode är signerad eller inte. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/vbaproject\#getName--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getModules() {#getModules--}
+```
+public VbaModuleCollection getModules()
+```
+
+
+Hämtar alla [VbaModule](../../com.aspose.diagram/vbamodule) objekt.
+
+**Returns:**
+[VbaModuleCollection](../../com.aspose.diagram/vbamodulecollection)
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+namnet på VBA-projektet.
+
+**Returns:**
+java.lang.String
+### getReferences() {#getReferences--}
+```
+public VbaProjectReferenceCollection getReferences()
+```
+
+
+Hämtar alla referenser till VBA-projektet.
+
+**Returns:**
+[VbaProjectReferenceCollection](../../com.aspose.diagram/vbaprojectreferencecollection)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSigned() {#isSigned--}
+```
+public boolean isSigned()
+```
+
+
+Anger om VBAcode är signerad eller inte.
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/vbaproject\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbaprojectreference/_index.md
+++ b/swedish/java/com.aspose.diagram/vbaprojectreference/_index.md
@@ -1,0 +1,261 @@
+---
+title: VbaProjectReference
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar referensen till VBA-projektet.
+type: docs
+weight: 434
+url: /sv/java/com.aspose.diagram/vbaprojectreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VbaProjectReference
+```
+
+Representerar referensen till VBA-projektet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getExtendedLibid()](#getExtendedLibid--) | det utökade Libid för referensen. |
+| [getLibid()](#getLibid--) | Libid för referensen. |
+| [getName()](#getName--) | namnet på referensen. |
+| [getRelativeLibid()](#getRelativeLibid--) | det refererade VBA-projektet\u9225\u6a9a identifieraren med en relativ sökväg. |
+| [getTwiddledlibid()](#getTwiddledlibid--) | det manipulerade Libid för referensen. |
+| [getType()](#getType--) | Hämtar typen för denna referens. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setExtendedLibid(String value)](#setExtendedLibid-java.lang.String-) | För beskrivningen av denna egenskap, se [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--) |
+| [setLibid(String value)](#setLibid-java.lang.String-) | För beskrivningen av denna egenskap, se [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--) |
+| [setName(String value)](#setName-java.lang.String-) | För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--) |
+| [setRelativeLibid(String value)](#setRelativeLibid-java.lang.String-) | För beskrivningen av denna egenskap, se [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--) |
+| [setTwiddledlibid(String value)](#setTwiddledlibid-java.lang.String-) | För beskrivningen av denna egenskap, se [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getExtendedLibid() {#getExtendedLibid--}
+```
+public String getExtendedLibid()
+```
+
+
+det utökade Libid för referensen. Endast för kontrollreferens.
+
+**Returns:**
+java.lang.String
+### getLibid() {#getLibid--}
+```
+public String getLibid()
+```
+
+
+Libid för referensen.
+
+**Returns:**
+java.lang.String
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+namnet på referensen.
+
+**Returns:**
+java.lang.String
+### getRelativeLibid() {#getRelativeLibid--}
+```
+public String getRelativeLibid()
+```
+
+
+det refererade VBA-projektet\u9225\u6a9a identifieraren med en relativ sökväg. Endast för projektreferens.
+
+**Returns:**
+java.lang.String
+### getTwiddledlibid() {#getTwiddledlibid--}
+```
+public String getTwiddledlibid()
+```
+
+
+det manipulerade Libid för referensen. Endast för kontrollreferens.
+
+**Returns:**
+java.lang.String
+### getType() {#getType--}
+```
+public int getType()
+```
+
+
+Hämtar typen för denna referens.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setExtendedLibid(String value) {#setExtendedLibid-java.lang.String-}
+```
+public void setExtendedLibid(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getExtendedLibid()](../../com.aspose.diagram/vbaprojectreference\#getExtendedLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setLibid(String value) {#setLibid-java.lang.String-}
+```
+public void setLibid(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLibid()](../../com.aspose.diagram/vbaprojectreference\#getLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setName(String value) {#setName-java.lang.String-}
+```
+public void setName(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getName()](../../com.aspose.diagram/vbaprojectreference\#getName--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setRelativeLibid(String value) {#setRelativeLibid-java.lang.String-}
+```
+public void setRelativeLibid(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getRelativeLibid()](../../com.aspose.diagram/vbaprojectreference\#getRelativeLibid--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setTwiddledlibid(String value) {#setTwiddledlibid-java.lang.String-}
+```
+public void setTwiddledlibid(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getTwiddledlibid()](../../com.aspose.diagram/vbaprojectreference\#getTwiddledlibid--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
+++ b/swedish/java/com.aspose.diagram/vbaprojectreferencecollection/_index.md
@@ -1,0 +1,288 @@
+---
+title: VbaProjectReferenceCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar alla referenser till VBA-projektet.
+type: docs
+weight: 435
+url: /sv/java/com.aspose.diagram/vbaprojectreferencecollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.CollectionBase](../../com.aspose.diagram/collectionbase)
+```
+public class VbaProjectReferenceCollection extends CollectionBase
+```
+
+Representerar alla referenser till VBA-projektet.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Object o)](#add-java.lang.Object-) | Lägger till ett objekt i CollectionBase-instansen. |
+| [addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)](#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) | Lägg till en referens till ett twiddlat typbibliotek och dess utökade typbibliotek. |
+| [addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)](#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-) | Lägg till en referens till ett externt VBA-projekt. |
+| [addRegisteredReference(String name, String libid)](#addRegisteredReference-java.lang.String-java.lang.String-) | Lägg till en referens till ett Automation-typbibliotek. |
+| [clear()](#clear--) | Tar bort alla objekt från CollectionBase-instansen. |
+| [contains(Object o)](#contains-java.lang.Object-) | Returnerar huruvida instansen innehåller detta objekt. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | Hämta referensen i listan efter index. |
+| [getClass()](#getClass--) |  |
+| [getCount()](#getCount--) | Hämtar antalet element som finns i CollectionBase-instansen. |
+| [hashCode()](#hashCode--) |  |
+| [indexOf(Object o)](#indexOf-java.lang.Object-) | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+| [iterator()](#iterator--) | Returnerar en enumerator som itererar genom CollectionBase-instansen. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | Tar bort objektet på det angivna indexet. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Object o) {#add-java.lang.Object-}
+```
+public int add(Object o)
+```
+
+
+Lägger till ett objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Objektet som ska läggas till i CollectionBase-instansen. |
+
+**Returns:**
+int - Positionen där det nya elementet infördes.
+### addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid) {#addControlRefrernce-java.lang.String-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addControlRefrernce(String name, String libid, String twiddledlibid, String extendedLibid)
+```
+
+
+Lägg till en referens till ett twiddlat typbibliotek och dess utökade typbibliotek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Referensens namn. |
+| libid | java.lang.String | Identifieraren för ett Automation-typbibliotek. |
+| twiddledlibid | java.lang.String | Identifieraren för ett twiddlat typbibliotek |
+| extendedLibid | java.lang.String | Identifieraren för ett utökat typbibliotek |
+
+**Returns:**
+int -
+### addProjectRefrernce(String name, String absoluteLibid, String relativeLibid) {#addProjectRefrernce-java.lang.String-java.lang.String-java.lang.String-}
+```
+public int addProjectRefrernce(String name, String absoluteLibid, String relativeLibid)
+```
+
+
+Lägg till en referens till ett externt VBA-projekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Referensens namn. |
+| absoluteLibid | java.lang.String | Den refererade VBA-projekt\u9225\u6a9a identifieraren med en absolut sökväg. |
+| relativeLibid | java.lang.String | Den refererade VBA-projekt\u9225\u6a9a identifieraren med en relativ sökväg. |
+
+**Returns:**
+int -
+### addRegisteredReference(String name, String libid) {#addRegisteredReference-java.lang.String-java.lang.String-}
+```
+public int addRegisteredReference(String name, String libid)
+```
+
+
+Lägg till en referens till ett Automation-typbibliotek.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| namn | java.lang.String | Referensens namn. |
+| libid | java.lang.String | Identifieraren för ett Automation-typbibliotek. |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla objekt från CollectionBase-instansen.
+
+### contains(Object o) {#contains-java.lang.Object-}
+```
+public boolean contains(Object o)
+```
+
+
+Returnerar huruvida instansen innehåller detta objekt.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | testobjekt |
+
+**Returns:**
+boolean - Om instansen innehåller detta objekt
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public VbaProjectReference get(int i)
+```
+
+
+Hämta referensen i listan efter index.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| i | int | Indexet. |
+
+**Returns:**
+[VbaProjectReference](../../com.aspose.diagram/vbaprojectreference) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som finns i CollectionBase-instansen.
+
+**Returns:**
+int - Antalet element som finns i CollectionBase‑instansen.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### indexOf(Object o) {#indexOf-java.lang.Object-}
+```
+public int indexOf(Object o)
+```
+
+
+Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| o | java.lang.Object | Bestämmer indexet för ett specifikt objekt i CollectionBase-instansen. |
+
+**Returns:**
+int - Indexet för värdet om det hittas i listan; annars -1.
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Returnerar en enumerator som itererar genom CollectionBase-instansen.
+
+**Returns:**
+java.util.Iterator - En iterator för CollectionBase‑instansen.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public void removeAt(int index)
+```
+
+
+Tar bort objektet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | Det nollbaserade indexet för objektet som ska tas bort. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
+++ b/swedish/java/com.aspose.diagram/vbaprojectreferencetype/_index.md
@@ -1,0 +1,156 @@
+---
+title: VbaProjectReferenceType
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar typen av VBA-projektreferens.
+type: docs
+weight: 436
+url: /sv/java/com.aspose.diagram/vbaprojectreferencetype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VbaProjectReferenceType
+```
+
+Representerar typen av VBA-projektreferens.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CONTROL](#CONTROL) | Anger en referens till ett förvridet typbibliotek och dess utökade typbibliotek. |
+| [PROJECT](#PROJECT) | Anger en referens till ett externt VBA-projekt. |
+| [REGISTERED](#REGISTERED) | Anger en referens till ett Automation-typbibliotek. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CONTROL {#CONTROL}
+```
+public static final int CONTROL
+```
+
+
+Anger en referens till ett förvridet typbibliotek och dess utökade typbibliotek.
+
+### PROJECT {#PROJECT}
+```
+public static final int PROJECT
+```
+
+
+Anger en referens till ett externt VBA-projekt.
+
+### REGISTERED {#REGISTERED}
+```
+public static final int REGISTERED
+```
+
+
+Anger en referens till ett Automation-typbibliotek.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/verticalalign/_index.md
+++ b/swedish/java/com.aspose.diagram/verticalalign/_index.md
@@ -1,0 +1,204 @@
+---
+title: VerticalAlign
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vertikal justering av text inom textblocket.
+type: docs
+weight: 437
+url: /sv/java/com.aspose.diagram/verticalalign/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class VerticalAlign
+```
+
+Anger vertikal justering av text inom textblocket.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [VerticalAlign(int value)](#VerticalAlign-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger vertikal justering av text inom textblocket. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setUfe(UnitFormulaErr value)](#setUfe-com.aspose.diagram.UnitFormulaErr-) | För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--) |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/verticalalign\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### VerticalAlign(int value) {#VerticalAlign-int-}
+```
+public VerticalAlign(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger vertikal justering av text inom textblocket.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setUfe(UnitFormulaErr value) {#setUfe-com.aspose.diagram.UnitFormulaErr-}
+```
+public void setUfe(UnitFormulaErr value)
+```
+
+
+För beskrivningen av denna egenskap, se [getUfe()](../../com.aspose.diagram/verticalalign\#getUfe--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [UnitFormulaErr](../../com.aspose.diagram/unitformulaerr) |  |
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/verticalalign\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/verticalalignvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/verticalalignvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VerticalAlignValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger vertikal justering av text inom textblocket.
+type: docs
+weight: 438
+url: /sv/java/com.aspose.diagram/verticalalignvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VerticalAlignValue
+```
+
+Anger vertikal justering av text inom textblocket.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM](#BOTTOM) | Botten. |
+| [MIDDLE](#MIDDLE) | Mitten. |
+| [TOP](#TOP) | Topp. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM {#BOTTOM}
+```
+public static final int BOTTOM
+```
+
+
+Botten.
+
+### MIDDLE {#MIDDLE}
+```
+public static final int MIDDLE
+```
+
+
+Mitten.
+
+### TOP {#TOP}
+```
+public static final int TOP
+```
+
+
+Topp.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/visruletargetsvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/visruletargetsvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: VisRuleTargetsValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger innehåll som definierar målet för valideringsregeln som skickas till och returneras av egenskapen ValidationRule.TargetType.
+type: docs
+weight: 439
+url: /sv/java/com.aspose.diagram/visruletargetsvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class VisRuleTargetsValue
+```
+
+Anger innehåll som definierar målet för valideringsregeln; skickas till och returneras av egenskapen ValidationRule.TargetType.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+| [VIS_RULE_TARGET_DOCUMENT](#VIS-RULE-TARGET-DOCUMENT) | Regeln gäller för former i dokumentet. |
+| [VIS_RULE_TARGET_PAGE](#VIS-RULE-TARGET-PAGE) | Regeln gäller för sidor i dokumentet. |
+| [VIS_RULE_TARGET_SHAPE](#VIS-RULE-TARGET-SHAPE) | Regeln gäller för själva dokumentet. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### VIS_RULE_TARGET_DOCUMENT {#VIS-RULE-TARGET-DOCUMENT}
+```
+public static final int VIS_RULE_TARGET_DOCUMENT
+```
+
+
+Regeln gäller för former i dokumentet.
+
+### VIS_RULE_TARGET_PAGE {#VIS-RULE-TARGET-PAGE}
+```
+public static final int VIS_RULE_TARGET_PAGE
+```
+
+
+Regeln gäller för sidor i dokumentet.
+
+### VIS_RULE_TARGET_SHAPE {#VIS-RULE-TARGET-SHAPE}
+```
+public static final int VIS_RULE_TARGET_SHAPE
+```
+
+
+Regeln gäller för själva dokumentet.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/walkpreference/_index.md
+++ b/swedish/java/com.aspose.diagram/walkpreference/_index.md
@@ -1,0 +1,179 @@
+---
+title: WalkPreference
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om en ändpunkt på en 1-D-form flyttas till en horisontell eller vertikal anslutningspunkt på formen den är fäst vid med dynamisk limning när formen flyttas till en tvetydig position.
+type: docs
+weight: 440
+url: /sv/java/com.aspose.diagram/walkpreference/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WalkPreference
+```
+
+Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [WalkPreference(int value)](#WalkPreference-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/walkpreference\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WalkPreference(int value) {#WalkPreference-int-}
+```
+public WalkPreference(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/walkpreference\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/walkpreferencevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/walkpreferencevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WalkPreferenceValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger om en ändpunkt på en 1-D-form flyttas till en horisontell eller vertikal anslutningspunkt på formen den är fäst vid med dynamisk limning när formen flyttas till en tvetydig position.
+type: docs
+weight: 441
+url: /sv/java/com.aspose.diagram/walkpreferencevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WalkPreferenceValue
+```
+
+Anger om en ändpunkt på en 1‑D-form flyttas till en horisontell eller vertikal anslutningspunkt på den form den är limmad till, med dynamisk limning, när formen flyttas till en tvetydig position.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [SIDE_TO_SIDE_CONNECTIONS](#SIDE-TO-SIDE-CONNECTIONS) | Standardvärdet. |
+| [SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS](#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS) | Begynnelsepunkten för den endimensionella formen flyttas till en horisontell anslutningspunkt, och slutpunkten flyttas till en vertikal anslutningspunkt (sidoförbindelser till toppen eller botten). |
+| [TOP_TO_BOTTOM_CONNECTIONS](#TOP-TO-BOTTOM-CONNECTIONS) | Båda ändpunkterna för den endimensionella formen flyttas till vertikala anslutningspunkter (upp‑till‑ned-förbindelser). |
+| [TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS](#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS) | Begynnelsepunkten för den endimensionella formen flyttas till en vertikal anslutningspunkt, och slutpunkten flyttas till en horisontell anslutningspunkt (upp‑till‑sida eller ner‑till‑sida-förbindelser). |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SIDE_TO_SIDE_CONNECTIONS {#SIDE-TO-SIDE-CONNECTIONS}
+```
+public static final int SIDE_TO_SIDE_CONNECTIONS
+```
+
+
+Standardvärdet. Båda ändpunkterna för den endimensionella formen flyttas till horisontella anslutningspunkter (sid‑till‑sid-förbindelser).
+
+### SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS {#SIDE-TO-TOP-OR-SIDE-TO-BOTTOM-CONNECTIONS}
+```
+public static final int SIDE_TO_TOP_OR_SIDE_TO_BOTTOM_CONNECTIONS
+```
+
+
+Begynnelsepunkten för den endimensionella formen flyttas till en horisontell anslutningspunkt, och slutpunkten flyttas till en vertikal anslutningspunkt (sidoförbindelser till toppen eller botten).
+
+### TOP_TO_BOTTOM_CONNECTIONS {#TOP-TO-BOTTOM-CONNECTIONS}
+```
+public static final int TOP_TO_BOTTOM_CONNECTIONS
+```
+
+
+Båda ändpunkterna för den endimensionella formen flyttas till vertikala anslutningspunkter (upp‑till‑ned-förbindelser).
+
+### TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS {#TOP-TO-SIDE-OR-BOTTOM-TO-SIDE-CONNECTIONS}
+```
+public static final int TOP_TO_SIDE_OR_BOTTOM_TO_SIDE_CONNECTIONS
+```
+
+
+Begynnelsepunkten för den endimensionella formen flyttas till en vertikal anslutningspunkt, och slutpunkten flyttas till en horisontell anslutningspunkt (upp‑till‑sida eller ner‑till‑sida-förbindelser).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/warninginfo/_index.md
+++ b/swedish/java/com.aspose.diagram/warninginfo/_index.md
@@ -1,0 +1,166 @@
+---
+title: WarningInfo
+second_title: Aspose.Diagram för Java API-referens
+description: Varningsinformation
+type: docs
+weight: 442
+url: /sv/java/com.aspose.diagram/warninginfo/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class WarningInfo
+```
+
+Varningsinformation
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [WarningInfo(int warningType, String description)](#WarningInfo-int-java.lang.String-) | Skapa varningsinformation. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDescription()](#getDescription--) | Hämta beskrivning av varningsinformation. |
+| [getWarningType()](#getWarningType--) | Hämta varningstyp. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### WarningInfo(int warningType, String description) {#WarningInfo-int-java.lang.String-}
+```
+public WarningInfo(int warningType, String description)
+```
+
+
+Skapa varningsinformation.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| warningType | int | varningstyp |
+| beskrivning | java.lang.String | varningsbeskrivning |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDescription() {#getDescription--}
+```
+public String getDescription()
+```
+
+
+Hämta beskrivning av varningsinformation.
+
+**Returns:**
+java.lang.String
+### getWarningType() {#getWarningType--}
+```
+public int getWarningType()
+```
+
+
+Hämta varningstyp.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/warningtype/_index.md
+++ b/swedish/java/com.aspose.diagram/warningtype/_index.md
@@ -1,0 +1,138 @@
+---
+title: WarningType
+second_title: Aspose.Diagram för Java API-referens
+description: WarningType
+type: docs
+weight: 443
+url: /sv/java/com.aspose.diagram/warningtype/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WarningType
+```
+
+WarningType
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [FONT_SUBSTITUTION](#FONT-SUBSTITUTION) | Varningstyp för teckensnittssubstitution när ett teckensnitt inte har hittats, denna varningstyp kan hämtas. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FONT_SUBSTITUTION {#FONT-SUBSTITUTION}
+```
+public static final int FONT_SUBSTITUTION
+```
+
+
+Varningstyp för teckensnittssubstitution när ett teckensnitt inte har hittats, denna varningstyp kan hämtas.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/window/_index.md
+++ b/swedish/java/com.aspose.diagram/window/_index.md
@@ -1,0 +1,899 @@
+---
+title: Window
+second_title: Aspose.Diagram för Java API-referens
+description: Representerar ett öppet fönster i en Microsoft Visio-instans.
+type: docs
+weight: 444
+url: /sv/java/com.aspose.diagram/window/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class Window
+```
+
+Representerar ett öppet fönster i en Microsoft Visio-instans. Detta element innehåller information som behövs för att exakt återskapa ett användargränssnittsfönster i applikationsarbetsytan när DatadiagramML-filen först öppnas av Visio.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [Window()](#Window--) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getContainer()](#getContainer--) | ID för behållare: Sida, Ark eller Master. |
+| [getContainerType()](#getContainerType--) | Kan vara ett av följande värden: Document, Page eller Master. |
+| [getDocument()](#getDocument--) | Filsökväg för dokumentet som visas i detta fönster. |
+| [getDynamicGridEnabled()](#getDynamicGridEnabled--) | Anger om den dynamiska rutnätsfunktionen är aktiverad för ett dokument eller ett fönster. |
+| [getGlueSettings()](#getGlueSettings--) | Anger de objekt som former limmas till när lim är aktiverat i dokumentet. |
+| [getID()](#getID--) | Det unika ID:t för elementet inom dess överordnade element. |
+| [getMaster()](#getMaster--) | Master-ID om detta fönster visar en master. |
+| [getPage()](#getPage--) | Sid-ID om detta fönster visar en sida. |
+| [getParentWindow()](#getParentWindow--) | ID för fönster som detta stencilsfönster är inbäddat i. |
+| [getReadOnly()](#getReadOnly--) | Skrivskyddsflagga om detta stencil inte är ett dokumentstencil. |
+| [getSheet()](#getSheet--) | ID för ark i behållare. |
+| [getShowConnectionPoints()](#getShowConnectionPoints--) | Anger om anslutningspunkter visas i ett fönster. |
+| [getShowGrid()](#getShowGrid--) | Anger om ett rutnät visas i ritfönstret. |
+| [getShowGuides()](#getShowGuides--) | Anger om hjälplinjer visas i ritfönstret. |
+| [getShowPageBreaks()](#getShowPageBreaks--) | Anger om sidbrytningar visas i ett fönster. |
+| [getShowRulers()](#getShowRulers--) | Anger om linjaler visas i ritfönstret. |
+| [getSnapAngles()](#getSnapAngles--) | Innehåller en samling av SnapAngle‑element. |
+| [getSnapExtensions()](#getSnapExtensions--) | Specificerar om en specifik snap-förlängningsinställning är aktiverad eller inaktiverad för det aktiva fönstret. |
+| [getSnapSettings()](#getSnapSettings--) | Specificerar de objekt som former fäster sig vid när snap är aktivt i fönstret. |
+| [getStencilGroup()](#getStencilGroup--) | Anger gruppen av sammanslagna stencilsfönster som fönstret är medlem i. |
+| [getStencilGroupPos()](#getStencilGroupPos--) | Innehåller ett heltal som anger den relativa positionen för ett stencil inom en grupp i ett fönster. |
+| [getTabSplitterPos()](#getTabSplitterPos--) | Anger bredden på sidflikskontrollen i ett ritfönster (som en bråkdel av den totala bredden på ritfönstret). |
+| [getViewCenterX()](#getViewCenterX--) | Valfri dubbel. |
+| [getViewCenterY()](#getViewCenterY--) | Valfri dubbel. |
+| [getViewScale()](#getViewScale--) | Valfri dubbel. |
+| [getWindowHeight()](#getWindowHeight--) | Höjd på fönsterrektangeln. |
+| [getWindowLeft()](#getWindowLeft--) | Vänsterkoordinat för fönsterrektangeln. |
+| [getWindowState()](#getWindowState--) | Detta attribut kan vara en summa av följande värden. |
+| [getWindowTop()](#getWindowTop--) | Övre koordinat för fönsterrektangeln. |
+| [getWindowType()](#getWindowType--) | Ett uppräknat värde som kan vara ett av följande: Drawing, Sheet, Stencil eller Icon. Ett fönsterelement med WindowType='Stencil' måste förekomma efter dess föräldraritningsfönster (WindowType='Drawing') och före alla andra ritfönsterelement. |
+| [getWindowWidth()](#getWindowWidth--) | Bredd på fönsterrektangeln. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setContainer(int value)](#setContainer-int-) | För beskrivningen av denna egenskap, se [getContainer()](../../com.aspose.diagram/window\#getContainer--) |
+| [setContainerType(int value)](#setContainerType-int-) | För beskrivningen av denna egenskap, se [getContainerType()](../../com.aspose.diagram/window\#getContainerType--) |
+| [setDocument(String value)](#setDocument-java.lang.String-) | För beskrivningen av den här egenskapen, se [getDocument()](../../com.aspose.diagram/window\#getDocument--) |
+| [setDynamicGridEnabled(int value)](#setDynamicGridEnabled-int-) | För beskrivningen av den här egenskapen, se [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--) |
+| [setGlueSettings(int value)](#setGlueSettings-int-) | För beskrivningen av den här egenskapen, se [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--) |
+| [setID(int value)](#setID-int-) | För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/window\#getID--) |
+| [setMaster(Master value)](#setMaster-com.aspose.diagram.Master-) | För beskrivningen av den här egenskapen, se [getMaster()](../../com.aspose.diagram/window\#getMaster--) |
+| [setPage(Page value)](#setPage-com.aspose.diagram.Page-) | För beskrivningen av den här egenskapen, se [getPage()](../../com.aspose.diagram/window\#getPage--) |
+| [setParentWindow(int value)](#setParentWindow-int-) | För beskrivningen av den här egenskapen, se [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--) |
+| [setReadOnly(int value)](#setReadOnly-int-) | För beskrivningen av den här egenskapen, se [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--) |
+| [setSheet(int value)](#setSheet-int-) | För beskrivningen av den här egenskapen, se [getSheet()](../../com.aspose.diagram/window\#getSheet--) |
+| [setShowConnectionPoints(int value)](#setShowConnectionPoints-int-) | För beskrivningen av den här egenskapen, se [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--) |
+| [setShowGrid(int value)](#setShowGrid-int-) | För beskrivningen av den här egenskapen, se [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--) |
+| [setShowGuides(int value)](#setShowGuides-int-) | För beskrivningen av den här egenskapen, se [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--) |
+| [setShowPageBreaks(int value)](#setShowPageBreaks-int-) | För beskrivningen av den här egenskapen, se [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--) |
+| [setShowRulers(int value)](#setShowRulers-int-) | För beskrivningen av den här egenskapen, se [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--) |
+| [setSnapExtensions(int value)](#setSnapExtensions-int-) | För beskrivningen av den här egenskapen, se [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--) |
+| [setSnapSettings(int value)](#setSnapSettings-int-) | För beskrivningen av den här egenskapen, se [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--) |
+| [setStencilGroup(String value)](#setStencilGroup-java.lang.String-) | För beskrivningen av den här egenskapen, se [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--) |
+| [setStencilGroupPos(int value)](#setStencilGroupPos-int-) | För beskrivningen av den här egenskapen, se [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--) |
+| [setTabSplitterPos(double value)](#setTabSplitterPos-double-) | För beskrivningen av den här egenskapen, se [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--) |
+| [setViewCenterX(double value)](#setViewCenterX-double-) | För beskrivningen av den här egenskapen, se [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--) |
+| [setViewCenterY(double value)](#setViewCenterY-double-) | För beskrivningen av den här egenskapen, se [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--) |
+| [setViewScale(double value)](#setViewScale-double-) | För beskrivningen av den här egenskapen, se [getViewScale()](../../com.aspose.diagram/window\#getViewScale--) |
+| [setWindowHeight(long value)](#setWindowHeight-long-) | För beskrivningen av den här egenskapen, se [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--) |
+| [setWindowLeft(int value)](#setWindowLeft-int-) | För beskrivningen av den här egenskapen, se [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--) |
+| [setWindowState(int value)](#setWindowState-int-) | För beskrivningen av den här egenskapen, se [getWindowState()](../../com.aspose.diagram/window\#getWindowState--) |
+| [setWindowTop(int value)](#setWindowTop-int-) | För beskrivningen av den här egenskapen, se [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--) |
+| [setWindowType(int value)](#setWindowType-int-) | För beskrivningen av den här egenskapen, se [getWindowType()](../../com.aspose.diagram/window\#getWindowType--) |
+| [setWindowWidth(long value)](#setWindowWidth-long-) | För beskrivningen av den här egenskapen, se [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Window() {#Window--}
+```
+public Window()
+```
+
+
+Konstruktor.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getContainer() {#getContainer--}
+```
+public int getContainer()
+```
+
+
+Behållarens ID: Page, Sheet eller Master. Endast relevant och nödvändig om ContainerType är specificerad.
+
+**Returns:**
+int
+### getContainerType() {#getContainerType--}
+```
+public int getContainerType()
+```
+
+
+Kan vara ett av följande värden: Dokument, Sida eller Master. Endast relevant när WindowType anges som Drawing eller Sheet.
+
+**Returns:**
+int
+### getDocument() {#getDocument--}
+```
+public String getDocument()
+```
+
+
+Filväg till dokumentet som visas i detta fönster. Detta attribut är relevant för fönster vars WindowType är specificerad som Stencil.
+
+**Returns:**
+java.lang.String
+### getDynamicGridEnabled() {#getDynamicGridEnabled--}
+```
+public int getDynamicGridEnabled()
+```
+
+
+Anger om den dynamiska rutnätsfunktionen är aktiverad för ett dokument eller ett fönster.
+
+**Returns:**
+int
+### getGlueSettings() {#getGlueSettings--}
+```
+public int getGlueSettings()
+```
+
+
+Anger de objekt som former limmas till när lim är aktiverat i dokumentet.
+
+**Returns:**
+int
+### getID() {#getID--}
+```
+public int getID()
+```
+
+
+Det unika ID:t för elementet inom dess överordnade element.
+
+**Returns:**
+int
+### getMaster() {#getMaster--}
+```
+public Master getMaster()
+```
+
+
+Master-ID om detta fönster visar en master.
+
+**Returns:**
+[Master](../../com.aspose.diagram/master)
+### getPage() {#getPage--}
+```
+public Page getPage()
+```
+
+
+Sidans ID om detta fönster visar en sida. Relevant endast när WindowType är specificerad som Drawing och ContainerType är specificerad som Page.
+
+**Returns:**
+[Page](../../com.aspose.diagram/page)
+### getParentWindow() {#getParentWindow--}
+```
+public int getParentWindow()
+```
+
+
+Fönstrets ID där detta stencil‑fönster finns. Relevant endast när WindowType är specificerad som Stencil.
+
+**Returns:**
+int
+### getReadOnly() {#getReadOnly--}
+```
+public int getReadOnly()
+```
+
+
+Skrivskyddsflagga om detta stencil inte är ett dokumentstencil.
+
+**Returns:**
+int
+### getSheet() {#getSheet--}
+```
+public int getSheet()
+```
+
+
+Bladets ID i behållaren. Relevant endast när Container är specificerad som Sheet.
+
+**Returns:**
+int
+### getShowConnectionPoints() {#getShowConnectionPoints--}
+```
+public int getShowConnectionPoints()
+```
+
+
+Anger om anslutningspunkter visas i ett fönster.
+
+**Returns:**
+int
+### getShowGrid() {#getShowGrid--}
+```
+public int getShowGrid()
+```
+
+
+Anger om ett rutnät visas i ritfönstret.
+
+**Returns:**
+int
+### getShowGuides() {#getShowGuides--}
+```
+public int getShowGuides()
+```
+
+
+Anger om hjälplinjer visas i ritfönstret.
+
+**Returns:**
+int
+### getShowPageBreaks() {#getShowPageBreaks--}
+```
+public int getShowPageBreaks()
+```
+
+
+Anger om sidbrytningar visas i ett fönster.
+
+**Returns:**
+int
+### getShowRulers() {#getShowRulers--}
+```
+public int getShowRulers()
+```
+
+
+Anger om linjaler visas i ritfönstret.
+
+**Returns:**
+int
+### getSnapAngles() {#getSnapAngles--}
+```
+public FloatPointNumCollection getSnapAngles()
+```
+
+
+Innehåller en samling av SnapAngle‑element.
+
+**Returns:**
+[FloatPointNumCollection](../../com.aspose.diagram/floatpointnumcollection)
+### getSnapExtensions() {#getSnapExtensions--}
+```
+public int getSnapExtensions()
+```
+
+
+Anger om en specifik snap‑utökninginställning är aktiverad eller inaktiverad för det aktiva fönstret. Värdet kan vara en summa av värdena i följande tabell.
+
+**Returns:**
+int
+### getSnapSettings() {#getSnapSettings--}
+```
+public int getSnapSettings()
+```
+
+
+Anger de objekt som former fäster sig vid när fästning är aktiv i fönstret. Värdet kan vara en summa av värdena i följande tabell.
+
+**Returns:**
+int
+### getStencilGroup() {#getStencilGroup--}
+```
+public String getStencilGroup()
+```
+
+
+Anger gruppen av sammanslagna stencil‑fönster som detta fönster tillhör. Detta attribut är endast relevant för Window‑element vars WindowType‑attribut är Stencil, och endast om stencil‑fönstret är en del av en sammanslagen grupp av stencil‑fönster. Alla stencil‑fönster som är en del av samma sammanslagna grupp har samma StencilGroup‑elementvärde.
+
+**Returns:**
+java.lang.String
+### getStencilGroupPos() {#getStencilGroupPos--}
+```
+public int getStencilGroupPos()
+```
+
+
+Innehåller ett heltal som anger den relativa positionen för ett stencil inom en grupp i ett fönster.
+
+**Returns:**
+int
+### getTabSplitterPos() {#getTabSplitterPos--}
+```
+public double getTabSplitterPos()
+```
+
+
+Anger bredden på sidflikskontrollen i ett ritfönster (som en bråkdel av den totala bredden på ritfönstret).
+
+**Returns:**
+double
+### getViewCenterX() {#getViewCenterX--}
+```
+public double getViewCenterX()
+```
+
+
+Valfri dubbel.
+
+**Returns:**
+double
+### getViewCenterY() {#getViewCenterY--}
+```
+public double getViewCenterY()
+```
+
+
+Valfri dubbel.
+
+**Returns:**
+double
+### getViewScale() {#getViewScale--}
+```
+public double getViewScale()
+```
+
+
+Valfri dubbel.
+
+**Returns:**
+double
+### getWindowHeight() {#getWindowHeight--}
+```
+public long getWindowHeight()
+```
+
+
+Höjd på fönsterrektangeln.
+
+**Returns:**
+long
+### getWindowLeft() {#getWindowLeft--}
+```
+public int getWindowLeft()
+```
+
+
+Vänsterkoordinat för fönsterrektangeln.
+
+**Returns:**
+int
+### getWindowState() {#getWindowState--}
+```
+public int getWindowState()
+```
+
+
+Detta attribut kan vara en summa av följande värden.
+
+**Returns:**
+int
+### getWindowTop() {#getWindowTop--}
+```
+public int getWindowTop()
+```
+
+
+Övre koordinat för fönsterrektangeln.
+
+**Returns:**
+int
+### getWindowType() {#getWindowType--}
+```
+public int getWindowType()
+```
+
+
+Ett uppräknat värde som kan vara ett av följande: Drawing, Sheet, Stencil eller Icon. Ett fönsterelement med WindowType='Stencil' måste förekomma efter dess föräldraritningsfönster (WindowType='Drawing') och före alla andra ritfönsterelement.
+
+**Returns:**
+int
+### getWindowWidth() {#getWindowWidth--}
+```
+public long getWindowWidth()
+```
+
+
+Bredd på fönsterrektangeln.
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setContainer(int value) {#setContainer-int-}
+```
+public void setContainer(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getContainer()](../../com.aspose.diagram/window\#getContainer--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setContainerType(int value) {#setContainerType-int-}
+```
+public void setContainerType(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getContainerType()](../../com.aspose.diagram/window\#getContainerType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setDocument(String value) {#setDocument-java.lang.String-}
+```
+public void setDocument(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDocument()](../../com.aspose.diagram/window\#getDocument--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setDynamicGridEnabled(int value) {#setDynamicGridEnabled-int-}
+```
+public void setDynamicGridEnabled(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getDynamicGridEnabled()](../../com.aspose.diagram/window\#getDynamicGridEnabled--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setGlueSettings(int value) {#setGlueSettings-int-}
+```
+public void setGlueSettings(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getGlueSettings()](../../com.aspose.diagram/window\#getGlueSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setID(int value) {#setID-int-}
+```
+public void setID(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getID()](../../com.aspose.diagram/window\#getID--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setMaster(Master value) {#setMaster-com.aspose.diagram.Master-}
+```
+public void setMaster(Master value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getMaster()](../../com.aspose.diagram/window\#getMaster--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Master](../../com.aspose.diagram/master) |  |
+
+### setPage(Page value) {#setPage-com.aspose.diagram.Page-}
+```
+public void setPage(Page value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPage()](../../com.aspose.diagram/window\#getPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [Page](../../com.aspose.diagram/page) |  |
+
+### setParentWindow(int value) {#setParentWindow-int-}
+```
+public void setParentWindow(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getParentWindow()](../../com.aspose.diagram/window\#getParentWindow--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setReadOnly(int value) {#setReadOnly-int-}
+```
+public void setReadOnly(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getReadOnly()](../../com.aspose.diagram/window\#getReadOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSheet(int value) {#setSheet-int-}
+```
+public void setSheet(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSheet()](../../com.aspose.diagram/window\#getSheet--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowConnectionPoints(int value) {#setShowConnectionPoints-int-}
+```
+public void setShowConnectionPoints(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowConnectionPoints()](../../com.aspose.diagram/window\#getShowConnectionPoints--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowGrid(int value) {#setShowGrid-int-}
+```
+public void setShowGrid(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowGrid()](../../com.aspose.diagram/window\#getShowGrid--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowGuides(int value) {#setShowGuides-int-}
+```
+public void setShowGuides(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowGuides()](../../com.aspose.diagram/window\#getShowGuides--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowPageBreaks(int value) {#setShowPageBreaks-int-}
+```
+public void setShowPageBreaks(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowPageBreaks()](../../com.aspose.diagram/window\#getShowPageBreaks--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setShowRulers(int value) {#setShowRulers-int-}
+```
+public void setShowRulers(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getShowRulers()](../../com.aspose.diagram/window\#getShowRulers--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSnapExtensions(int value) {#setSnapExtensions-int-}
+```
+public void setSnapExtensions(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSnapExtensions()](../../com.aspose.diagram/window\#getSnapExtensions--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSnapSettings(int value) {#setSnapSettings-int-}
+```
+public void setSnapSettings(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSnapSettings()](../../com.aspose.diagram/window\#getSnapSettings--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setStencilGroup(String value) {#setStencilGroup-java.lang.String-}
+```
+public void setStencilGroup(String value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStencilGroup()](../../com.aspose.diagram/window\#getStencilGroup--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setStencilGroupPos(int value) {#setStencilGroupPos-int-}
+```
+public void setStencilGroupPos(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStencilGroupPos()](../../com.aspose.diagram/window\#getStencilGroupPos--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setTabSplitterPos(double value) {#setTabSplitterPos-double-}
+```
+public void setTabSplitterPos(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getTabSplitterPos()](../../com.aspose.diagram/window\#getTabSplitterPos--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setViewCenterX(double value) {#setViewCenterX-double-}
+```
+public void setViewCenterX(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewCenterX()](../../com.aspose.diagram/window\#getViewCenterX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setViewCenterY(double value) {#setViewCenterY-double-}
+```
+public void setViewCenterY(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewCenterY()](../../com.aspose.diagram/window\#getViewCenterY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setViewScale(double value) {#setViewScale-double-}
+```
+public void setViewScale(double value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getViewScale()](../../com.aspose.diagram/window\#getViewScale--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | double |  |
+
+### setWindowHeight(long value) {#setWindowHeight-long-}
+```
+public void setWindowHeight(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowHeight()](../../com.aspose.diagram/window\#getWindowHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### setWindowLeft(int value) {#setWindowLeft-int-}
+```
+public void setWindowLeft(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowLeft()](../../com.aspose.diagram/window\#getWindowLeft--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWindowState(int value) {#setWindowState-int-}
+```
+public void setWindowState(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowState()](../../com.aspose.diagram/window\#getWindowState--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWindowTop(int value) {#setWindowTop-int-}
+```
+public void setWindowTop(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowTop()](../../com.aspose.diagram/window\#getWindowTop--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWindowType(int value) {#setWindowType-int-}
+```
+public void setWindowType(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowType()](../../com.aspose.diagram/window\#getWindowType--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWindowWidth(long value) {#setWindowWidth-long-}
+```
+public void setWindowWidth(long value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getWindowWidth()](../../com.aspose.diagram/window\#getWindowWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | long |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/windowcollection/_index.md
+++ b/swedish/java/com.aspose.diagram/windowcollection/_index.md
@@ -1,0 +1,268 @@
+---
+title: WindowCollection
+second_title: Aspose.Diagram för Java API-referens
+description: Fönstersamling.
+type: docs
+weight: 445
+url: /sv/java/com.aspose.diagram/windowcollection/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.Collection](../../com.aspose.diagram/collection)
+```
+public class WindowCollection extends Collection
+```
+
+Fönstersamling.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [add(Window window)](#add-com.aspose.diagram.Window-) | Lägg till fönstret i samlingen. |
+| [clear()](#clear--) | Tar bort alla element från samlingen. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int index)](#get-int-) | Hämtar elementet på det angivna indexet. |
+| [getClass()](#getClass--) |  |
+| [getClientHeight()](#getClientHeight--) | Valfri int. |
+| [getClientWidth()](#getClientWidth--) | Valfri int. |
+| [getCount()](#getCount--) | Hämtar antalet element som faktiskt finns i samlingen. |
+| [hashCode()](#hashCode--) |  |
+| [isExist(int index)](#isExist-int-) | Finns ett objekt i samlingen. |
+| [iterator()](#iterator--) | Stöder en enkel iteration över en icke-generisk samling. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(Window window)](#remove-com.aspose.diagram.Window-) | Ta bort fönstret från samlingen. |
+| [setClientHeight(int value)](#setClientHeight-int-) | För beskrivningen av denna egenskap, se [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--) |
+| [setClientWidth(int value)](#setClientWidth-int-) | För beskrivningen av denna egenskap, se [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(Window window) {#add-com.aspose.diagram.Window-}
+```
+public int add(Window window)
+```
+
+
+Lägg till fönstret i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+**Returns:**
+int -
+### clear() {#clear--}
+```
+public void clear()
+```
+
+
+Tar bort alla element från samlingen.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int index) {#get-int-}
+```
+public Window get(int index)
+```
+
+
+Hämtar elementet på det angivna indexet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int |  |
+
+**Returns:**
+[Window](../../com.aspose.diagram/window) - 
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClientHeight() {#getClientHeight--}
+```
+public int getClientHeight()
+```
+
+
+Valfri int.
+
+**Returns:**
+int
+### getClientWidth() {#getClientWidth--}
+```
+public int getClientWidth()
+```
+
+
+Valfri int.
+
+**Returns:**
+int
+### getCount() {#getCount--}
+```
+public int getCount()
+```
+
+
+Hämtar antalet element som faktiskt finns i samlingen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isExist(int index) {#isExist-int-}
+```
+public boolean isExist(int index)
+```
+
+
+Finns ett objekt i samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| index | int | index för elementet. |
+
+**Returns:**
+boolean -
+### iterator() {#iterator--}
+```
+public Iterator iterator()
+```
+
+
+Stöder en enkel iteration över en icke-generisk samling.
+
+**Returns:**
+java.util.Iterator -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(Window window) {#remove-com.aspose.diagram.Window-}
+```
+public void remove(Window window)
+```
+
+
+Ta bort fönstret från samlingen.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| window | [Window](../../com.aspose.diagram/window) |  |
+
+### setClientHeight(int value) {#setClientHeight-int-}
+```
+public void setClientHeight(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getClientHeight()](../../com.aspose.diagram/windowcollection\#getClientHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setClientWidth(int value) {#setClientWidth-int-}
+```
+public void setClientWidth(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getClientWidth()](../../com.aspose.diagram/windowcollection\#getClientWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/windowstatevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/windowstatevalue/_index.md
@@ -1,0 +1,264 @@
+---
+title: WindowStateValue
+second_title: Aspose.Diagram för Java API-referens
+description: Ett heltal som specificerar bitflaggor.
+type: docs
+weight: 446
+url: /sv/java/com.aspose.diagram/windowstatevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowStateValue
+```
+
+Ett heltal som specificerar bitflaggor. Detta attribut kan vara en summa av följande värden.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [ACTIVE](#ACTIVE) | Aktiv. |
+| [ANCHOR_BOTTOM](#ANCHOR-BOTTOM) | Fäst botten. |
+| [ANCHOR_LEFT](#ANCHOR-LEFT) | Fäst vänster. |
+| [ANCHOR_MERGED](#ANCHOR-MERGED) | Fäst sammanslagen. |
+| [ANCHOR_RIGHT](#ANCHOR-RIGHT) | Fäst höger. |
+| [ANCHOR_TOP](#ANCHOR-TOP) | Fäst topp. |
+| [DOCKED_BOTTOM](#DOCKED-BOTTOM) | Dockad botten. |
+| [DOCKED_LEFT](#DOCKED-LEFT) | Dockad vänster. |
+| [DOCKED_RIGHT](#DOCKED-RIGHT) | Dockad höger. |
+| [DOCKED_TOP](#DOCKED-TOP) | Dockad topp. |
+| [DOUBLEING](#DOUBLEING) | Dubbeling. |
+| [MAXIMIZED](#MAXIMIZED) | Maximerad. |
+| [MINIMIZED](#MINIMIZED) | Minimerad. |
+| [RESTORED](#RESTORED) | Återställd. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ACTIVE {#ACTIVE}
+```
+public static final int ACTIVE
+```
+
+
+Aktiv.
+
+### ANCHOR_BOTTOM {#ANCHOR-BOTTOM}
+```
+public static final int ANCHOR_BOTTOM
+```
+
+
+Fäst botten.
+
+### ANCHOR_LEFT {#ANCHOR-LEFT}
+```
+public static final int ANCHOR_LEFT
+```
+
+
+Fäst vänster.
+
+### ANCHOR_MERGED {#ANCHOR-MERGED}
+```
+public static final int ANCHOR_MERGED
+```
+
+
+Fäst sammanslagen.
+
+### ANCHOR_RIGHT {#ANCHOR-RIGHT}
+```
+public static final int ANCHOR_RIGHT
+```
+
+
+Fäst höger.
+
+### ANCHOR_TOP {#ANCHOR-TOP}
+```
+public static final int ANCHOR_TOP
+```
+
+
+Fäst topp.
+
+### DOCKED_BOTTOM {#DOCKED-BOTTOM}
+```
+public static final int DOCKED_BOTTOM
+```
+
+
+Dockad botten.
+
+### DOCKED_LEFT {#DOCKED-LEFT}
+```
+public static final int DOCKED_LEFT
+```
+
+
+Dockad vänster.
+
+### DOCKED_RIGHT {#DOCKED-RIGHT}
+```
+public static final int DOCKED_RIGHT
+```
+
+
+Dockad höger.
+
+### DOCKED_TOP {#DOCKED-TOP}
+```
+public static final int DOCKED_TOP
+```
+
+
+Dockad topp.
+
+### DOUBLEING {#DOUBLEING}
+```
+public static final int DOUBLEING
+```
+
+
+Dubbeling.
+
+### MAXIMIZED {#MAXIMIZED}
+```
+public static final int MAXIMIZED
+```
+
+
+Maximerad.
+
+### MINIMIZED {#MINIMIZED}
+```
+public static final int MINIMIZED
+```
+
+
+Minimerad.
+
+### RESTORED {#RESTORED}
+```
+public static final int RESTORED
+```
+
+
+Återställd.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/windowtypevalue/_index.md
+++ b/swedish/java/com.aspose.diagram/windowtypevalue/_index.md
@@ -1,0 +1,174 @@
+---
+title: WindowTypeValue
+second_title: Aspose.Diagram för Java API-referens
+description: Ett uppräknat värde som kan vara ett av följande Drawing Sheet Stencil eller Icon.
+type: docs
+weight: 447
+url: /sv/java/com.aspose.diagram/windowtypevalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class WindowTypeValue
+```
+
+Ett uppräknat värde som kan vara ett av följande: Drawing, Sheet, Stencil eller Icon. Ett Window‑element med WindowType='Stencil' måste förekomma efter dess föräldra‑ritningsfönster (WindowType='Drawing') och före alla andra ritningsfönsterelement.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [DRAWING](#DRAWING) | Drawing |
+| [ICON](#ICON) | Icon. |
+| [SHEET](#SHEET) | Sheet |
+| [STENCIL](#STENCIL) | Stencil. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DRAWING {#DRAWING}
+```
+public static final int DRAWING
+```
+
+
+Drawing
+
+### ICON {#ICON}
+```
+public static final int ICON
+```
+
+
+Icon.
+
+### SHEET {#SHEET}
+```
+public static final int SHEET
+```
+
+
+Sheet
+
+### STENCIL {#STENCIL}
+```
+public static final int STENCIL
+```
+
+
+Stencil.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xamlsaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/xamlsaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XAMLSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när diagramssidor renderas till XAML.
+type: docs
+weight: 448
+url: /sv/java/com.aspose.diagram/xamlsaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XAMLSaveOptions extends SaveOptions
+```
+
+Tillåter att ange ytterligare alternativ när diagramssidor renderas till XAML.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [XAMLSaveOptions()](#XAMLSaveOptions--) | Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getPageCount()](#getPageCount--) | antalet sidor att rendera i XAML. |
+| [getPageIndex()](#getPageIndex--) | det nollbaserade indexet för den första sidan som ska renderas. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska sparas som bild eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger formatet som de renderade diagrammetsidorna kommer att sparas i om detta sparaalternativobjekt används. |
+| [getStreamProvider()](#getStreamProvider--) | IStreamProvider för att exportera objekt. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--) |
+| [setStreamProvider(IStreamProvider value)](#setStreamProvider-com.aspose.diagram.IStreamProvider-) | För beskrivningen av den här egenskapen, se [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XAMLSaveOptions() {#XAMLSaveOptions--}
+```
+public XAMLSaveOptions()
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+antalet sidor som ska renderas i XAML. Standard är MaxValue vilket betyder att alla sidor i diagrammet kommer att renderas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+det 0-baserade indexet för den första sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska sparas i bilden eller bara förgrunden. Om true – renderas endast förgrundssidor (med bakgrund om den finns). Om false – renderas förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket de renderade diagrammenyerna ska sparas om detta spara-alternativobjekt används. Kan endast vara Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getStreamProvider() {#getStreamProvider--}
+```
+public IStreamProvider getStreamProvider()
+```
+
+
+IStreamProvider för att exportera objekt.
+
+**Returns:**
+[IStreamProvider](../../com.aspose.diagram/istreamprovider)
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/xamlsaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/xamlsaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xamlsaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/xamlsaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setStreamProvider(IStreamProvider value) {#setStreamProvider-com.aspose.diagram.IStreamProvider-}
+```
+public void setStreamProvider(IStreamProvider value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getStreamProvider()](../../com.aspose.diagram/xamlsaveoptions\#getStreamProvider--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IStreamProvider](../../com.aspose.diagram/istreamprovider) |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xform/_index.md
+++ b/swedish/java/com.aspose.diagram/xform/_index.md
@@ -1,0 +1,436 @@
+---
+title: XForm
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller element som styr linjeattribut för en form, såsom mönstervikt och färg.
+type: docs
+weight: 449
+url: /sv/java/com.aspose.diagram/xform/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm
+```
+
+Innehåller element som styr linjeattribut för en form, såsom mönster, tjocklek och färg. Dessa element bestämmer om linjeändarna är formaterade (till exempel med en pilspets), storleken på linjeändformat, radien på den avrundade cirkeln som tillämpas på linjen och linjeändstil (rund eller fyrkantig).
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAngle()](#getAngle--) | Representerar figurens aktuella rotationsvinkel i förhållande till dess förälder. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getFlipX()](#getFlipX--) | Indikerar om formen har vändts horisontellt |
+| [getFlipY()](#getFlipY--) | Indikerar om formen har vändts vertikalt. |
+| [getHeight()](#getHeight--) | Anger formens höjd i ritningsenheter. |
+| [getLocPinX()](#getLocPinX--) | Anger x-koordinaten för formens pinne (rotationscentrum) i förhållande till formens ursprung. |
+| [getLocPinY()](#getLocPinY--) | Anger y-koordinaten för formens pinne (rotationscentrum) i förhållande till formens ursprung. |
+| [getPinPos()](#getPinPos--) | Anger pinnens position för formen |
+| [getPinX()](#getPinX--) | Anger x-koordinaten för formens pinne (rotationscentrum) i förhållande till dess förälders ursprung. |
+| [getPinY()](#getPinY--) | Anger y-koordinaten för formens pinne (rotationscentrum) i förhållande till dess förälders ursprung. |
+| [getResizeMode()](#getResizeMode--) | Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp. |
+| [getWidth()](#getWidth--) | Innehåller bredden på den associerade formen i ritningsenheter. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(DoubleValue value)](#setAngle-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getAngle()](../../com.aspose.diagram/xform\#getAngle--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/xform\#getDel--) |
+| [setFlipX(BoolValue value)](#setFlipX-com.aspose.diagram.BoolValue-) | För beskrivningen av denna egenskap, se [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--) |
+| [setFlipY(BoolValue value)](#setFlipY-com.aspose.diagram.BoolValue-) | För beskrivningen av denna egenskap, se [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--) |
+| [setHeight(DoubleValue value)](#setHeight-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/xform\#getHeight--) |
+| [setLocPinX(DoubleValue value)](#setLocPinX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--) |
+| [setLocPinY(DoubleValue value)](#setLocPinY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--) |
+| [setPinPos(int value)](#setPinPos-int-) | För beskrivningen av denna egenskap, se [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--) |
+| [setPinX(DoubleValue value)](#setPinX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getPinX()](../../com.aspose.diagram/xform\#getPinX--) |
+| [setPinY(DoubleValue value)](#setPinY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getPinY()](../../com.aspose.diagram/xform\#getPinY--) |
+| [setResizeMode(ResizeMode value)](#setResizeMode-com.aspose.diagram.ResizeMode-) | För beskrivningen av denna egenskap, se [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--) |
+| [setWidth(DoubleValue value)](#setWidth-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/xform\#getWidth--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAngle() {#getAngle--}
+```
+public DoubleValue getAngle()
+```
+
+
+Representerar figurens aktuella rotationsvinkel i förhållande till dess förälder.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getFlipX() {#getFlipX--}
+```
+public BoolValue getFlipX()
+```
+
+
+Indikerar om formen har vändts horisontellt
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getFlipY() {#getFlipY--}
+```
+public BoolValue getFlipY()
+```
+
+
+Indikerar om formen har vändts vertikalt.
+
+**Returns:**
+[BoolValue](../../com.aspose.diagram/boolvalue)
+### getHeight() {#getHeight--}
+```
+public DoubleValue getHeight()
+```
+
+
+Anger formens höjd i ritningsenheter.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinX() {#getLocPinX--}
+```
+public DoubleValue getLocPinX()
+```
+
+
+Anger x-koordinaten för formens pinne (rotationscentrum) i förhållande till formens ursprung. Standardformeln för att bestämma LocPinX är: F='Width\* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getLocPinY() {#getLocPinY--}
+```
+public DoubleValue getLocPinY()
+```
+
+
+Anger y-koordinaten för formens pinne (rotationscentrum) i förhållande till formens ursprung. Standardformeln för att bestämma LocPinY är: F='Height \* 0.5'.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinPos() {#getPinPos--}
+```
+public int getPinPos()
+```
+
+
+Anger pinnens position för formen
+
+**Returns:**
+int
+### getPinX() {#getPinX--}
+```
+public DoubleValue getPinX()
+```
+
+
+Anger x-koordinaten för formens pinne (rotationscentrum) i förhållande till dess förälders ursprung.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getPinY() {#getPinY--}
+```
+public DoubleValue getPinY()
+```
+
+
+Anger y-koordinaten för formens pinne (rotationscentrum) i förhållande till dess förälders ursprung.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getResizeMode() {#getResizeMode--}
+```
+public ResizeMode getResizeMode()
+```
+
+
+Anger den aktuella inställningen för storleksändringsbeteende för formen när den finns i en grupp.
+
+**Returns:**
+[ResizeMode](../../com.aspose.diagram/resizemode)
+### getWidth() {#getWidth--}
+```
+public DoubleValue getWidth()
+```
+
+
+Innehåller bredden på den associerade formen i ritningsenheter.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(DoubleValue value) {#setAngle-com.aspose.diagram.DoubleValue-}
+```
+public void setAngle(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getAngle()](../../com.aspose.diagram/xform\#getAngle--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/xform\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setFlipX(BoolValue value) {#setFlipX-com.aspose.diagram.BoolValue-}
+```
+public void setFlipX(BoolValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFlipX()](../../com.aspose.diagram/xform\#getFlipX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setFlipY(BoolValue value) {#setFlipY-com.aspose.diagram.BoolValue-}
+```
+public void setFlipY(BoolValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getFlipY()](../../com.aspose.diagram/xform\#getFlipY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [BoolValue](../../com.aspose.diagram/boolvalue) |  |
+
+### setHeight(DoubleValue value) {#setHeight-com.aspose.diagram.DoubleValue-}
+```
+public void setHeight(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getHeight()](../../com.aspose.diagram/xform\#getHeight--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinX(DoubleValue value) {#setLocPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLocPinX()](../../com.aspose.diagram/xform\#getLocPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setLocPinY(DoubleValue value) {#setLocPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setLocPinY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getLocPinY()](../../com.aspose.diagram/xform\#getLocPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinPos(int value) {#setPinPos-int-}
+```
+public void setPinPos(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPinPos()](../../com.aspose.diagram/xform\#getPinPos--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPinX(DoubleValue value) {#setPinX-com.aspose.diagram.DoubleValue-}
+```
+public void setPinX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPinX()](../../com.aspose.diagram/xform\#getPinX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setPinY(DoubleValue value) {#setPinY-com.aspose.diagram.DoubleValue-}
+```
+public void setPinY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getPinY()](../../com.aspose.diagram/xform\#getPinY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setResizeMode(ResizeMode value) {#setResizeMode-com.aspose.diagram.ResizeMode-}
+```
+public void setResizeMode(ResizeMode value)
+```
+
+
+För beskrivningen av denna egenskap, se [getResizeMode()](../../com.aspose.diagram/xform\#getResizeMode--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [ResizeMode](../../com.aspose.diagram/resizemode) |  |
+
+### setWidth(DoubleValue value) {#setWidth-com.aspose.diagram.DoubleValue-}
+```
+public void setWidth(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getWidth()](../../com.aspose.diagram/xform\#getWidth--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xform1d/_index.md
+++ b/swedish/java/com.aspose.diagram/xform1d/_index.md
@@ -1,0 +1,261 @@
+---
+title: XForm1D
+second_title: Aspose.Diagram för Java API-referens
+description: Innehåller x- och y-koordinater för startpunkten och slutpunkten av en 1‑D-form.
+type: docs
+weight: 450
+url: /sv/java/com.aspose.diagram/xform1d/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XForm1D
+```
+
+Innehåller x- och y-koordinater för startpunkten och slutpunkten för en 1‑D-form. Detta element visas endast för 1‑D-former.
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [deepClone()](#deepClone--) | Skapar en djup kopia av denna instans. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBeginX()](#getBeginX--) | Representerar x-koordinaten för startpunkten av 1‑D-formen, i förhållande till dess förälders origo. |
+| [getBeginY()](#getBeginY--) | Representerar y-koordinaten för startpunkten av 1‑D-formen, i förhållande till dess förälders origo. |
+| [getClass()](#getClass--) |  |
+| [getDel()](#getDel--) | En flagga som indikerar om elementet har raderats lokalt. |
+| [getEndX()](#getEndX--) | Representerar x-koordinaten för slutpunkten av en 1‑D-form i förhållande till dess förälders origo. |
+| [getEndY()](#getEndY--) | Representerar y-koordinaten för slutpunkten av en 1‑D-form i förhållande till dess förälders ursprung. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBeginX(DoubleValue value)](#setBeginX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--) |
+| [setBeginY(DoubleValue value)](#setBeginY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--) |
+| [setDel(int value)](#setDel-int-) | För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/xform1d\#getDel--) |
+| [setEndX(DoubleValue value)](#setEndX-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--) |
+| [setEndY(DoubleValue value)](#setEndY-com.aspose.diagram.DoubleValue-) | För beskrivningen av denna egenskap, se [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public Object deepClone()
+```
+
+
+Skapar en djup kopia av denna instans.
+
+**Returns:**
+java.lang.Object -
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBeginX() {#getBeginX--}
+```
+public DoubleValue getBeginX()
+```
+
+
+Representerar x-koordinaten för startpunkten av 1‑D-formen, i förhållande till dess förälders origo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getBeginY() {#getBeginY--}
+```
+public DoubleValue getBeginY()
+```
+
+
+Representerar y-koordinaten för startpunkten av 1‑D-formen, i förhållande till dess förälders origo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDel() {#getDel--}
+```
+public int getDel()
+```
+
+
+En flagga som indikerar om elementet har raderats lokalt. Ett värde på 1 indikerar att elementet raderades lokalt.
+
+**Returns:**
+int
+### getEndX() {#getEndX--}
+```
+public DoubleValue getEndX()
+```
+
+
+Representerar x-koordinaten för slutpunkten av en 1‑D-form i förhållande till dess förälders origo.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### getEndY() {#getEndY--}
+```
+public DoubleValue getEndY()
+```
+
+
+Representerar y-koordinaten för slutpunkten av en 1‑D-form i förhållande till dess förälders ursprung.
+
+**Returns:**
+[DoubleValue](../../com.aspose.diagram/doublevalue)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBeginX(DoubleValue value) {#setBeginX-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBeginX()](../../com.aspose.diagram/xform1d\#getBeginX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setBeginY(DoubleValue value) {#setBeginY-com.aspose.diagram.DoubleValue-}
+```
+public void setBeginY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getBeginY()](../../com.aspose.diagram/xform1d\#getBeginY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setDel(int value) {#setDel-int-}
+```
+public void setDel(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDel()](../../com.aspose.diagram/xform1d\#getDel--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setEndX(DoubleValue value) {#setEndX-com.aspose.diagram.DoubleValue-}
+```
+public void setEndX(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEndX()](../../com.aspose.diagram/xform1d\#getEndX--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### setEndY(DoubleValue value) {#setEndY-com.aspose.diagram.DoubleValue-}
+```
+public void setEndY(DoubleValue value)
+```
+
+
+För beskrivningen av denna egenskap, se [getEndY()](../../com.aspose.diagram/xform1d\#getEndY--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [DoubleValue](../../com.aspose.diagram/doublevalue) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xjustify/_index.md
+++ b/swedish/java/com.aspose.diagram/xjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: XJustify
+second_title: Aspose.Diagram för Java API-referens
+description: X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+type: docs
+weight: 451
+url: /sv/java/com.aspose.diagram/xjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class XJustify
+```
+
+X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [XJustify(int value)](#XJustify-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/xjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XJustify(int value) {#XJustify-int-}
+```
+public XJustify(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/xjustify\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xjustifyvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/xjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: XJustifyValue
+second_title: Aspose.Diagram för Java API-referens
+description: X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+type: docs
+weight: 452
+url: /sv/java/com.aspose.diagram/xjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class XJustifyValue
+```
+
+X‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [CENTERED](#CENTERED) | Centrerad. |
+| [LEFT_JUSTIFIED](#LEFT-JUSTIFIED) | Vänsterjusterad (standard). |
+| [RIGHT_JUSTIFIED](#RIGHT-JUSTIFIED) | Högerjusterad. |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrerad.
+
+### LEFT_JUSTIFIED {#LEFT-JUSTIFIED}
+```
+public static final int LEFT_JUSTIFIED
+```
+
+
+Vänsterjusterad (standard).
+
+### RIGHT_JUSTIFIED {#RIGHT-JUSTIFIED}
+```
+public static final int RIGHT_JUSTIFIED
+```
+
+
+Högerjusterad.
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/xpssaveoptions/_index.md
+++ b/swedish/java/com.aspose.diagram/xpssaveoptions/_index.md
@@ -1,0 +1,329 @@
+---
+title: XPSSaveOptions
+second_title: Aspose.Diagram för Java API-referens
+description: Tillåter att ange ytterligare alternativ när diagramssidor renderas till XPS.
+type: docs
+weight: 453
+url: /sv/java/com.aspose.diagram/xpssaveoptions/
+---
+
+**Inheritance:**
+java.lang.Object, [com.aspose.diagram.SaveOptions](../../com.aspose.diagram/saveoptions)
+```
+public class XPSSaveOptions extends SaveOptions
+```
+
+Tillåter att ange ytterligare alternativ när diagramssidor renderas till XPS.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [XPSSaveOptions()](#XPSSaveOptions--) | Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [createSaveOptions(int saveFormat)](#createSaveOptions-int-) | Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDefaultFont()](#getDefaultFont--) | När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. |
+| [getExportHiddenPage()](#getExportHiddenPage--) | Definierar om dolda sidor ska exporteras eller inte. |
+| [getPageCount()](#getPageCount--) | antalet sidor som ska renderas i XPS. |
+| [getPageIndex()](#getPageIndex--) | det nollbaserade indexet för den första sidan som ska renderas. |
+| [getSaveForegroundPagesOnly()](#getSaveForegroundPagesOnly--) | Anger om alla sidor ska sparas som bild eller endast förgrunden. |
+| [getSaveFormat()](#getSaveFormat--) | Anger formatet som de renderade diagrammetsidorna kommer att sparas i om detta sparaalternativobjekt används. |
+| [getWarningCallback()](#getWarningCallback--) | varnings‑återanrop. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setDefaultFont(String value)](#setDefaultFont-java.lang.String-) | För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--) |
+| [setExportHiddenPage(boolean value)](#setExportHiddenPage-boolean-) | För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--) |
+| [setPageCount(int value)](#setPageCount-int-) | För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--) |
+| [setPageIndex(int value)](#setPageIndex-int-) | För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--) |
+| [setSaveForegroundPagesOnly(boolean value)](#setSaveForegroundPagesOnly-boolean-) | För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--) |
+| [setSaveFormat(int value)](#setSaveFormat-int-) | För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--) |
+| [setWarningCallback(IWarningCallback value)](#setWarningCallback-com.aspose.diagram.IWarningCallback-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XPSSaveOptions() {#XPSSaveOptions--}
+```
+public XPSSaveOptions()
+```
+
+
+Initierar en ny instans av den här klassen som kan användas för att spara ett dokument i formatet Aspose.Diagram.SaveFileFormat.
+
+### createSaveOptions(int saveFormat) {#createSaveOptions-int-}
+```
+public static SaveOptions createSaveOptions(int saveFormat)
+```
+
+
+Skapar ett sparaalternativobjekt av en klass som är lämplig för det angivna sparformatet.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| saveFormat | int | Den Aspose.Diagram.SaveFileFormat som ska användas för att skapa ett save options-objekt. |
+
+**Returns:**
+[SaveOptions](../../com.aspose.diagram/saveoptions) - An object of a class that derives from [SaveOptions](../../com.aspose.diagram/saveoptions).
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDefaultFont() {#getDefaultFont--}
+```
+public String getDefaultFont()
+```
+
+
+När tecken i diagrammet är Unicode och inte har ställts in med korrekt teckensnittsvärde eller teckensnittet inte är installerat lokalt, kan de visas som block i PDF, bild eller XPS. Ställ in DefaultFont, t.ex. MingLiu eller MS Gothic, för att visa dessa tecken.
+
+**Returns:**
+java.lang.String
+### getExportHiddenPage() {#getExportHiddenPage--}
+```
+public boolean getExportHiddenPage()
+```
+
+
+Definierar om dolda sidor ska exporteras eller inte. Standardvärdet är true.
+
+**Returns:**
+boolean
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+antalet sidor som ska renderas i XPS. Standard är MaxValue vilket betyder att alla diagrammetsidor kommer att renderas.
+
+**Returns:**
+int
+### getPageIndex() {#getPageIndex--}
+```
+public int getPageIndex()
+```
+
+
+det 0-baserade indexet för den första sidan som ska renderas. Standard är 0.
+
+**Returns:**
+int
+### getSaveForegroundPagesOnly() {#getSaveForegroundPagesOnly--}
+```
+public boolean getSaveForegroundPagesOnly()
+```
+
+
+Anger om alla sidor ska sparas i bilden eller bara förgrunden. Om true – renderas endast förgrundssidor (med bakgrund om den finns). Om false – renderas förgrundssidor (med bakgrund om den finns) följt av tomma bakgrundssidor. Kan returnera true endast när PageCount > 1. Standardvärdet är false.
+
+**Returns:**
+boolean
+### getSaveFormat() {#getSaveFormat--}
+```
+public int getSaveFormat()
+```
+
+
+Anger det format i vilket de renderade diagrammenyerna ska sparas om detta spara-alternativobjekt används. Kan endast vara Aspose.Diagram.SaveFileFormat.
+
+**Returns:**
+int
+### getWarningCallback() {#getWarningCallback--}
+```
+public IWarningCallback getWarningCallback()
+```
+
+
+varnings‑återanrop.
+
+**Returns:**
+[IWarningCallback](../../com.aspose.diagram/iwarningcallback)
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setDefaultFont(String value) {#setDefaultFont-java.lang.String-}
+```
+public void setDefaultFont(String value)
+```
+
+
+För beskrivningen av denna egenskap, se [getDefaultFont()](../../com.aspose.diagram/saveoptions\#getDefaultFont--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.String |  |
+
+### setExportHiddenPage(boolean value) {#setExportHiddenPage-boolean-}
+```
+public void setExportHiddenPage(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getExportHiddenPage()](../../com.aspose.diagram/xpssaveoptions\#getExportHiddenPage--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setPageCount(int value) {#setPageCount-int-}
+```
+public void setPageCount(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageCount()](../../com.aspose.diagram/xpssaveoptions\#getPageCount--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setPageIndex(int value) {#setPageIndex-int-}
+```
+public void setPageIndex(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getPageIndex()](../../com.aspose.diagram/xpssaveoptions\#getPageIndex--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setSaveForegroundPagesOnly(boolean value) {#setSaveForegroundPagesOnly-boolean-}
+```
+public void setSaveForegroundPagesOnly(boolean value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveForegroundPagesOnly()](../../com.aspose.diagram/xpssaveoptions\#getSaveForegroundPagesOnly--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | boolean |  |
+
+### setSaveFormat(int value) {#setSaveFormat-int-}
+```
+public void setSaveFormat(int value)
+```
+
+
+För beskrivningen av den här egenskapen, se [getSaveFormat()](../../com.aspose.diagram/xpssaveoptions\#getSaveFormat--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### setWarningCallback(IWarningCallback value) {#setWarningCallback-com.aspose.diagram.IWarningCallback-}
+```
+public void setWarningCallback(IWarningCallback value)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| value | [IWarningCallback](../../com.aspose.diagram/iwarningcallback) |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/yjustify/_index.md
+++ b/swedish/java/com.aspose.diagram/yjustify/_index.md
@@ -1,0 +1,179 @@
+---
+title: YJustify
+second_title: Aspose.Diagram för Java API-referens
+description: Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+type: docs
+weight: 454
+url: /sv/java/com.aspose.diagram/yjustify/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public class YJustify
+```
+
+Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+## Konstruktörer
+
+| Konstruktor | Beskrivning |
+| --- | --- |
+| [YJustify(int value)](#YJustify-int-) | Konstruktor. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object value)](#equals-java.lang.Object-) | Är objekt lika. |
+| [getClass()](#getClass--) |  |
+| [getUfe()](#getUfe--) | Anger attribut för ett element. |
+| [getValue()](#getValue--) | Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen. |
+| [hashCode()](#hashCode--) | Fungerar som en hash‑funktion för en viss typ. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setValue(int value)](#setValue-int-) | För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/yjustify\#getValue--) |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### YJustify(int value) {#YJustify-int-}
+```
+public YJustify(int value)
+```
+
+
+Konstruktor.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### equals(Object value) {#equals-java.lang.Object-}
+```
+public boolean equals(Object value)
+```
+
+
+Är objekt lika.
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | java.lang.Object |  |
+
+**Returns:**
+boolean -
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getUfe() {#getUfe--}
+```
+public UnitFormulaErr getUfe()
+```
+
+
+Anger attribut för ett element.
+
+**Returns:**
+[UnitFormulaErr](../../com.aspose.diagram/unitformulaerr)
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+Fungerar som en hash‑funktion för en viss typ.
+
+**Returns:**
+int -
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setValue(int value) {#setValue-int-}
+```
+public void setValue(int value)
+```
+
+
+För beskrivningen av denna egenskap, se [getValue()](../../com.aspose.diagram/yjustify\#getValue--)
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| värde | int |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/swedish/java/com.aspose.diagram/yjustifyvalue/_index.md
+++ b/swedish/java/com.aspose.diagram/yjustifyvalue/_index.md
@@ -1,0 +1,165 @@
+---
+title: YJustifyValue
+second_title: Aspose.Diagram för Java API-referens
+description: Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+type: docs
+weight: 455
+url: /sv/java/com.aspose.diagram/yjustifyvalue/
+---
+
+**Inheritance:**
+java.lang.Object
+```
+public final class YJustifyValue
+```
+
+Anger y‑avståndet för smart‑tag‑knappen relativt till punkten som definieras av X‑ och Y‑elementen.
+## Fält
+
+| Fält | Beskrivning |
+| --- | --- |
+| [BOTTOM_JUSTIFIED](#BOTTOM-JUSTIFIED) | Bottenjusterad. |
+| [CENTERED](#CENTERED) | Centrerad. |
+| [TOP_JUSTIFIED](#TOP-JUSTIFIED) | Topjusterad (standard). |
+| [UNDEFINED](#UNDEFINED) | Odefinierad. |
+## Metoder
+
+| Metod | Beskrivning |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BOTTOM_JUSTIFIED {#BOTTOM-JUSTIFIED}
+```
+public static final int BOTTOM_JUSTIFIED
+```
+
+
+Bottenjusterad.
+
+### CENTERED {#CENTERED}
+```
+public static final int CENTERED
+```
+
+
+Centrerad.
+
+### TOP_JUSTIFIED {#TOP-JUSTIFIED}
+```
+public static final int TOP_JUSTIFIED
+```
+
+
+Topjusterad (standard).
+
+### UNDEFINED {#UNDEFINED}
+```
+public static final int UNDEFINED
+```
+
+
+Odefinierad.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| Parameter | Typ | Beskrivning |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 451/451
- Errors: 0
- Source: `english/java`
- Output: `swedish/java`

🤖 Generated by RDA